### PR TITLE
Pagination - Increase flexibility

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -107,7 +107,7 @@ class Pagination {
 
 		static::$total_pages = ceil(static::$total_items / static::$per_page) ?: 1;
 
-		static::$current_page = (int) \URI::segment(static::$uri_segment);
+		is_null(static::$current_page) and static::$current_page = (int) \URI::segment(static::$uri_segment);
 
 		if (static::$current_page > static::$total_pages)
 		{
@@ -138,15 +138,36 @@ class Pagination {
 		}
 
 		$pagination = '';
+		$pagination .= '&nbsp;'.static::prev_link('&laquo Previous').'&nbsp;&nbsp;';
+		$pagination .= static::page_links();
+		$pagination .= '&nbsp;'.static::next_link('Next &raquo;');
 
+		return $pagination;
+	}
+	
+	// --------------------------------------------------------------------
+
+	/**
+	 * Pagination Page Number links
+	 *
+	 * @access public
+	 * @return mixed    Markup for page number links
+	 */
+	public static function page_links()
+	{
+		if (static::$total_pages == 1)
+		{
+			return '';
+		}
+		
+		$pagination = '';
+		
 		// Let's get the starting page number, this is determined using num_links
 		$start = ((static::$current_page - static::$num_links) > 0) ? static::$current_page - (static::$num_links - 1) : 1;
 
 		// Let's get the ending page number
 		$end   = ((static::$current_page + static::$num_links) < static::$total_pages) ? static::$current_page + static::$num_links : static::$total_pages;
-
-		$pagination .= '&nbsp;'.static::prev_link('&laquo Previous').'&nbsp;&nbsp;';
-
+		
 		for($i = $start; $i <= $end; $i++)
 		{
 			if (static::$current_page == $i)
@@ -159,9 +180,7 @@ class Pagination {
 				$pagination .= \Html::anchor(rtrim(static::$pagination_url, '/') . $url, $i);
 			}
 		}
-
-		$pagination .= '&nbsp;'.static::next_link('Next &raquo;');
-
+		
 		return $pagination;
 	}
 


### PR DESCRIPTION
Moved the page link assembly into it's own method so they can be retrieved separate from the [hardcoded] previous and next links.
This enables more flexibility in how the pagination is displayed on the page. Still needs more development in that direction, but I think this is pretty essential.

Oh, also added a check to see if current page is null before automatically assigning it. This allows manual specification of the page number, which I had to do when using pagination where the page number isn't always in the same segment due to routes.
