### PR TITLE
Labels as array

### DIFF
--- a/classes/date.php
+++ b/classes/date.php
@@ -144,7 +144,7 @@ class Date {
 			return false;
 		}
 		$timestamp = mktime($time['tm_hour'], $time['tm_min'], $time['tm_sec'],
-						$time['tm_mon'], $time['tm_mday'], $time['tm_year']+1901 );
+						$time['tm_mon'], $time['tm_mday'], $time['tm_year']+1900 );
 
 		return static::factory($timestamp + static::$server_gmt_offset);
 	}

--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -118,7 +118,7 @@ class Fieldset_Field
 	 */
 	public function set_label($label)
 	{
-		$this->label = (string) $label;
+		$this->label = $label;
 		$this->set_attribute('label', $label);
 	}
 

--- a/classes/form.php
+++ b/classes/form.php
@@ -604,15 +604,20 @@ class Form {
 		$attributes = $this->get_config('form_attributes');
 		$action && $attributes['action'] = $action;
 
-		$output = static::open($attributes).PHP_EOL;
+		$open = static::open($attributes).PHP_EOL;
 		$fields = $this->field();
+		$fields_output = '';
 		foreach ($fields as $f)
 		{
-			$output .= $this->build_field($f).PHP_EOL;
+			$fields_output .= $this->build_field($f).PHP_EOL;
 		}
-		$output .= static::close();
+		$close = static::close();
 
-		return $output;
+		$template =  $this->get_config('form_template', "\t\t{form_open}\n{fields}\n\t\t{form_close}\n");
+		$template = str_replace(array('{form_open}', '{fields}', '{form_close}'),
+			array($open, $fields_output, $close),
+			$template);
+		return $template;
 	}
 
 	/**

--- a/classes/form.php
+++ b/classes/form.php
@@ -520,8 +520,9 @@ class Form {
 	{
 		if (is_array($label))
 		{
+			$attributes = $label;
 			$label = $attributes['label'];
-			$id = $attributes['id'];
+			isset($attributes['id']) && $id = $attributes['id'];
 		}
 
 		if (! empty($id))

--- a/classes/form.php
+++ b/classes/form.php
@@ -433,6 +433,8 @@ class Form {
 			$attributes['id'] = static::get_class_config('auto_id_prefix', '').$attributes['name'];
 		}
 
+		unset($attributes['type']);
+
 		return html_tag('textarea', static::attr_to_string($attributes), $value);
 	}
 
@@ -501,6 +503,8 @@ class Form {
 		}
 		$input .= str_repeat("\t", 0);
 
+		unset($attributes['type']);
+
 		return html_tag('select', static::attr_to_string($attributes), $input);
 	}
 
@@ -520,7 +524,10 @@ class Form {
 			$id = $attributes['id'];
 		}
 
-		$attributes['for'] = $id;
+		if (! empty($id))
+		{
+			$attributes['for'] = $id;
+		}
 		unset($attributes['label']);
 		unset($attributes['id']);
 

--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -228,7 +228,7 @@ class Fuel {
 
 		if (static::$path_cache !== null && array_key_exists($cache_id.$path, static::$path_cache))
 		{
-			return static::$path_cache[$path];
+			return static::$path_cache[$cache_id.$path];
 		}
 
 		$found = $multiple ? array() : false;


### PR DESCRIPTION
Allowing passing of labels as an array instead of just a string via $form->add ... this way you can add attributes such as class"" to the label portion. Passing as string still works as expected.
