### PR TITLE
Fix Date class. strptime returns years since 1900 not 1901. Dates were a 

### DIFF
--- a/classes/date.php
+++ b/classes/date.php
@@ -144,7 +144,7 @@ class Date {
 			return false;
 		}
 		$timestamp = mktime($time['tm_hour'], $time['tm_min'], $time['tm_sec'],
-						$time['tm_mon'], $time['tm_mday'], $time['tm_year']+1901 );
+						$time['tm_mon'], $time['tm_mday'], $time['tm_year']+1900 );
 
 		return static::factory($timestamp + static::$server_gmt_offset);
 	}


### PR DESCRIPTION
Fix Date class. strptime returns years since 1900 not 1901. Dates were a year in the future. Fixed
