### PR TITLE
Allow setting labels as array including attributes instead of just tring 

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -118,7 +118,7 @@ class Fieldset_Field
 	 */
 	public function set_label($label)
 	{
-		$this->label = (string) $label;
+		$this->label = $label;
 		$this->set_attribute('label', $label);
 	}
 

--- a/classes/form.php
+++ b/classes/form.php
@@ -516,8 +516,10 @@ class Form {
 	{
 		if (is_array($label))
 		{
+			$attributes = $label;
 			$label = $attributes['label'];
 			$id = $attributes['id'];
+			isset($attributes['id']) && $id = $attributes['id'];
 		}
 
 		$attributes['for'] = $id;


### PR DESCRIPTION
Allow setting labels as array including attributes instead of just tring in form->add. Strings still work as expected
