### PR TITLE
Date Bug

### DIFF
--- a/classes/date.php
+++ b/classes/date.php
@@ -144,7 +144,7 @@ class Date {
 			return false;
 		}
 		$timestamp = mktime($time['tm_hour'], $time['tm_min'], $time['tm_sec'],
-						$time['tm_mon'], $time['tm_mday'], $time['tm_year']+1900 );
+						$time['tm_mon'] + 1, $time['tm_mday'], $time['tm_year'] + 1900);
 
 		return static::factory($timestamp + static::$server_gmt_offset);
 	}


### PR DESCRIPTION
Fixed bug in \Date::create_from_string() where the date produced would always be exactly one month behind the actual date. See http://dev.fuelphp.com/issues/111 for more.

Signed-off-by: Ben Corlett bencorlett@me.com
