### PR TITLE
Issue #30

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -194,6 +194,14 @@ class Uri {
 		return static::create();
 	}
 
+    /**
+     * Gets the base URL
+     */
+    public static function base()
+    {
+        return \Config::get('base_url');
+    }
+
 	/**
 	 * @var	string	The URI string
 	 */


### PR DESCRIPTION
Added Uri::base() to get the base URL for uniformity of the URI class rather than manually using \Config::get('base_url'). fixes #30
