### PR TITLE
Let Session_Db fall back on the active database group if none is provided

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -48,7 +48,7 @@ class DBUtil {
 	}
 
 	/**
-	 * Creates a table.  Will throw a Database_Exception if it cannot.
+	 * Drops a table.  Will throw a Database_Exception if it cannot.
 	 *
 	 * @throws	Fuel\Database_Exception
 	 * @param	string	$table	the table name

--- a/config/session.php
+++ b/config/session.php
@@ -83,7 +83,7 @@ return array(
 	// specific configuration settings for database based sessions
 	'db'			=> array(
 		'cookie_name'		=> 'fueldid',				// name of the session cookie for database based sessions
-		'database'			=> 'dev',					// name of the database name (as configured in config/db.php)
+		'database'			=> null,					// name of the database name (as configured in config/db.php)
 		'table'				=> 'sessions',				// name of the sessions table
 		'gc_probability'	=> 5						// probability % (between 0 and 100) for garbage collection
 						),


### PR DESCRIPTION
Let Session_Db fall back on the active database group if none is provided in app/config/session.php now 'dev' was hardcoded.
