### PR TITLE
Modification to Lang class

### DIFF
--- a/base.php
+++ b/base.php
@@ -86,10 +86,6 @@ if ( ! function_exists('array_to_attr'))
 				$property = $value;
 			}
 
-			if (in_array($property, array('value', 'alt', 'title')))
-			{
-				$value = htmlentities($value, ENT_QUOTES, \Fuel::$encoding);
-			}
 			$attr_str .= $property.'="'.$value.'" ';
 		}
 

--- a/classes/config.php
+++ b/classes/config.php
@@ -97,9 +97,9 @@ CONF;
 /* End of file $file.php */
 CONF;
 
-		($path = \Fuel::find_file('config', $file, '.php')) or $path[0] = APPPATH.'config'.DS.$file.'.php';
+		($path = \Fuel::find_file('config', $file, '.php')) or $path = APPPATH.'config'.DS.$file.'.php';
 
-		$path = pathinfo($path[0]);
+		$path = pathinfo($path);
 
 		return File::update($path['dirname'], $path['basename'], $content);
 	}

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -100,7 +100,7 @@ abstract class Controller_Rest extends \Controller {
 		if (method_exists('Format', 'to_'.$this->request->format))
 		{
 			// Set the correct format header
-			$this->response->set_header('Content-Type: '.$this->_supported_formats[$this->request->format]);
+			$this->response->set_header('Content-Type', $this->_supported_formats[$this->request->format]);
 
 			$this->response->body(Format::factory($data)->{'to_'.$this->request->format}());
 		}

--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -373,7 +373,7 @@ abstract class Email_Driver {
 				$origbcc = $this->bcc_recipients;
 				$this->_bcc_batch_running = false;
 				while ($offset < $count && $return)
-				{ // TODO: Add to codeigniter version
+				{ 
 					// Loop while we still have batches of blind carbon copies to send.
 					// Note that the first run outputs any to and cc addresses also.
 					$length = $count >= $offset + $this->bcc_batch_size ? $this->bcc_batch_size : $count % $this->bcc_batch_size;

--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -118,8 +118,6 @@ class Fuel {
 
 		\Router::add(\Config::get('routes'));
 
-		\View::$auto_encode = \Config::get('security.auto_encode_view_data');
-
 		if ( ! static::$is_cli)
 		{
 			if (\Config::get('base_url') === null)
@@ -141,6 +139,8 @@ class Fuel {
 		{
 			static::add_package($package);
 		}
+
+		\View::$auto_encode = \Config::get('security.auto_encode_view_data');
 
 		// Set some server options
 		setlocale(LC_ALL, static::$locale);

--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -215,13 +215,33 @@ class Fuel {
 	public static function find_file($directory, $file, $ext = '.php', $multiple = false, $cache = true)
 	{
 		$cache_id = '';
-		$paths = static::$_paths;
 
-		// get extra information of the active request
-		if (class_exists('Request', false) and $active = \Request::active())
+		// the file requested namespaced?
+		if($pos = strripos(ltrim($file, '\\'), '\\'))
 		{
-			$cache_id = md5($active->uri->uri);
-			$paths = array_merge($active->paths, $paths);
+			$file = ltrim($file, '\\');
+
+			// get the namespace path
+			if ($path = \Autoloader::namespace_path('\\'.ucfirst(substr($file, 0, $pos))))
+			{
+				// and strip the classes directory as we need the module root
+				$paths = array(substr($path,0, -8));
+
+				// strip the namespace from the filename
+				$file = substr($file, $pos+1);
+			}
+		}
+		else
+		{
+			// not namespaced, use Fuel's search paths
+			$paths = static::$_paths;
+
+			// get extra information of the active request
+			if (class_exists('Request', false) and $active = \Request::active())
+			{
+				$cache_id = md5($active->uri->uri);
+				$paths = array_merge($active->paths, $paths);
+			}
 		}
 
 		$path = $directory.DS.strtolower($file).$ext;

--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -46,7 +46,7 @@ class Inflector {
 		'/(bu|campu)s$/'           => '\1\2ses',    // bus, campus
 		'/(alias|status|virus)/'   => '\1es',       // alias
 		'/(octop)us$/'             => '\1i',        // octopus
-		'/(ax|cri|test)is$/'       => '\1es',       // axis, crisis
+		'/(ax|cris|test)is$/'      => '\1es',       // axis, crisis
 		'/s$/'                     => 's',          // no change (compatibility)
 		'/$/'                      => 's',
 	);
@@ -78,7 +78,7 @@ class Inflector {
 		'/(s)tatuses$/'         => '\1\2tatus',
 		'/(c)hildren$/'         => '\1\2hild',
 		'/(n)ews$/'             => '\1\2ews',
-		'/s$/'                  => '',
+		'/([^u])s$/'            => '\1',
 	);
 
 

--- a/classes/lang.php
+++ b/classes/lang.php
@@ -35,7 +35,9 @@ class Lang {
 		$lang = array();
 
 		// Use the current language, failing that use the fallback language
-		foreach (array(\Config::get('language'), static::$fallback) as $language)
+		$langconf = (is_array(\Config::get('language'))) ? \Config::get('language') : array(\Config::get('language'));
+
+		foreach (array_merge($langconf, (array)static::$fallback) as $language)
 		{
 			if ($path = \Fuel::find_file('lang/'.$language, $file, '.php', true))
 			{

--- a/classes/lang.php
+++ b/classes/lang.php
@@ -30,6 +30,8 @@ class Lang {
 
 	public static $fallback = 'en';
 
+	public static $context = 'front';
+
 	public static function load($file, $group = null)
 	{
 		$lang = array();
@@ -90,6 +92,12 @@ class Lang {
 			return  static::_parse_params($return, $params);
 		}
 
+		if(!isset(static::$lines[$line]))
+		{
+			parent::set($line,$line);
+			static::save();
+		}
+
 		isset(static::$lines[$line]) and $line = static::$lines[$line];
 
 		return static::_parse_params($line, $params);
@@ -128,6 +136,26 @@ class Lang {
 		{
 			return $string;
 		}
+	}
+
+	public static function save()
+	{
+		
+				$content = <<<CONF
+<?php
+
+CONF;
+		$content .= 'return '.str_replace('  ', "\t", var_export(static::$lines, true)).';';
+		$content .= <<<CONF
+
+
+CONF;
+		$language = \Config::get('language');
+		$path = \Fuel::find_file('lang/'.$language, self::$context, '.php');
+
+		$path = pathinfo($path[0]);
+
+		return File::update($path['dirname'], $path['basename'], $content);
 	}
 }
 

--- a/classes/uri.php
+++ b/classes/uri.php
@@ -195,6 +195,24 @@ class Uri {
 	}
 
 	/**
+	 * Gets the base URL, including the index_file
+	 *
+	 * @return  the base uri
+	 */
+	public static function base($include_index = true)
+	{
+		$url = \Config::get('base_url');
+
+		if ($include_index and \Config::get('index_file'))
+		{
+			$url .= \Config::get('index_file').'/';
+		}
+
+		return $url;
+	}
+
+
+	/**
 	 * @var	string	The URI string
 	 */
 	public $uri = '';

--- a/classes/view.php
+++ b/classes/view.php
@@ -37,6 +37,7 @@ class View {
 	// Array of global view data
 	protected static $_global_data = array();
 
+	// Output encoding setting
 	public static $auto_encode = true;
 
 	// View filename
@@ -44,6 +45,9 @@ class View {
 
 	// Array of local variables
 	protected $_data = array();
+
+	// File extension used for views
+	protected $extension = 'php';
 
 	/**
 	 * Returns a new View object. If you do not define the "file" parameter,
@@ -298,7 +302,7 @@ class View {
 	 */
 	public function set_filename($file)
 	{
-		if (($path = \Fuel::find_file('views', $file, '.php', false, false)) === false)
+		if (($path = \Fuel::find_file('views', $file, '.'.$this->extension, false, false)) === false)
 		{
 			throw new \View_Exception('The requested view could not be found: '.\Fuel::clean_path($file));
 		}

--- a/tests/uri.php
+++ b/tests/uri.php
@@ -29,12 +29,14 @@ class Tests_Uri extends TestCase {
 	 */
 	public function test_create()
 	{
+		$prefix = (Config::get('index_file')) ? Config::get('index_file').'/' : '';
+
 		$output = Uri::create('controller/method');
-		$expected = "index.php/controller/method";
+		$expected = $prefix."controller/method";
 		$this->assertEquals($expected, $output);
 
 		$output = Uri::create('controller/:some', array('some' => 'thing', 'and' => 'more'), array('what' => ':and'));
-		$expected = "index.php/controller/thing?what=more";
+		$expected = $prefix."controller/thing?what=more";
 		$this->assertEquals($expected, $output);
 	}
 


### PR DESCRIPTION
The scenario is this:
You need to show the user a message, so you add in your controller / view a lang::line method.
For each line you use, you have to update the correspondant lang file.

So I added a save functionallity to the lang class (following the pattern of the config class), so, if a line is not found in the lang file, it will be saved in the array of the default language.

I've not solved the use of this functionallity using groups or multiple files. The name of the file you want the updates to be saved is stored in the static $context variable.

I think this idea can be done in a better way, such as using groups also or set the save function to be optional, but I think it's a good idea to be evolved. I've implemented it in CI and save me a lot of time.

Please, if I'm not doing this in the proper way, let me know.

Best regards. Santiago. 
