### PR TITLE
Fixed incorrect recursion condition in Arr::flatten_assoc

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -40,7 +40,7 @@ class Arr {
 		foreach ($array as $key => $val)
 		{
 			$curr_key[] = $key;
-			if (is_array($val) and array_values($val) !== $val)
+			if (is_array($val))
 			{
 				static::flatten_assoc($val, $glue, false);
 			}

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -24,9 +24,10 @@ class Arr {
 	 * @param	array	The array to flatten
 	 * @param	string	What to glue the keys together with
 	 * @param	bool	Whether to reset and start over on a new array
+	 * @param	int		Number of levels (array dimensions) remaining to flatten
 	 * @return	array
 	 */
-	public static function flatten_assoc($array, $glue = ':', $reset = true)
+	public static function flatten_assoc($array, $glue = ':', $reset = true, $level = 1)
 	{
 		static $return = array();
 		static $curr_key = array();
@@ -40,9 +41,9 @@ class Arr {
 		foreach ($array as $key => $val)
 		{
 			$curr_key[] = $key;
-			if (is_array($val))
+			if (is_array($val) and $level > 0)
 			{
-				static::flatten_assoc($val, $glue, false);
+				static::flatten_assoc($val, $glue, false, $level-1);
 			}
 			else
 			{


### PR DESCRIPTION
Test case:

```
$multilevel = array(
    'level1' => array(
        'level2' => array(
            'level3'
        )
    )
);
print_r( Arr::flatten_assoc($people) );
```

---

With this patch:

```
Array
(
    [level1:level2:0] => level3
)
```

---

Without this patch

```
Array
(
    [level1:level2] => Array
        (
            [0] => level3
        )
)
```
