### PR TITLE
Modification to Lang class

### DIFF
--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -110,6 +110,8 @@ abstract class ViewModel {
 		}
 
 		$this->_auto_encode = (bool) $setting;
+
+		return $this;
 	}
 
 	/**
@@ -156,7 +158,7 @@ abstract class ViewModel {
 	 */
 	public function __set($name, $val)
 	{
-		$this->set($name, $val, \View::$auto_encode);
+		return $this->set($name, $val, \View::$auto_encode);
 	}
 
 	/**
@@ -169,6 +171,8 @@ abstract class ViewModel {
 	public function set($name, $val, $encode = null)
 	{
 		$this->_template->set($name, $val, $encode);
+
+		return $this;
 	}
 
 	/**
@@ -183,6 +187,8 @@ abstract class ViewModel {
 	{
 		\Error::notice('The ViewModel::set_safe() method is depricated and will be removed at 1.0. Use set(name, var, true) instead.');
 		$this->_template->set($name, $val, true);
+
+		return $this;
 	}
 
 	/**
@@ -195,6 +201,8 @@ abstract class ViewModel {
 	{
 		\Error::notice('The ViewModel::set_safe() method is depricated and will be removed at 1.0. Use set(name, var, false) instead.');
 		$this->_template->set($name, $val, false);
+
+		return $this;
 	}
 
 	/**

--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -80,7 +80,7 @@ abstract class ViewModel {
 		$this->before();
 
 		// Set this as the controller output if this is the first ViewModel loaded
-		if ( ! \Request::active()->controller_instance->response->body instanceof ViewModel)
+		if (empty(\Request::active()->controller_instance->response->body))
 		{
 			\Request::active()->controller_instance->response->body = $this;
 		}


### PR DESCRIPTION
The scenario is this:
You need to show the user a message, so you add in your controller / view a lang::line method.
For each line you use, you have to update the correspondant lang file.

So I added a save functionallity to the lang class (following the pattern of the config class), so, if a line is not found in the lang file, it will be saved in the array of the default language.

I've not solved the use of this functionallity using groups or multiple files. The name of the file you want the updates to be saved is stored in the static $context variable.

I think this idea can be done in a better way, such as using groups also or set the save function to be optional, but I think it's a good idea to be evolved. I've implemented it in CI and save me a lot of time.

Please, if I'm not doing this in the proper way, let me know.

Best regards. Santiago.

Sorry about commiting to the master branch. I got to get used with the github interface.
