### PR TITLE
Uri class new methods

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -264,6 +264,25 @@ class Uri {
 	{
 		return $this->get();
 	}
+	
+	public function without_params()
+	{
+		$segments = \Request::active()->uri->get_segments();
+		
+		$params = \Request::active()->route->method_params;
+		if(count($params)) array_splice($segments,-count($params));
+		return implode('/',$segments);
+	}
+	
+	public function without_action()
+	{
+		$segments = \Request::active()->uri->get_segments();
+		$params = \Request::active()->route->method_params;
+		if(count($params)) array_splice($segments,-count($params));
+
+		if(\Request::active()->route->action != 'index') array_splice($segments,-1);
+		return implode('/',$segments);
+	}
 }
 
 /* End of file uri.php */


### PR DESCRIPTION
The first one returns the url without the parameters. This come handy when implementing a function across different modules or controllers which have a differente uri segment lenght. Also may be useful on a later modification to the pagination class (for a more flexible uri_segment).

The second does the same but also removing the action. This is useful when trying to know if different functions belongs to the same controller, eg: you have a menu item 'blog' which has to be 'active' on blog/item, blog/search, etc.
