### PR TITLE
Hotfix/remove _force_loopable (no longer in used)

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -339,18 +339,6 @@ abstract class Controller_Rest extends \Controller {
 		exit('Not authorized.');
 	}
 
-	// Force it into an array
-	protected function _force_loopable($data)
-	{
-		// Force it to be something useful
-		if ( ! is_array($data) and ! is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		return $data;
-	}
-
 }
 
 /* End of file rest.php */


### PR DESCRIPTION
Controller_Rest::_format_xml is now replace with Format::to_xml, so in this case _force_loopable will never be used/called by any other method.
