### PR TITLE
Hotfix/autoloader lowercase issue

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -241,7 +241,7 @@ class Autoloader {
 				{
 					$class_no_ns = substr($class, $pos + 1);
 
-					$file_path = strtolower($path.substr($namespace, strlen($ns) + 1).DS.str_replace('_', DS, $class_no_ns).'.php');
+					$file_path = $path.strtolower(substr($namespace, strlen($ns) + 1).DS.str_replace('_', DS, $class_no_ns).'.php');
 					if (is_file($file_path))
 					{
 						// Fuel::$path_cache[$class] = $file_path;


### PR DESCRIPTION
Autoloader lowercasing whole paths not just the part of the fuel app, and so it can't find files when uppercase characters are in the path of case-sensitive filesystems.
I had this problem with module's classes always issuing 404. This fixed the problem.
