### PR TITLE
External assets should be able to have an empty URI scheme/protocol

### DIFF
--- a/classes/asset.php
+++ b/classes/asset.php
@@ -148,7 +148,7 @@ class Asset {
 			$filename = $item['file'];
 			$attr = $item['attr'];
 
-			if (strpos($filename, '://') === false)
+			if ( ! preg_match('|^(\w+:)?//|', $filename))
 			{
 				if ( ! ($file = static::find_file($filename, static::$_folders[$type])))
 				{


### PR DESCRIPTION
If you leave off the protocol (scheme officially) from a URI, then the browser will choose the protocol used to get the page. A classic example is jQuery from the Google CDN:

//ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js

So if you're viewing the page through https it'll automatically prepend it; likewise http. This prevents the nasty dialog box you get in IE when requests are made through both secure and non-secure protocols.
