### PR TITLE
Bugfix fieldset

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -90,6 +90,9 @@ class Fieldset_Field
 		// Don't allow name in attributes
 		unset($attributes['name']);
 
+		// Take rules out of attributes
+		unset($attributes['rules']);
+
 		// Set certain types through specific setter
 		foreach (array('label', 'type', 'value', 'options') as $prop)
 		{


### PR DESCRIPTION
Currently, Fieldset leaves the rules attribute (used only for validation) in the array, and it gets displayed in the resulting HTML field
