### PR TITLE
New Arr method - Arr::filter_keys()

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -83,6 +83,31 @@ class Arr {
 	}
 
 	/**
+	 * Filters an array by an array of keys
+	 *
+	 * @param   array   the array to filter.
+	 * @param   array   the keys to filter
+	 * @param   bool    if true, removes the matched elements.
+	 * @return  array
+	 */
+	public static function filter_keys($array, $keys, $remove = false)
+	{
+		$return = array();
+		foreach ($keys as $key)
+		{
+			if (isset($array[$key]) and  ! $remove)
+			{
+				$return[$key] = $array[$key];
+			}
+			elseif (isset($array[$key]) and $remove)
+			{
+				unset($array[$key]);
+			}
+		}
+		return $remove ? $array : $return;
+	}
+
+	/**
 	 * Returns the element of the given array or a default if it is not set.
 	 *
 	 * @param   array  the array to fetch from

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -399,6 +399,37 @@ class Tests_Arr extends TestCase {
 		$this->assertEquals(Arr::sort($data, 'info.pet.type', 'downer'), $expected);
 	}
 
+	public function filter_provider()
+	{
+		return array(
+			
+		);
+	}
+
+	/**
+	 * Tests Arr::filter_keys()
+	 * 
+	 * @test
+	 */
+	public function test_filter_keys()
+	{
+		$data = array(
+			'epic' => 'win',
+			'weak' => 'sauce',
+			'foo' => 'bar'
+		);
+		$expected = array(
+			'epic' => 'win',
+			'foo' => 'bar'
+		);
+		$expected_remove = array(
+			'weak' => 'sauce',
+		);
+		$keys = array('epic', 'foo');
+		$this->assertEquals(Arr::filter_keys($data, $keys), $expected);
+		$this->assertEquals(Arr::filter_keys($data, $keys, true), $expected_remove);
+	}
+
 }
 
 /* End of file arr.php */

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -399,13 +399,6 @@ class Tests_Arr extends TestCase {
 		$this->assertEquals(Arr::sort($data, 'info.pet.type', 'downer'), $expected);
 	}
 
-	public function filter_provider()
-	{
-		return array(
-			
-		);
-	}
-
 	/**
 	 * Tests Arr::filter_keys()
 	 * 


### PR DESCRIPTION
This is quite useful to me. Use it to extract only certain keys from an array.
Passing `true` as the third argument returns the array minus the specified keys.
