### PR TITLE
Precision fix for Image_Driver

### DIFF
--- a/classes/asset.php
+++ b/classes/asset.php
@@ -153,7 +153,7 @@ class Asset {
 			{
 				if ( ! ($file = static::find_file($filename, static::$_folders[$type])))
 				{
-					throw new \Fuel_Exception('Could not find asset: '.$filename);
+					throw new \Fuel_Exception('Could not find asset: '.$file);
 				}
 
 				$file = static::$_asset_url.$file;

--- a/classes/asset.php
+++ b/classes/asset.php
@@ -153,7 +153,7 @@ class Asset {
 			{
 				if ( ! ($file = static::find_file($filename, static::$_folders[$type])))
 				{
-					throw new \Fuel_Exception('Could not find asset: '.$file);
+					throw new \Fuel_Exception('Could not find asset: '.$filename);
 				}
 
 				$file = static::$_asset_url.$file;

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -298,9 +298,9 @@ abstract class Image_Driver {
 		$sizes   = $this->sizes();
 		$width   = $this->convert_number($width, true);
 		$height  = $this->convert_number($height, false);
-		$widthr  = bcdiv($sizes->width, $width);
-		$heightr = bcdiv($sizes->height, $height);
-		$compare = bccomp($widthr, $heightr);
+		$widthr  = bcdiv($sizes->width, $width, 10);
+		$heightr = bcdiv($sizes->height, $height, 10);
+		$compare = bccomp($widthr, $heightr, 10);
 		$x = $y = 0;
 		if ($compare < 1)
 		{

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -254,15 +254,18 @@ abstract class Image_Driver {
 		if ($keepar)
 		{
 			// See which is the biggest ratio
-			$width_ratio  = $width / $sizes->width;
-			$height_ratio = $height / $sizes->height;
-			if ($width_ratio > $height_ratio)
+			$width_ratio  = bcdiv($width, $sizes->width, 10);
+			$height_ratio = bcdiv($height, $sizes->height, 10);
+			$compare = bccomp($width_ratio, $height_ratio, 10);
+			if ($compare > -1)
 			{
-				$width = floor($sizes->width * $height_ratio);
+				$height = ceil((real) bcmul($sizes->height, $height_ratio, 10));
+				$width = ceil((real) bcmul($sizes->width, $height_ratio, 10));
 			}
 			else
 			{
-				$height = floor($sizes->height * $width_ratio);
+				$height = ceil((real) bcmul($sizes->height, $width_ratio, 10));
+				$width = ceil((real) bcmul($sizes->width, $width_ratio, 10));
 			}
 		}
 		if ($pad)
@@ -295,16 +298,19 @@ abstract class Image_Driver {
 		$sizes   = $this->sizes();
 		$width   = $this->convert_number($width, true);
 		$height  = $this->convert_number($height, false);
-		$widthr  = $sizes->width / $width;
-		$heightr = $sizes->height / $height;
+		$widthr  = bcdiv($sizes->width, $width);
+		$heightr = bcdiv($sizes->height, $height);
+		$compare = bccomp($widthr, $heightr);
 		$x = $y = 0;
-		if ($widthr < $heightr)
+		if ($compare < 1)
 		{
-			$this->_resize($width, $height * $widthr, true, false);
+			$t_height = ceil((float) bcmul($height, $widthr, 10));
+			$this->_resize($width, $t_height, true, false);
 		}
 		else
 		{
-			$this->_resize($width * $heightr, $height, true, false);
+			$t_width = ceil((float) bcmul($width, $heightr, 10));
+			$this->_resize($t_width, $height, true, false);
 		}
 		$sizes = $this->sizes();
 		$y = floor(($sizes->height - $height) / 2);

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -252,7 +252,8 @@ abstract class Image_Driver {
 		if ($keepar)
 		{
 			// See which is the biggest ratio
-			if (function_exists('bcdiv')) {
+			if (function_exists('bcdiv'))
+			{
 				$width_ratio  = bcdiv($width, $sizes->width, 10);
 				$height_ratio = bcdiv($height, $sizes->height, 10);
 				$compare = bccomp($width_ratio, $height_ratio, 10);
@@ -266,7 +267,9 @@ abstract class Image_Driver {
 					$height = ceil((real) bcmul($sizes->height, $width_ratio, 10));
 					$width = ceil((real) bcmul($sizes->width, $width_ratio, 10));
 				}
-			} else {
+			}
+			else
+			{
 				$width_ratio  = $width / $sizes->width;
 				$height_ratio = $height / $sizes->height;
 				if ($width_ratio >= $height_ratio)
@@ -312,7 +315,8 @@ abstract class Image_Driver {
 		$width   = $this->convert_number($width, true);
 		$height  = $this->convert_number($height, false);
 		$x = $y = 0;
-		if (function_exists('bcdiv')) {
+		if (function_exists('bcdiv'))
+		{
 			$widthr  = bcdiv($sizes->width, $width, 10);
 			$heightr = bcdiv($sizes->height, $height, 10);
 			$compare = bccomp($widthr, $heightr, 10);
@@ -326,7 +330,9 @@ abstract class Image_Driver {
 				$t_width = ceil((float) bcmul($width, $heightr, 10));
 				$this->_resize($t_width, $height, true, false);
 			}
-		} else {
+		}
+		else
+		{
 			$widthr  = $sizes->width / $width;
 			$heightr = $sizes->height / $height;
 			if ($widthr < $heightr)

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -254,18 +254,33 @@ abstract class Image_Driver {
 		if ($keepar)
 		{
 			// See which is the biggest ratio
-			$width_ratio  = bcdiv($width, $sizes->width, 10);
-			$height_ratio = bcdiv($height, $sizes->height, 10);
-			$compare = bccomp($width_ratio, $height_ratio, 10);
-			if ($compare > -1)
-			{
-				$height = ceil((real) bcmul($sizes->height, $height_ratio, 10));
-				$width = ceil((real) bcmul($sizes->width, $height_ratio, 10));
-			}
-			else
-			{
-				$height = ceil((real) bcmul($sizes->height, $width_ratio, 10));
-				$width = ceil((real) bcmul($sizes->width, $width_ratio, 10));
+			if (function_exists('bcdiv')) {
+				$width_ratio  = bcdiv($width, $sizes->width, 10);
+				$height_ratio = bcdiv($height, $sizes->height, 10);
+				$compare = bccomp($width_ratio, $height_ratio, 10);
+				if ($compare > -1)
+				{
+					$height = ceil((real) bcmul($sizes->height, $height_ratio, 10));
+					$width = ceil((real) bcmul($sizes->width, $height_ratio, 10));
+				}
+				else
+				{
+					$height = ceil((real) bcmul($sizes->height, $width_ratio, 10));
+					$width = ceil((real) bcmul($sizes->width, $width_ratio, 10));
+				}
+			} else {
+				$width_ratio  = $width / $sizes->width;
+				$height_ratio = $height / $sizes->height;
+				if ($width_ratio >= $height_ratio)
+				{
+					$height = ceil($sizes->height * $height_ratio);
+					$width = ceil($sizes->width * $height_ratio);
+				}
+				else
+				{
+					$height = ceil($sizes->height * $width_ratio);
+					$width = ceil($sizes->width * $width_ratio);
+				}
 			}
 		}
 		if ($pad)
@@ -298,19 +313,34 @@ abstract class Image_Driver {
 		$sizes   = $this->sizes();
 		$width   = $this->convert_number($width, true);
 		$height  = $this->convert_number($height, false);
-		$widthr  = bcdiv($sizes->width, $width, 10);
-		$heightr = bcdiv($sizes->height, $height, 10);
-		$compare = bccomp($widthr, $heightr, 10);
 		$x = $y = 0;
-		if ($compare < 1)
-		{
-			$t_height = ceil((float) bcmul($height, $widthr, 10));
-			$this->_resize($width, $t_height, true, false);
-		}
-		else
-		{
-			$t_width = ceil((float) bcmul($width, $heightr, 10));
-			$this->_resize($t_width, $height, true, false);
+		if (function_exists('bcdiv')) {
+			$widthr  = bcdiv($sizes->width, $width, 10);
+			$heightr = bcdiv($sizes->height, $height, 10);
+			$compare = bccomp($widthr, $heightr, 10);
+			if ($compare < 1)
+			{
+				$t_height = ceil((float) bcmul($height, $widthr, 10));
+				$this->_resize($width, $t_height, true, false);
+			}
+			else
+			{
+				$t_width = ceil((float) bcmul($width, $heightr, 10));
+				$this->_resize($t_width, $height, true, false);
+			}
+		} else {
+			$widthr  = $sizes->width / $width;
+			$heightr = $sizes->height / $height;
+			if ($widthr < $heightr)
+			{
+				$t_height = ceil($height * $widthr);
+				$this->_resize($width, $t_height, true, false);
+			}
+			else
+			{
+				$t_width = ceil($width * $heightr);
+				$this->_resize($t_width, $height, true, false);
+			}
 		}
 		$sizes = $this->sizes();
 		$y = floor(($sizes->height - $height) / 2);


### PR DESCRIPTION
Fixed an error where floats precision loss adversely affected outputted image. Known to happen when resizing image under ~2% of original size.
