### PR TITLE
Uri::create() method change '&' to '&amp;'

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -164,7 +164,7 @@ class Uri {
 			foreach ($get_variables as $key => $val)
 			{
 				$url .= $char.$key.'='.$val;
-				$char = '&';
+				$char = '&amp;';
 			}
 		}
 


### PR DESCRIPTION
In Method Uri::create();
When creating GET variables/values is used symbol '&' which isn't very secure/good for web validation.
