### PR TITLE
Bug Fix for REST Controller

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -100,7 +100,7 @@ abstract class Controller_Rest extends \Controller {
 		if (method_exists('Format', 'to_'.$this->request->format))
 		{
 			// Set the correct format header
-			$this->response->set_header('Content-Type: '.$this->_supported_formats[$this->request->format]);
+			$this->response->set_header('Content-Type', $this->_supported_formats[$this->request->format]);
 
 			$this->response->body(Format::factory($data)->{'to_'.$this->request->format}());
 		}


### PR DESCRIPTION
On line 103 of core/classes/controller/rest.php, the call to response->set_header was only passing a single parameter. With this change there is no longer an error.
