### PR TITLE
Fixed to correctly reference CamelCased namespaced classes in Autoloader

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -233,7 +233,7 @@ class Autoloader {
 		else
 		{
 			// need to stick the trimed \ back on...
-			$namespace = '\\'.ucfirst(strtolower(substr($class, 0, $pos)));
+			$namespace = '\\'.ucfirst(substr($class, 0, $pos));
 
 			foreach (static::$namespaces as $ns => $path)
 			{


### PR DESCRIPTION
Fixed to correctly reference CamelCased namespaced classes so they can be loaded.

Everywhere else the namespace is only treated with ucfirst() function, so when we have CamelCased namespaces and the autoloader strtolower() the namespace name, it would never be found as it is not the same thus giving the error: \CamelCasedNamespace\MyClass not found.
