### PR TITLE
Error array label

### DIFF
--- a/classes/validation/error.php
+++ b/classes/validation/error.php
@@ -108,7 +108,7 @@ class Validation_Error extends \Exception {
 
 		$value    = is_array($this->value) ? implode(', ', $this->value) : $this->value;
 		$find     = array(':field', ':label', ':value', ':rule');
-		$replace  = array($this->field->name, $this->field->label, $value, $this->callback);
+		$replace  = array($this->field->name, is_array($this->field->label) ? $this->field->label['label'] : $this->field->label, $value, $this->callback);
 		foreach($this->params as $key => $val)
 		{
 			$find[]		= ':param:'.($key + 1);


### PR DESCRIPTION
There was a problem when setting a label as an array like this:

$form->add('note', array('label'=>'Note', 'class'=>'label_top'), array(

the form renders fine but the has a problem when trying to get the field name for an error message. This commit fixes that by checking if the label is an array.
