### PR TITLE
Fix for the timezone issue

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -126,6 +126,12 @@ class Fuel {
 		}
 
 		\Config::load($config);
+		
+		// Set the timezone if it was configured
+		if($timezone = \Config::get('default_timezone', false))
+		{
+			date_default_timezone_set($timezone);
+		}
 
 		static::$_paths = array(APPPATH, COREPATH);
 


### PR DESCRIPTION
Set the timezone when Fuel inits if it was configured in the config array in the APP thus getting rid of the timezone change in the bootstrap.php in APP folder.

This is the fix for [issue 116](https://github.com/fuel/core/issues/116) (sadly GitHub doesn't allow to attach a pull-request to an already opened issue)
