### PR TITLE
Fixed bug in Autoloader::alias_to_namespace where aliasing to a given namespace would create the wrong alias.

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -134,6 +134,7 @@ class Autoloader {
 	 */
 	public static function alias_to_namespace($class, $namespace = '')
 	{
+		! empty($namespace) and $namespace = rtrim($namespace, '\\').'\\';
 		$parts = explode('\\', $class);
 		$root_class = $namespace.array_pop($parts);
 		class_alias($class, $root_class);


### PR DESCRIPTION
Autoloader::alias_to_namespace('Foo\Bar', '\Baz'); Would create an Alias of \BazBar instead of \Baz\Bar.
If we want to continue supporting this, then this is the fix. But since it's not used in any of the core classes (WanWizard grep'd the source and the second parameter isn't used anywhere in the core) we could also decide to drop it.
