### PR TITLE
Fix namespace for the Exception

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -430,7 +430,7 @@ class Upload {
 		// anything to save?
 		if (empty($files))
 		{
-			throw new Exception('No uploaded files are selected.');
+			throw new \Exception('No uploaded files are selected.');
 		}
 
 		// make sure we have a valid path


### PR DESCRIPTION
This is a fix for the namespace of the exception which will be thrown when no files selected while uploading.
