### PR TITLE
Fixed array_key_exists call on possible Model (instance of ArrayAcces) in fieldset repopulate

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -315,7 +315,7 @@ class Fieldset
 			{
 				if (is_array($input) or $input instanceof \ArrayAccess)
 				{
-					if (array_key_exists($f->name, $input))
+					if (isset($input[$f->name]))
 					{
 						$f->set_value($input[$f->name], true);
 					}


### PR DESCRIPTION
Changed array_key_exists to isset in the fieldset repopulate function because array_key_exists will not call the offsetExists function in an ArrayAcces object. As described [here](http://nl3.php.net/manual/en/class.arrayaccess.php) and [here](http://php.net/manual/en/arrayaccess.offsetexists.php).
