### PR TITLE
HTML tags are parsed in docblock long descriptions

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -468,7 +468,7 @@ class Form {
 	/**
 	 * Select
 	 *
-	 * Generates a <select> element based on the given parameters
+	 * Generates a html select element based on the given parameters
 	 *
 	 * @param	array
 	 * @return	string


### PR DESCRIPTION
HTML tags are parsed in docblock long descriptions. An unclosed tag will break documenters.

See the bottom of the right hand frame for the Form class on http://fuelphp.com/api/ for an example of the issue.
