### PR TITLE
Provide the ability to specify a directory of shared packages to allow shared and project specific packages

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -401,7 +401,20 @@ class Fuel {
 	{
 		if ( ! is_array($package))
 		{
-			$package = array($package => PKGPATH.$package.DS);
+			$input = $package;
+
+			if (is_dir(PKGPATH.$package.DS))
+			{
+				$package = array($package => PKGPATH.$package.DS);
+			}
+			elseif (defined('SHAREDPKGPATH') and is_dir(SHAREDPKGPATH.$package.DS))
+			{
+				$package = array($package => SHAREDPKGPATH.$package.DS);
+			}
+			else
+			{
+				throw new \Exception("Package {$input} not found");
+			}
 		}
 		foreach ($package as $name => $path)
 		{


### PR DESCRIPTION
We saw this as a necessity for many organisations who wish to use Fuel as a development platform for many sites. They would ideally like to have a set of tried and tested shared packages which any developer can use in any project. They would also like to have packages local to a particular project. Some local packages would, at the end of the development on a particular project, be put into the shared directory.

This also provides slightly nicer handling of packages not being found. Currently, it just gets a PHP when it fails to include a package.

This is twinned with a commit to phil-lavin/fuel which I have done a pull request for.
