### PR TITLE
removed the instantiation of a Uri class just to cast it back to a string

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -90,11 +90,6 @@ class Response {
 
 		$response->status = $redirect_code;
 
-		if (strpos($url, '://') === false)
-		{
-			$url = Uri::create($url);
-		}
-
 		if ($method == 'location')
 		{
 			$response->set_header('Location', $url);


### PR DESCRIPTION
I had a problem where calling `Response::redirect('/auth/login')` when being on the url '/bla' would endup taking me to 'bla/auth/login' because the Uri class was stripping off the leading slash causing it to turn into a relative url, instead of absolute. There wasnt really a need to turn $url into a URI object just to cast it back to a string so removed that.
