### PR TITLE
\Upload::save()

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -414,7 +414,7 @@ class Upload {
 				{
 					if (isset(static::$files[$param]))
 					{
-						$files = array(static::$files[$param]);
+						$files[$param] = static::$files[$param];
 					}
 				}
 			}


### PR DESCRIPTION
If parameter of \Upload::save() is integer, an invalid index is assigned to $files. (When uploading multiple files.)
