### PR TITLE
Fuel::init cleanup. Everything uses Config now and timezone defaults to date_default_timezone_get()

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -98,6 +98,8 @@ class Fuel {
 	 */
 	public static function init($config)
 	{
+		\Config::load($config);
+	
 		if (static::$initialized)
 		{
 			throw new \Fuel_Exception("You can't initialize Fuel more than once.");
@@ -110,7 +112,7 @@ class Fuel {
 		// Start up output buffering
 		ob_start();
 
-		static::$profiling = isset($config['profiling']) ? $config['profiling'] : false;
+		static::$profiling = \Config::get('profiling', false);
 
 		if (static::$profiling)
 		{
@@ -118,19 +120,17 @@ class Fuel {
 			\Profiler::mark(__METHOD__.' Start');
 		}
 
-		static::$cache_dir = isset($config['cache_dir']) ? $config['cache_dir'] : APPPATH.'cache/';
-		static::$caching = isset($config['caching']) ? $config['caching'] : false;
-		static::$cache_lifetime = isset($config['cache_lifetime']) ? $config['cache_lifetime'] : 3600;
+		static::$cache_dir = \Config::get('cache_dir', APPPATH.'cache/');
+		static::$caching = \Config::get('caching', false);
+		static::$cache_lifetime = \Config::get('cache_lifetime', 3600);
 
 		if (static::$caching)
 		{
 			static::$path_cache = static::cache('Fuel::path_cache');
 		}
 
-		\Config::load($config);
-
 		// set a default timezone if one is defined
-		static::$timezone = \Config::get('default_timezone', static::$timezone);
+		static::$timezone = \Config::get('default_timezone') ?: date_default_timezone_get();
 		date_default_timezone_set(static::$timezone);
 
 		// set the encoding and locale to use


### PR DESCRIPTION
Now from another branch
