### PR TITLE
Hotfix/dbutil add drop multiple columns

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -134,7 +134,7 @@ class DBUtil {
 
 	protected static function alter_fields($type, $table, $fields)
 	{
-		$sql = 'ALTER TABLE '.DB::quote_identifier(DB::table_prefix($table)).' '.$type.' ';
+		$sql = 'ALTER TABLE '.DB::quote_identifier(DB::table_prefix($table)).' ';
 		if ($type === 'DROP')
 		{
 			if( ! is_array($fields))
@@ -142,11 +142,12 @@ class DBUtil {
 				$fields = array($fields);
 			}
 			$fields = array_map(function($field){
-				return DB::quote_identifier($field);
+				return 'DROP '.DB::quote_identifier($field);
 			}, $fields);
 			$sql .= implode(', ', $fields);
 		} else {
-			$sql .= static::process_fields($fields);
+		  $sql .= $type.' ';
+			$sql .= '('.static::process_fields($fields).')';
 		}
 		return DB::query($sql, DB::UPDATE)->execute();
 	}


### PR DESCRIPTION
Using DBUtil to add or drop multiple columns gave a mysql error. This should fix that issue.
