### PR TITLE
Moved temp image path outside of substr(). No more truncated absolute paths.

### DIFF
--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -30,7 +30,7 @@ class Image_Imagemagick extends Image_Driver {
 		{
 			do
 			{
-				$this->image_temp = substr($this->config['temp_dir'].$this->config['temp_append'].md5(time() * microtime()), 0, 32).'.png';
+				$this->image_temp = $this->config['temp_dir'].substr($this->config['temp_append'].md5(time() * microtime()), 0, 32).'.png';
 			}
 			while (file_exists($this->image_temp));
 		}
@@ -327,4 +327,4 @@ class Image_Imagemagick extends Image_Driver {
 	}
 }
 
-// End of file imagemagic.php
+// End of file imagemagick.php


### PR DESCRIPTION
Moved temp image path outside of substr(). Absolute paths were being truncated to 32 characters, resulting in attempted placement of temp images in folders where they should not be or could not be written to.
