### PR TITLE
Remove broken ORIG_PATH_INFO check

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -50,10 +50,6 @@ class Uri {
 		{
 			$uri = $_SERVER['PATH_INFO'];
 		}
-		elseif (isset($_SERVER['ORIG_PATH_INFO']) and ! empty($_SERVER['ORIG_PATH_INFO']))
-		{
-			$uri = $_SERVER['ORIG_PATH_INFO'];
-		}
 		else
 		{
 			if (isset($_SERVER['REQUEST_URI']))


### PR DESCRIPTION
So this is entirely conceptual and experimental, please don't hurt me :(

We're running php5.3 with php-fpm (fast cgi). We have enabled cgi.fix_pathinfo on the server and site.com/controller as well as site.com/controller/method work fine.

However, when we go to site.com/ this throws a (fuel) 404 and does not take the default route for this. This is because on /controller/method $_SERVER['PATH_INFO'] is '/controller/method' and $_SERVER['ORIG_PATH_INFO'] is /index.php/controller/method. When we go to site.com/ $_SERVER['PATH_INFO'] is not set and $_SERVER['ORIG_PATH_INFO'] is /index.php.

We have a fairly standard php-fpm setup. More details can be provided if you need them.

One would assume that ORIG_PATH_INFO would always be prefixed with /index.php and would not work unless you have a Controller_Index.php.

It seems that falling back and using the code for REQUEST_URI parsing works in our instance (i.e. if we remove the PATH_INFO and ORIG_PATH_INFO checks) but I can see the small performance benefit of being able to use PATH_INFO directly with no parsing.
