### PR TITLE
Updated View to allow files with non .php extensions to be loaded.

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -300,15 +300,17 @@ class View {
 	/**
 	 * Sets the view filename.
 	 *
-	 *     $view->set_filename($file);
+	 *     $view->set_filename($file, $extension);
 	 *
 	 * @param   string  view filename
+	 * @param   string  view filename extension
 	 * @return  View
 	 * @throws  Fuel_Exception
 	 */
-	public function set_filename($file)
+	public function set_filename($file, $extension = null)
 	{
-		if (($path = \Fuel::find_file('views', $file, '.'.$this->extension, false, false)) === false)
+		$extension = $extension ?: '.' . $this->extension;	
+		if (($path = \Fuel::find_file('views', $file, $extension, false, false)) === false)
 		{
 			throw new \Fuel_Exception('The requested view could not be found: '.\Fuel::clean_path($file));
 		}


### PR DESCRIPTION
Added an additional parameter to View->set_filename() that allows the filename extension to be specified. This allows you to use non .php files as views, such as .html, .js, etc.

Signed-off-by: Chuck Liddell liddellc@gmail.com
