### PR TITLE
Stops dates > 10 years from hanging; no rounding up dates by default

### DIFF
--- a/classes/date.php
+++ b/classes/date.php
@@ -203,10 +203,12 @@ class Date {
 	/**
 	 * Returns the time ago
 	 *
-	 * @param	int		UNIX timestamp from current server
+	 * @param	int		Beginning UNIX timestamp
+	 * @param	int		End UNIX timestamp, null means current time
+	 * @param	bool	Set to true in order to round last value
 	 * @return	string	Time ago
 	 */
-	public static function time_ago($timestamp, $from_timestamp = null)
+	public static function time_ago($timestamp, $from_timestamp = null, $round = false)
 	{
 		if ($timestamp === null)
 		{
@@ -220,15 +222,15 @@ class Date {
 		\Lang::load('date', true);
 
 		$difference = $from_timestamp - $timestamp;
-		$periods	= array('second', 'minute', 'hour', 'day', 'week', 'month', 'years', 'decade');
-		$lengths	= array(60, 60, 24, 7, 4.35, 12, 10);
+		$periods	= array('second', 'minute', 'hour', 'day', 'week', 'month', 'year');
+		$lengths	= array(60, 60, 24, 7, 4.3482, 12);
 
-		for ($j = 0; $difference >= $lengths[$j]; $j++)
+		for ($j = 0; $j != count($lengths) AND $difference >= $lengths[$j]; $j++)
 		{
 			$difference /= $lengths[$j];
 		}
 
-        $difference = round($difference);
+		$difference = ($round ? round($difference) : floor($difference));
 
 		if ($difference != 1)
 		{


### PR DESCRIPTION
Previous to this fix: dates beyond exactly one decade (to the day) caused server to hang, and time difference was rounded. First, while I could see instances where you may want to refer to dates in past as having been decades in the past or rounding upwards, that is very much an exception. E.g., On 9/11/2011, 9/11 happened <?=Date::time_ago(mktime(0,0,0,9,11,2001),mktime(0,0,0,9,11,2011));?>... Should that say 1 decade ago? What about when it is 14 years ago? Without this commit, at 14 years, it will say 1 decade. Then, when it is 15 years ago, it will tell you it happened 2 decades ago, but that would be false. The third parameter introduces the option to round instead of floor the value.
