### PR TITLE
Uri::create() accept urls

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -153,11 +153,16 @@ class Uri {
 	 */
 	public static function create($uri = null, $variables = array(), $get_variables = array())
 	{
-		$url = \Config::get('base_url');
-
-		if (\Config::get('index_file'))
+		$url = '';
+		
+		if(!preg_match("/^(http|https|ftp):\/\//i", $uri))
 		{
-			$url .= \Config::get('index_file').'/';
+			$url .= \Config::get('base_url');
+
+			if (\Config::get('index_file'))
+			{
+				$url .= \Config::get('index_file').'/';
+			}
 		}
 
 		$url = $url.ltrim(is_null($uri) ? static::string() : $uri, '/');

--- a/tests/uri.php
+++ b/tests/uri.php
@@ -46,6 +46,10 @@ class Tests_Uri extends TestCase {
 		$output = Uri::create('controller/:some', array('some' => 'thing', 'and' => 'more'), array('what' => ':and'));
 		$expected = $prefix."controller/thing.html?what=more";
 		$this->assertEquals($expected, $output);
+		
+		$output = Uri::create('http://example.com/controller/:some', array('some' => 'thing', 'and' => 'more'), array('what' => ':and'));
+		$expected = "http://example.com/controller/thing.html?what=more";
+		$this->assertEquals($expected, $output);
 
 	}
 


### PR DESCRIPTION
allow the Uri::create method to accept full urls and still replace elements/append get variables to the end

for example

``` php
Uri::create('http://example.com/controller/:some', array('some' => 'thing'), array('what' => ':and'));
```

becomes

```
http://example.com/controller/thing?what=more
```

this is useful for things like generating urls to cdn cached assets & still maintaining the ability to replace elements inside of the link
