### PR TITLE
Arr::assoc_to_keyval()

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -22,6 +22,33 @@ namespace Fuel\Core;
 class Arr {
 
 	/**
+	 * Converts a multi-dimensional associative array into an array of key => values with the provided field names
+	 *
+	 * @param   array   the array to convert
+	 * @param   string	the field name of the key field
+	 * @param   string	the field name of the value field
+	 * @return  array
+	 */
+	public static function assoc_to_keyval($assoc = null, $key_field = null, $val_field = null)
+	{
+		if(empty($assoc) OR empty($key_field) OR empty($val_field))
+		{
+			return null;
+		}
+		
+		$output = array();
+		foreach($assoc as $row)
+		{
+			if(isset($row[$key_field]) AND isset($row[$val_field]))
+			{
+				$output[$row[$key_field]] = $row[$val_field];
+			}
+		}
+		
+		return $output;
+	}
+
+	/**
 	 * Flattens a multi-dimensional associative array down into a 1 dimensional
 	 * associative array.
 	 *

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -37,6 +37,40 @@ class Tests_Arr extends TestCase {
 			),
 		);
 	}
+	
+	/**
+	 * Tests Arr::assoc_to_keyval()
+	 *
+	 * @test
+	 */
+	public function test_assoc_to_keyval()
+	{
+		$assoc = array(
+			array(
+				'color' => 'red',
+				'rank' => 4,
+				'name' => 'Apple',
+				),
+			array(
+				'color' => 'yellow',
+				'rank' => 3,
+				'name' => 'Banana',
+				),
+			array(
+				'color' => 'purple',
+				'rank' => 2,
+				'name' => 'Grape',
+				),
+			);
+		
+		$expected = array(
+			'red' => 'Apple',
+			'yellow' => 'Banana',
+			'purple' => 'Grape',
+			);
+		$output = Arr::assoc_to_keyval($assoc, 'color', 'name');
+		$this->assertEquals($expected, $output);
+	}
 
 	/**
 	 * Tests Arr::element()


### PR DESCRIPTION
Added the Arr::assoc_to_keyval() method for turning multidimensional array elements into a key=>value array.
