### PR TITLE
Security::htmlentities() infinite loop

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -167,7 +167,7 @@ class Security {
 		static $already_cleaned = array();
 
 		// Nothing to escape for non-string scalars, or for already processed values
-		if (is_bool($value) or is_int($value) or is_float($value) or in_array($value, $already_cleaned))
+		if (is_bool($value) or is_int($value) or is_float($value) or in_array($value, $already_cleaned, true))
 		{
 			return $value;
 		}


### PR DESCRIPTION
When you have a call to a function in a view and that function loads a child view (with data) you get an infinite loop in the Security::htmlentities() method.

Loading the parent view gets it passed through to the Security::htmlentities() method and because it is a whitelisted class it just gets added to the $already_cleaned array. When the child view with its data gets loaded by the function called in the parent view each item of data passed to the child view gets passed to the Security::htmlentities() method.

These strings are then compared to the parent view by in_array() which by its default behaviour tried to convert the view to a string so that the comparison can be made. In converting the parent view to a string it tries to render it and thus must call the function in it which contains the child view to get its value. However, to do this the child view must be loaded and its data passed through the Security::htmlentities() method. Herein lies the recursion.

Making the in_array() perform strict checking by passing it true as the 3rd parameter fixes this recursion as the parent view will not be converted to a string.

This may also have been an alternative fix to the previous issue with Security::htmlentities() - https://github.com/fuel/core/issues/263 
