### PR TITLE
Removed $options in MongoDB::remove_index.

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -905,7 +905,7 @@ class Mongo_Db {
 			throw new \Mongo_DbException("Index could not be removed from MongoDB Collection because no keys were specified");
 		}
 
-		if ($this->db->{$collection}->deleteIndex($keys, $options) == TRUE)  // @TODO : can't work, $options is undefined
+		if ($this->db->{$collection}->deleteIndex($keys) == TRUE)
 		{
 			$this->_clear();
 			return $this;


### PR DESCRIPTION
The var is not defined and not needed since the function doesn't use options, only the $key param as seen here: http://php.net/manual/en/mongocollection.deleteindex.php
