### PR TITLE
Fixed support for path setting in autoloading packages

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -159,9 +159,10 @@ class Fuel {
 		\Event::register('shutdown', 'Fuel::finish');
 
 		//Load in the packages
-		foreach (\Config::get('always_load.packages', array()) as $package)
+		foreach (\Config::get('always_load.packages', array()) as $package => $path)
 		{
-			static::add_package($package);
+			is_string($package) and $path = array($package => $path);
+			static::add_package($path);
 		}
 
 		// Load in the routes


### PR DESCRIPTION
As shown in the comments the package can have a location not relative to PKGPATH. But this wasn't passed through.
