### PR TITLE
Allow passing only an array to set_attribute

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -241,7 +241,7 @@ class Fieldset_Field
 	 * @param	mixed			new value or null to unset
 	 * @return	Fieldset_Field	this, to allow chaining
 	 */
-	public function set_attribute($config, $value)
+	public function set_attribute($config, $value = null)
 	{
 		$config = is_array($config) ? $config : array($config => $value);
 		foreach ($config as $key => $value)


### PR DESCRIPTION
This change allows passing of just an array of key/value pairs to set_attribute. 

Looks like it was intended this way, but for some reason was not setup to allow it.

I know this only throws a warning, but it seemed to make sense to just fix it.
