### PR TITLE
This change is to allow developers to pass data as objects in addition to arrays.

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -69,8 +69,12 @@ class View {
 	 * @param   array   array of values
 	 * @return  View
 	 */
-	public static function factory($file = null, array $data = null, $auto_encode = null)
+	public static function factory($file = null, $data = null, $auto_encode = null)
 	{
+		if (is_object($data))
+			$data = get_object_vars($data);
+		elseif (!is_array($data))
+			$data = array($data);
 		return new static($file, $data, $auto_encode);
 	}
 


### PR DESCRIPTION
$data->test = 'value' calls get_object_vars($data), which converts it into an array. $data['test']='value'

If an object is sent, convert it into an array. If something other than
an object or array is sent, convert it to an array.
