### PR TITLE
Trim SQL compilation

### DIFF
--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -174,7 +174,7 @@ class Database_Query {
 			$sql = strtr($sql, $values);
 		}
 
-		return $sql;
+		return trim($sql);
 	}
 
 	/**


### PR DESCRIPTION
This is because, when it falls back to execute(), the substr check gets confused if there's preceding WS.
