### PR TITLE
Develop

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -169,7 +169,7 @@ class Upload {
 	 */
 	public static function get_errors($index = null)
 	{
-		if (is_null($index) or ! isset(static::$files[$index]) or $files[$index]['error'] == 0)
+		if (is_null($index) or ! isset(static::$files[$index]) or static::$files[$index]['error'] == 0)
 		{
 			return array_filter(static::$files, function($file) { return $file['error'] != 0; } );
 		}

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -370,7 +370,7 @@ class Upload {
 			}
 
 			// update the valid flag
-			static::$valid = (static::$valid and ($files[$key]['error'] === 0));
+			static::$valid = (!static::$valid and ($files[$key]['error'] === 0));
 
 			// and add the message text
 			static::$files[$key]['message'] = \Lang::line('upload.'.static::$files[$key]['error']);


### PR DESCRIPTION
WanWizard has already fixed the issue regarding the missing static keyword, this request fixes an issue where the static::$valid property would remain as false due to it being false by default. The statement never evaluated to true due to this problem and so calling Upload::is_valid() always returned false even when successful.
