### PR TITLE
CSRF protection using HMAC of session ID

### DIFF
--- a/classes/crypt.php
+++ b/classes/crypt.php
@@ -138,6 +138,21 @@ class Crypt {
 
 	// --------------------------------------------------------------------
 
+	/*
+	 * generate the HMAC of a string
+	 *
+	 * @param	string	text to be hashed
+	 * @access	public
+	 * @return	string	message digest
+	 */
+	public static function hmac($value)
+	{
+		// calculate the hmac-sha256 hash of this value
+		return static::safe_b64encode(static::$hasher->hash($value));
+	}
+
+	// --------------------------------------------------------------------
+
 	private static function safe_b64encode($value)
 	{
 		$data = base64_encode($value);


### PR DESCRIPTION
On the roadmap for Fuel 1.1, the "Multi-Form support for CSRF security" feature has been postponed. The suggested solution for this is to use the available Javascript functions to update the CSRF token upon form submission. I see three problems with this solution.
1. Additional effort required by the developer.
2. Cookies cannot be HTTP Only which reduces security.
3. Javascript must be enabled (a small problem, admittedly).

This patch instead uses the HMAC method described by Barth et. al. in the paper Robust Defenses for Cross-Site Request Forgery (http://seclab.stanford.edu/websec/csrf/csrf.pdf). Instead of using a new nonce for every request, the HMAC of the user's session ID is used as a token. Due to the fact that the token can be regenerated with the same result upon each request there is no need to store the token in a cookie, which in turn solves the three problems listed above.

Two potential problems that could exist with the HMAC method is that leaking the token to an external application would be worse than before, and that there could be issues when an aggresive session ID regeneration scheme is used. The first one isn't an issue unless the developer does something seriously stupid. Secondly, an aggressive regeneration shouldn't be necessary due to the fact that the ID is AES encrypted.

This solution could be further extended in accordance to the recommendations of Barth et. al. by instead using the Referer header when a site is using HTTPS. In any case, I believe this implementation is a superior alternative, so I hope you will discuss it in your team.
