### PR TITLE
Merging root config as expected

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -43,7 +43,7 @@ class Config {
 
 		if ($group === null)
 		{
-			static::$items = $reload ? $config : static::$items + $config;
+			static::$items = $reload ? array_merge(static::$items, $config);
 		}
 		else
 		{


### PR DESCRIPTION
When trying to merge an own config file with the root config (by not defining a group when calling Config::load) I found out that I could not overwrite already defined variables - without a group only "new" configuration can be added to the group (because the + operator for arrays is used instead of array_merge)

I guess there was some reason why this behavior was implemented this way, yet the documentation on http://fuelphp.com/docs/classes/config.html does not state this limitation with the group parameter: "If this is not set or is null then the loaded config will be merged with the root config." Merging implies that config variables can be overwritten.
