### PR TITLE
Image class fixes. credits for original author (dudeami)

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -317,33 +317,24 @@ abstract class Image_Driver {
 		$x = $y = 0;
 		if (function_exists('bcdiv'))
 		{
-			$widthr  = bcdiv($sizes->width, $width, 10);
-			$heightr = bcdiv($sizes->height, $height, 10);
-			$compare = bccomp($widthr, $heightr, 10);
-			if ($compare < 1)
+			if (bccomp(bcdiv($sizes->width, $width, 10), bcdiv($sizes->height, $height, 10), 10) < 1)
 			{
-				$t_height = ceil((float) bcmul($height, $widthr, 10));
-				$this->_resize($width, $t_height, true, false);
+				$this->_resize($width, 0, true, false);
 			}
 			else
 			{
-				$t_width = ceil((float) bcmul($width, $heightr, 10));
-				$this->_resize($t_width, $height, true, false);
+				$this->_resize(0, $height, true, false);
 			}
 		}
 		else
 		{
-			$widthr  = $sizes->width / $width;
-			$heightr = $sizes->height / $height;
-			if ($widthr < $heightr)
+			if ($sizes->width / $width < $sizes->height / $height)
 			{
-				$t_height = ceil($height * $widthr);
-				$this->_resize($width, $t_height, true, false);
+				$this->_resize($width, 0, true, false);
 			}
 			else
 			{
-				$t_width = ceil($width * $heightr);
-				$this->_resize($t_width, $height, true, false);
+				$this->_resize(0, $height, true, false);
 			}
 		}
 		$sizes = $this->sizes();

--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -21,7 +21,7 @@ class Image_Imagemagick extends \Image_Driver {
 	private $size_cache = null;
 	private $im_path = null;
 
-	public function load($filename)
+	public function load($filename, $return_data = false)
 	{
 		extract(parent::load($filename));
 
@@ -130,7 +130,7 @@ class Image_Imagemagick extends \Image_Driver {
 	 *
 	 * @link  http://www.imagemagick.org/Usage/thumbnails/#rounded
 	 */
-	protected function _rounded($radius, $sides)
+	protected function _rounded($radius, $sides, $antialias = 0)
 	{
 		extract(parent::_rounded($radius, $sides, null));
 
@@ -195,7 +195,7 @@ class Image_Imagemagick extends \Image_Driver {
 		$new = '"'.$filename.'"';
 		$this->exec('convert', $old.' '.$new);
 
-		if ($this->config['persistent'] === false)
+		if ($this->config['persistence'] === false)
 			$this->reload();
 
 		return $this;
@@ -262,6 +262,8 @@ class Image_Imagemagick extends \Image_Driver {
 	{
 		//  Determine the path
 		$this->im_path = realpath($this->config['imagemagick_dir'].$program);
+		if ( ! $this->im_path)
+			$this->im_path = realpath($this->config['imagemagick_dir'].$program);
 		if ( ! $this->im_path)
 			$this->im_path = realpath($this->config['imagemagick_dir'].$program.'.exe');
 		if ( ! $this->im_path)

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -19,7 +19,7 @@ class Image_Imagick extends \Image_Driver {
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
 	private $imagick = null;
 
-	public function load($filename)
+	public function load($filename, $return_data = false)
 	{
 		extract(parent::load($filename));
 		
@@ -35,7 +35,7 @@ class Image_Imagick extends \Image_Driver {
 	{
 		extract(parent::_crop($x1, $y1, $x2, $y2));
 		
-		$this->imagick->cropImage(($x2 - $x1), ($y2 - $y1), $y1, $x1);
+		$this->imagick->cropImage(($x2 - $x1), ($y2 - $y1), $x1, $y1);
 	}
 
 	protected function _resize($width, $height = null, $keepar = true, $pad = true)
@@ -85,7 +85,7 @@ class Image_Imagick extends \Image_Driver {
 		$this->imagick->compositeImage($wmimage, \Imagick::COMPOSITE_COPYOPACITY, 0, 0);
 	}
 	
-	protected function _rounded($radius, $sides)
+	protected function _rounded($radius, $sides, $antialias = 0)
 	{
 		extract(parent::_rounded($radius, $sides, null));
 		
@@ -162,12 +162,14 @@ class Image_Imagick extends \Image_Driver {
 		$this->run_queue();
 		$this->add_background();
 		
+		$filetype = $this->image_extension;
+		
 		if ($this->imagick->getImageFormat() != $filetype)
 			$this->imagick->setImageFormat($filetype);
 		
 		file_put_contents($filename, $this->imagick->getImageBlob());
 
-		if ($this->config['persistent'] === false)
+		if ($this->config['persistence'] === false)
 			$this->reload();
 		
 		return $this;

--- a/config/image.php
+++ b/config/image.php
@@ -22,7 +22,7 @@
 
 return array(
 	/**
-	 * The driver to be used. Currently gd or imagemagick
+	 * The driver to be used. Currently gd, imagemagick or imagick
 	 */
 	'driver' => 'gd',
 
@@ -68,10 +68,10 @@ return array(
 	/**
 	 * Sets if the queue should be cleared after a save(), save_pa(), or output().
 	 */
-	'clear_queue' => false,
+	'clear_queue' => true,
 
 	/**
-	 * Determines whether to automatically reload the image (true) or keep the changes (false) when saving or outputting.
+	 * Determines whether to automatically reload the image (false) or keep the changes (true) when saving or outputting.
 	 */
 	'persistence' => false,
 


### PR DESCRIPTION
Fixed `resize_crop()` bugs, fixed typos in config, chenged one config value as suggested per image class author; fixed imagemagick (almost did not work); fixe Imagick class - did not work at all; fixed Declaration of `Fuel\Core\Image_*::_rounded()` should be compatible with... and similar notices; and others can't remember
