### PR TITLE
Hotfix/image preset resize

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -254,18 +254,18 @@ abstract class Image_Driver {
 			// See which is the biggest ratio
 			if (function_exists('bcdiv'))
 			{
-				$width_ratio  = bcdiv((real) $width, $sizes->width, 10);
-				$height_ratio = bcdiv((real) $height, $sizes->height, 10);
+				$width_ratio  = bcdiv((float) $width, $sizes->width, 10);
+				$height_ratio = bcdiv((float) $height, $sizes->height, 10);
 				$compare = bccomp($width_ratio, $height_ratio, 10);
 				if ($compare > -1)
 				{
-					$height = ceil((real) bcmul($sizes->height, $height_ratio, 10));
-					$width = ceil((real) bcmul($sizes->width, $height_ratio, 10));
+					$height = ceil((float) bcmul($sizes->height, $height_ratio, 10));
+					$width = ceil((float) bcmul($sizes->width, $height_ratio, 10));
 				}
 				else
 				{
-					$height = ceil((real) bcmul($sizes->height, $width_ratio, 10));
-					$width = ceil((real) bcmul($sizes->width, $width_ratio, 10));
+					$height = ceil((float) bcmul($sizes->height, $width_ratio, 10));
+					$width = ceil((float) bcmul($sizes->width, $width_ratio, 10));
 				}
 			}
 			else

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -254,8 +254,8 @@ abstract class Image_Driver {
 			// See which is the biggest ratio
 			if (function_exists('bcdiv'))
 			{
-				$width_ratio  = bcdiv($width, $sizes->width, 10);
-				$height_ratio = bcdiv($height, $sizes->height, 10);
+				$width_ratio  = bcdiv((real) $width, $sizes->width, 10);
+				$height_ratio = bcdiv((real) $height, $sizes->height, 10);
 				$compare = bccomp($width_ratio, $height_ratio, 10);
 				if ($compare > -1)
 				{


### PR DESCRIPTION
bugfix - when using presets for resizing or crop resizing always getting black images because of bcdiv not calculating the ratios correctly due to type cast strangeness;
