### PR TITLE
To get the post-array, you now can use \Input::post() instead of \Input::

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -136,7 +136,7 @@ class Input {
 	 * @param	mixed	The default value
 	 * @return	string
 	 */
-	public static function get($index, $default = null)
+	public static function get($index = null, $default = null)
 	{
 		return static::_fetch_from_array($_GET, $index, $default);
 	}
@@ -149,7 +149,7 @@ class Input {
 	 * @param	mixed	The default value
 	 * @return	string
 	 */
-	public static function post($index, $default = null)
+	public static function post($index = null, $default = null)
 	{
 		return static::_fetch_from_array($_POST, $index, $default);
 	}
@@ -212,7 +212,7 @@ class Input {
 	 * @param	mixed	The default value
 	 * @return	string
 	 */
-	public static function get_post($index, $default = null)
+	public static function get_post($index = null, $default = null)
 	{
 		return static::post($index, 's)meR4nD0ms+rIng') === 's)meR4nD0ms+rIng'
 				? static::get($index, $default)


### PR DESCRIPTION
http://fuelphp.com/dev-docs/classes/input.html writes for \Input::post()

post($index, $default = null)
$index  required    The key in the $_POST array, or _null_ for the entire array

To get the post-array, you had to use \Input::post(null).
Now you can use \Input::post()

---

Fix also works for \Input::get() and \Input::get_post()
