### PR TITLE
Rest controller empty() check breaks on 0

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -101,12 +101,12 @@ abstract class Controller_Rest extends \Controller {
 	 *
 	 * Takes pure data and optionally a status code, then creates the response
 	 *
-	 * @param  array
+	 * @param  mixed
 	 * @param  int
 	 */
 	protected function response($data = array(), $http_code = 200)
 	{
-		if (empty($data))
+		if ((is_array($data) and empty($data)) or ($data == ''))
 		{
 			$this->response->status = 404;
 			return;


### PR DESCRIPTION
Rest controller response() method can take a string or int as a param but the empty() check makes it 404 on '0'. Fix this.
