### PR TITLE
Input::real_ip() check for HTTP_X_CLUSTER_CLIENT_IP (Issue #403)

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -153,7 +153,11 @@ class Input {
 	 */
 	public static function real_ip()
 	{
-		if (static::server('HTTP_X_FORWARDED_FOR') !== null)
+		if (static::server('HTTP_X_CLUSTER_CLIENT_IP') !== null)
+		{
+			return static::server('HTTP_X_CLUSTER_CLIENT_IP');
+		}
+		elseif (static::server('HTTP_X_FORWARDED_FOR') !== null)
 		{
 			return static::server('HTTP_X_FORWARDED_FOR');
 		}


### PR DESCRIPTION
Added 'HTTP_X_CLUSTER_CLIENT_IP' to the list of things to check for in Input::real_ip() to fix #403
