### PR TITLE
Closures as routes

### DIFF
--- a/classes/route.php
+++ b/classes/route.php
@@ -32,6 +32,8 @@ class Route {
 
 	public $translation = null;
 
+	public $closure = null;
+
 	protected $search = null;
 
 	public function __construct($path, $translation = null)
@@ -87,13 +89,6 @@ class Route {
 	 */
 	public function matched($uri = '', $named_params = array())
 	{
-		$path = $this->translation;
-
-		if ($uri != '')
-		{
-			$path = preg_replace('#^'.$this->search.'$#uD', $this->translation, $uri);
-		}
-
 		// Clean out all the non-named stuff out of $named_params
 		foreach($named_params as $key => $val)
 		{
@@ -104,7 +99,22 @@ class Route {
 		}
 
 		$this->named_params = $named_params;
-		$this->segments = explode('/', trim($path, '/'));
+		
+		if ($this->translation instanceof \Closure)
+		{
+			$this->closure = $this->translation;
+		}
+		else
+		{
+			$path = $this->translation;
+
+			if ($uri != '')
+			{
+				$path = preg_replace('#^'.$this->search.'$#uD', $this->translation, $uri);
+			}
+
+			$this->segments = explode('/', trim($path, '/'));
+		}
 
 		return $this;
 	}

--- a/classes/router.php
+++ b/classes/router.php
@@ -104,6 +104,11 @@ class Router {
 			$match->parse($request);
 		}
 
+		if ($match->closure !== null)
+		{
+			return $match;
+		}
+
 		return static::find_controller($match);
 	}
 


### PR DESCRIPTION
Route objects now have a property called 'closure' which is null by default. If the value of the route is an anonymous function, that property is set to the closure. The Request class checks this property to decide if a controller/action search is necessary or not.

The closure can have one parameter, which will be passed the Request object. Named parameters will therefore be available, while "regular" parameters (using $1, $2 etc) are not, since their use is more about re-routing than passing values. They could probably be implemented, but then you guys would have to make a decision on how they should work with closures.

I've tested this with a closure throwing a 404 exception, returning only a string and returning a full View object, and all seems to work fine, but I suppose you might have some more tests you would like to run.

Finally, it might seem like the Request class has gotten a full makeover, but you'll see that I've mainly just moved some things around to make it all work smoothly.
