### PR TITLE
Restore case-insensetive behavior of Input::server() method.

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -372,7 +372,7 @@ class Input {
 	 */
 	public static function server($index = null, $default = null)
 	{
-		return (is_null($index) and func_num_args() === 0) ? $_SERVER : \Arr::get($_SERVER, $index, $default);
+		return (is_null($index) and func_num_args() === 0) ? $_SERVER : \Arr::get($_SERVER, strtoupper($index), $default);
 	}
 
 	/**


### PR DESCRIPTION
Bug introduced in 8242001a5f6f4cfb1b6c1364155966625686c514
