### PR TITLE
HTTPS detection fix for nginx server

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -181,7 +181,7 @@ class Arr {
 			$curr_key[] = $key;
 			if (is_array($val) and ($indexed or array_values($val) !== $val))
 			{
-				static::flatten_assoc($val, $glue, false);
+				static::flatten($val, $glue, false. false);
 			}
 			else
 			{

--- a/classes/input.php
+++ b/classes/input.php
@@ -190,7 +190,15 @@ class Input {
 	 */
 	public static function protocol()
 	{
-		return (static::server('HTTPS') !== null and static::server('HTTPS') != 'off') ? 'https' : 'http';
+		if (static::server('HTTPS') !== null and static::server('HTTPS') != 'off')
+		{
+			return 'https';
+		}
+		elseif (static::server('SERVER_PORT') == 443)
+		{
+			return 'https';
+		}
+		return 'http';
 	}
 
 	/**


### PR DESCRIPTION
This allows Input::protocol() to function properly on nginx.

nginx does not set $_SERVER['HTTPS'] by default.  You have to check the server port to see if it's HTTPS or HTTP.  The best solution would be to just set the HTTPS variable in the nginx config file, but I don't think most people would know to do that.
