### PR TITLE
Fixed Oil returning HTML 404 message when there an error exception

### DIFF
--- a/classes/error.php
+++ b/classes/error.php
@@ -53,7 +53,7 @@ class Error {
 			logger(Fuel::L_ERROR, $severity.' - '.$last_error['message'].' in '.$last_error['file'].' on line '.$last_error['line']);
 
 			$error = new \ErrorException($last_error['message'], $last_error['type'], 0, $last_error['file'], $last_error['line']);
-			if (\Fuel::$env == \Fuel::PRODUCTION AND !\Fuel::$is_cli)
+			if (\Fuel::$env == \Fuel::PRODUCTION AND ! \Fuel::$is_cli)
 			{	
 				static::show_production_error($error);
 			}
@@ -82,7 +82,7 @@ class Error {
 		$severity = ( ! isset(static::$levels[$e->getCode()])) ? $e->getCode() : static::$levels[$e->getCode()];
 		logger(Fuel::L_ERROR, $severity.' - '.$e->getMessage().' in '.$e->getFile().' on line '.$e->getLine());
 
-		if (\Fuel::$env == \Fuel::PRODUCTION AND !\Fuel::$is_cli)
+		if (\Fuel::$env == \Fuel::PRODUCTION AND ! \Fuel::$is_cli)
 		{
 			static::show_production_error($e);
 		}

--- a/classes/error.php
+++ b/classes/error.php
@@ -53,13 +53,13 @@ class Error {
 			logger(Fuel::L_ERROR, $severity.' - '.$last_error['message'].' in '.$last_error['file'].' on line '.$last_error['line']);
 
 			$error = new \ErrorException($last_error['message'], $last_error['type'], 0, $last_error['file'], $last_error['line']);
-			if (\Fuel::$env != Fuel::PRODUCTION)
-			{
-				static::show_php_error($error);
+			if (\Fuel::$env == \Fuel::PRODUCTION AND !\Fuel::$is_cli)
+			{	
+				static::show_production_error($error);
 			}
 			else
 			{
-				static::show_production_error($error);
+				static::show_php_error($error);
 			}
 
 			exit(1);
@@ -82,13 +82,13 @@ class Error {
 		$severity = ( ! isset(static::$levels[$e->getCode()])) ? $e->getCode() : static::$levels[$e->getCode()];
 		logger(Fuel::L_ERROR, $severity.' - '.$e->getMessage().' in '.$e->getFile().' on line '.$e->getLine());
 
-		if (\Fuel::$env != Fuel::PRODUCTION)
+		if (\Fuel::$env == \Fuel::PRODUCTION AND !\Fuel::$is_cli)
 		{
-			static::show_php_error($e);
+			static::show_production_error($e);
 		}
 		else
 		{
-			static::show_production_error($e);
+			static::show_php_error($e);
 		}
 	}
 


### PR DESCRIPTION
Fixed Oil returning HTML 404 message when there an error exception on production environment
### Sample on production

```
$ php oil r migrate
<!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8">
    <title>Fuel PHP Framework</title>
    <style type="text/css">
        * { margin: 0; padding: 0; }
        body { background-color: #EEE; font-family: sans-serif; font-size: 16px; line-height: 20px; margin: 40px; }
        #wrapper { padding: 30px; background: #fff; color: #333; margin: 0 auto; width: 800px; }
        h1 { color: #000; font-size: 55px; padding: 0 0 25px; line-height: 1em; }
        .intro { font-size: 22px; line-height: 30px; font-family: georgia, serif; color: #555; padding: 29px 0 20px; border-top: 1px solid #CCC; }
        p { margin: 0 0 15px; line-height: 22px;}
    </style>
</head>
<body>
    <div id="wrapper">
        <h1>Oops!</h1>
        <p class="intro">An unexpected error has occurred.</p>
    </div>
</body> 
```

I don't think it would be relevant to show a generic error message for oil, as the oil should and would only be accessible from developer or server admin
