### PR TITLE
Strict comparison for migrating down.

### DIFF
--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -78,7 +78,7 @@ class Migrate {
 				\Cli::write('Migrated to latest version: ' . $result .'.', 'green');
 			}
 		}
-		
+
 	}
 
 	public static function up()
@@ -100,13 +100,13 @@ class Migrate {
 	public static function down()
 	{
 		\Config::load('migrations', true);
-		
+
 		if (($version = \Config::get('migrations.version') - 1) < 0)
 		{
 			throw new \Oil\Exception('You are already on the first migration.');
 		}
 
-		if (\Migrate::version($version))
+		if (\Migrate::version($version) !== false)
 		{
 			static::_update_version($version);
 			\Cli::write("Migrated to version: {$version}.", 'green');


### PR DESCRIPTION
On a successful database migration `Migrate:version()` returns the version, which, here would be 0, and would eval to `false`. Thus `_update_version` would never run and would screw things up. This Commit fixes that (hopefully).

P.S. This is my first pull request, ever.
