### PR TITLE
Fix for #432 - Format::_from_xml() not working with recursion

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -96,6 +96,11 @@ class Format {
 
 		$array = array();
 
+		if (is_object ( $data))
+		{
+			$data = get_object_vars($data);
+		}
+
 		foreach ($data as $key => $value)
 		{
 			if (is_object($value) or is_array($value))


### PR DESCRIPTION
A simple fix for the issue #432 : Format::_from_xml() doesn't work
properly with recursion  The change checks for an object and then converts it on each recursion through the XML DOM.
