### PR TITLE
Make field being validated accessible from validation rules

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -112,6 +112,11 @@ class Validation {
 	 * @var  array  contains validation error messages, will overwrite those from lang files
 	 */
 	protected $error_messages = array();
+	
+	/**
+	 * @var  mixed  contains the field currently being validated
+	 */
+	protected $_current_validation_field = null;
 
 	protected function __construct($fieldset)
 	{
@@ -416,7 +421,12 @@ class Validation {
 			return;
 		}
 
-		$output = call_user_func_array(reset($rule), array_merge(array($value), $params));
+		$rule_callback = reset($rule);
+		$rule_callback[0]->_current_validation_field = $field;
+
+		$output = call_user_func_array($rule_callback, array_merge(array($value), $params));
+
+		$rule_callback[0]->_current_validation_field = null;
 
 		if ($output === false && $value !== false)
 		{


### PR DESCRIPTION
Store the field currently being validated in a $_current_validation_field property on the class containing the rule being run.

I originally thought to pass it through as a parameter but this would mean all current validation rules would break. The idea to store it in a parameter came from waldmeister on irc.

To use it with Orm Models the property will either need to be added to the Orm\Model class, or to every model that wants to use custom validation. Custom validation classes would also need the property adding to them.
