### PR TITLE
Added to_url function, creates a string suitable for use in URLs

### DIFF
--- a/classes/str.php
+++ b/classes/str.php
@@ -285,6 +285,30 @@ class Str {
 			return $args[($next ? $i++ : $i) % count($args)];
 		};
 	}
+	
+	/**
+	 * Returns a string suitable for use in a URL. Spaces are converted to hyphens,
+	 * everything is lowercase and non-standard characters are removed.
+	 *
+	 * @param	string	$url			required	URL to be returned
+	 * @param 	string	$space_replace				Character to use instead of a space
+	 * @return	string
+	 */
+	public static function to_url($url, $space_replace = '-')
+	{
+		// Lower case, no funny business
+		$url = strtolower($url);
+		$url = strip_tags($url);
+		$url = stripslashes($url);
+		$url = trim($url);
+
+		// Replace spaces
+		$url = preg_replace("/\s+/", $space_replace, $url);
+
+		// Remove anything that isn’t a number, letter, hyphen or underscore
+		$url = preg_replace("/[^a-z0-9\-\_]/", '', $url);
+
+		// Return without bits hanging off the end
+		return trim($url, $space_replace);
+	}
 }
-
-

--- a/tests/str.php
+++ b/tests/str.php
@@ -212,4 +212,17 @@ class Tests_Str extends TestCase {
 		$output = Str::random('nozero', 22);
 		$this->assertFalse(strpos($output, '0'));	
 	}
+	
+	/**
+	 * Test for Str::to_url()
+	 *
+	 * @test
+	 */
+	public function test_to_url()
+	{
+		$output = Str::to_url('Oh, hello! You’re a nice chap .');
+		$expected = "oh-hello-youre-a-nice-chap";
+
+		$this->assertEquals($expected, $output);
+	}
 }


### PR DESCRIPTION
Accepts a string, removes everything that isn’t a number or letter, converts spaces into hyphens. Optionally change hyphens for something else as part of the function.

I use this in almost every single project I work on, so I’d obviously love to see it as part of Fuel.
