### PR TITLE
Reverse the logic for Upload::is_valid() status

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -364,12 +364,12 @@ class Upload {
 		}
 
 		// determine the validate status
-		$valid = true;
+		$valid = false;
 		foreach(static::$files as $key => $value)
 		{
-			if ($value['error'] !== 0)
+			if ($value['error'] == 0)
 			{
-				$valid = false;
+				$valid = true;
 				break;
 			}
 		}


### PR DESCRIPTION
Changed the determination of the validate status to presume invalid until a valid upload is found, rather than the opposite.
