### PR TITLE
fixed Str::lcfirst() fallback, if mb_strtolower does'nt exist

### DIFF
--- a/classes/str.php
+++ b/classes/str.php
@@ -156,7 +156,7 @@ class Str {
 		return function_exists('mb_strtolower')
 			? mb_strtolower(mb_substr($str, 0, 1, $encoding), $encoding).
 				mb_substr($str, 1, mb_strlen($str, $encoding), $encoding)
-			: ucfirst($str);
+			: lcfirst($str);
 	}
 
 	/**


### PR DESCRIPTION
the lcfirst fallback in the str class pointet to ucfirst...not to lcfirst
