### PR TITLE
Fixed deprecated method "Arr::replace_keys"

### DIFF
--- a/classes/agent.php
+++ b/classes/agent.php
@@ -549,7 +549,7 @@ class Agent {
 				}
 			}
 
-			$result[$browser] = \Arr::replace_keys($properties, static::$keys);
+			$result[$browser] = \Arr::replace_key($properties, static::$keys);
 
 		}
 


### PR DESCRIPTION
Fixed the use of a deprecated method "Arr::replace_keys" that cause hundreds of log warnings
