### PR TITLE
Fixed misspelling

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -110,7 +110,7 @@ class Input {
 				$uri = substr($uri, 1);
 			}
 
-			// Lets split the URI up in case it containes a ?.  This would
+			// Lets split the URI up in case it contains a ?.  This would
 			// indecate the server requires 'index.php?' and that mod_rewrite
 			// is not being used.
 			preg_match('#(.*?)\?(.*)#i', $uri, $matches);


### PR DESCRIPTION
Correct misspelling containes to contains. 
Correct misspelling indecate to indicate.
