### PR TITLE
[Mongo] Allow select to take single values for includes and excludes rather than 

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -262,12 +262,12 @@ class Mongo_Db {
 	{
 	 	if ( ! is_array($includes))
 	 	{
-	 		$includes = array();
+	 		$includes = array($includes);
 	 	}
 
 	 	if ( ! is_array($excludes))
 	 	{
-	 		$excludes = array();
+	 		$excludes = array($excludes);
 	 	}
 
 	 	if ( ! empty($includes))


### PR DESCRIPTION
Allow select to take single values for includes and excludes rather than having to have an arrays. ex: $mongodb->select('foo')->get('foobar');
