### PR TITLE
Fix possiblity test_days_in_month() test will fail every leap years

### DIFF
--- a/tests/date.php
+++ b/tests/date.php
@@ -27,7 +27,11 @@ class Tests_Date extends TestCase {
 	 */
 	public function test_days_in_month()
 	{
-		$output = Date::days_in_month(2);
+		$output = Date::days_in_month(8);
+		$expected = 31;
+		$this->assertEquals($expected, $output);
+
+		$output = Date::days_in_month(2,2001);
 		$expected = 28;
 		$this->assertEquals($expected, $output);
 


### PR DESCRIPTION
Given `$output = Date::days_in_month(2);` executed next year (2012) or any leap year would return 29 instead of 28, which would make the test fail. 
