### PR TITLE
Allow adding a Fieldset_Field to a Fieldset via add()

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -194,6 +194,17 @@ class Fieldset
 	 */
 	public function add($name, $label = '', array $attributes = array(), array $rules = array())
 	{
+		if (is_a($name, 'Fieldset_Field'))
+		{
+			// Make sure it doesn't conflict with existing fields
+			if ($existing_field = static::field($name->name))
+			{
+				\Error::notice('Field with this name exists already, cannot be overwritten through add().');
+				return $existing_field;
+			}
+			$this->fields[$name->name] = $name;
+			return $name;
+		}
 		if (empty($name) || (is_array($name) and empty($name['name'])))
 		{
 			throw new \InvalidArgumentException('Cannot create field without name.');


### PR DESCRIPTION
Added support for creating a Fieldset_Field instance outside of the Fieldset, then adding it to the Fieldset via the `add()` method.

I have a use case that requires this ability, and although it may not be a common use case, I don't think it interferes with much. Here's what I'm doing: (And please let me know if there's a better way of accomplishing this)

My models tend to share many properties, so I have separated common fields into "sub-models" from which the parent model inherits fields. Currently I have the "sub-models" `Address` and `Person`, and actually `Address` is also a "sub-model" of `Person`, because most people have addresses.

Using Fieldset to generate the forms for this setup poses a challenge; Simply using `add_model()` only adds the fields that are directly in the current model, and doesn't include the fields that are to be inherited from "sub-models" like `Address`. I went the route of implementing my own `set_form_fields()` in my models, which adds the fields for the current model, looks for any sub-models to inherit from, and adds those fields as well, but adds the name to an HTML form array so that the end result is HTML that looks something that looks like this:

```
<input name="core_field1" />
<input name="core_field2" />
<input name="address[addr_field1]" />
```

That way I can later retrieve the fields from POST, separated into the different models ready for validation, and if field names are shared between models, they don't conflict.

So far, so good. Problem is, in my `set_form_fields()`, the line `$instance and $form->populate($instance);` only populates the core fields. My solution to that was to create a separate `Fieldset` for the sub-model, add the fields for the submodel, populate it, then add the fields from that Fieldset into the main Fieldset. This pull request adds the ability to add those fields to another fieldset.
