### PR TITLE
Leave the _404_ route of modules alone

### DIFF
--- a/classes/request.php
+++ b/classes/request.php
@@ -301,7 +301,7 @@ class Request {
 					{
 						$name = $module;
 					}
-					elseif (strpos($name, $module.'/') !== 0 and $name != $module)
+					elseif (strpos($name, $module.'/') !== 0 and $name != $module and $name !== '_404_')
 					{
 						$name = $module.'/'.$name;
 					}


### PR DESCRIPTION
This used to be the case but was broken in the below commit:

https://github.com/fuel/core/commit/6200219db1809144a2499ea0ec1400b3bafb4734#classes/request.php

Just added a check that the route is not `_404_` for when the module name is prepended to the route.
