### PR TITLE
Fix REST format detection via HTTP_ACCEPT

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -160,7 +160,7 @@ abstract class Controller_Rest extends \Controller {
 		}
 
 		// Otherwise, check the HTTP_ACCEPT (if it exists and we are allowed)
-		if (\Config::get('rest.ignore_http_accept') === false and \Input::server('HTTP_ACCEPT'))
+		if (\Config::get('rest.ignore_http_accept') !== false and \Input::server('HTTP_ACCEPT'))
 		{
 			// Check all formats against the HTTP_ACCEPT header
 			foreach (array_keys($this->_supported_formats) as $format)


### PR DESCRIPTION
Simple logic error was preventing the Rest controller from detecting the return format if specified only using `HTTP_ACCEPT`
