### PR TITLE
Multiple bugs with Arr and Str TestCase

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -587,7 +587,7 @@ class Arr {
 	 */
 	public static function prepend(&$arr, $key, $value = null)
 	{
-		$arr = (is_array($key) ? $key : array($key => $value)) + $arr;
+		return $arr = (is_array($key) ? $key : array($key => $value)) + $arr;
 	}
 
 }

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -587,7 +587,7 @@ class Arr {
 	 */
 	public static function prepend(&$arr, $key, $value = null)
 	{
-		return $arr = (is_array($key) ? $key : array($key => $value)) + $arr;
+		$arr = (is_array($key) ? $key : array($key => $value)) + $arr;
 	}
 
 }

--- a/classes/str.php
+++ b/classes/str.php
@@ -88,7 +88,7 @@ class Str {
 		$encoding or $encoding = \Fuel::$encoding;
 
 		return function_exists('mb_substr')
-			? mb_substr($str, $start, $length, $encoding)
+			? mb_substr($str, $start, (is_null($length) ? strlen($str) : $length), $encoding)
 			: (is_null($length) ? substr($str, $start) : substr($str, $start, $length));
 	}
 

--- a/classes/str.php
+++ b/classes/str.php
@@ -88,7 +88,7 @@ class Str {
 		$encoding or $encoding = \Fuel::$encoding;
 
 		return function_exists('mb_substr')
-			? mb_substr($str, $start, (is_null($length) ? strlen($str) : $length), $encoding)
+			? mb_substr($str, $start, (is_null($length) ? mb_strlen($str, $encoding) : $length), $encoding)
 			: (is_null($length) ? substr($str, $start) : substr($str, $start, $length));
 	}
 

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -555,8 +555,8 @@ class Tests_Arr extends TestCase {
 			'two' => 2,
 			'three' => 3,
 		);
-		$output = Arr::prepend($arr, 'one', 1);
-		$this->assertEquals($expected, $output);
+		Arr::prepend($arr, 'one', 1);
+		$this->assertEquals($expected, $arr);
 	}
 	
 	/**
@@ -575,8 +575,8 @@ class Tests_Arr extends TestCase {
 			'two' => 2,
 			'three' => 3,
 		);
-		$output = Arr::prepend($arr, array('one' => 1));
-		$this->assertEquals($expected, $output);
+		Arr::prepend($arr, array('one' => 1));
+		$this->assertEquals($expected, $arr);
 	}
 }
 

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -159,16 +159,7 @@ class Tests_Arr extends TestCase {
 	 */
 	public function test_element_throws_exception_when_array_is_not_an_array()
 	{
-		try 
-		{
-			$output = Arr::element('Jack', 'name', 'Unknown Name');
-		}
-		catch (\InvalidArgumentException $e) 
-		{
-			return ;
-		}
-
-		$this->fail("Expected Exception \InvalidArgumentException not thrown");
+		$output = Arr::element('Jack', 'name', 'Unknown Name');
 	}
 
 	/**

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -155,12 +155,20 @@ class Tests_Arr extends TestCase {
 	 * Tests Arr::element()
 	 *
 	 * @test
+	 * @expectedException InvalidArgumentException
 	 */
-	public function test_element_when_array_is_not_an_array()
+	public function test_element_throws_exception_when_array_is_not_an_array()
 	{
-		$expected = "Unknown Name";
-		$output = Arr::element('Jack', 'name', 'Unknown Name');
-		$this->assertEquals($expected, $output);
+		try 
+		{
+			$output = Arr::element('Jack', 'name', 'Unknown Name');
+		}
+		catch (\InvalidArgumentException $e) 
+		{
+			return ;
+		}
+
+		$this->fail("Expected Exception \InvalidArgumentException not thrown");
 	}
 
 	/**
@@ -214,11 +222,12 @@ class Tests_Arr extends TestCase {
 	 *
 	 * @test
 	 * @dataProvider person_provider
-	 * @expectedException InvalidArgumentException
 	 */
-	public function test_elements_throws_exception_when_keys_is_not_an_array($person)
+	public function test_elements_when_keys_is_not_an_array($person)
 	{
+		$expected = 'Jack';
 		$output = Arr::elements($person, 'name', 'Unknown');
+		$this->assertEquals($expected, $output);
 	}
 
 	/**

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -555,7 +555,8 @@ class Tests_Arr extends TestCase {
 			'two' => 2,
 			'three' => 3,
 		);
-		$this->assertEquals($expected, Arr::prepend($arr, 'one', 1));
+		$output = Arr::prepend($arr, 'one', 1);
+		$this->assertEquals($expected, $output);
 	}
 	
 	/**
@@ -574,7 +575,8 @@ class Tests_Arr extends TestCase {
 			'two' => 2,
 			'three' => 3,
 		);
-		$this->assertEquals($expected, Arr::prepend($arr, array('one' => 1)));
+		$output = Arr::prepend($arr, array('one' => 1));
+		$this->assertEquals($expected, $output);
 	}
 }
 


### PR DESCRIPTION
# Arr

```
1) Fuel\Core\Tests_Arr::test_element_when_array_is_not_an_array
InvalidArgumentException: First parameter must be an array or ArrayAccess object.
```

Arr::element() **now** expect the first argument to be an array, InvalidArgumentException will be thrown when set otherwise

```
1) Fuel\Core\Tests_Arr::test_elements_throws_exception_when_keys_is_not_an_array with data set #0 (array('Jack', '21', 200, array('Pittsburgh', 'PA', 'US')))
Expected exception InvalidArgumentException
```

Arr:element() **now** accept $keys as either array or string.

```
2) Fuel\Core\Tests_Arr::test_prepend
Failed asserting that <null> is equal to 
Array
(
    [one] => 1
    [two] => 2
    [three] => 3
)
```

Since Arr::prepend just reference the array and not return it, the output return NULL.
# Str

```
5) Fuel\Core\Tests_Str::test_truncate_not_html with data set #0 (15, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-<h1>Lorem ipsum dol...</h1>
+<h1>Lorem ipsum dol...</>

6) Fuel\Core\Tests_Str::test_truncate_is_html with data set #0 (15, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-<h1>Lorem ipsum dol...</h1>
+<h1>Lorem ipsum dol...</>

7) Fuel\Core\Tests_Str::test_truncate_multiple_tags with data set #0 (15, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-<p><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</strong></p>
+<p><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</strong></p></></></></>
```

Problem cause by mb_substr will return '' when $length = null (Reference: http://www.php.net/manual/en/function.mb-substr.php#77515)
