### PR TITLE
Fixed #538:

### DIFF
--- a/classes/controller/template.php
+++ b/classes/controller/template.php
@@ -51,7 +51,14 @@ abstract class Controller_Template extends \Controller {
 		// If the response is a Response object, we don't want to create a new one
 		if ($this->auto_render === true and ! $response instanceof \Response)
 		{
-			$response = \Response::forge($this->template);
+			$status = null; // it should set to 200 when given null
+
+			if ($this->response instanceof \Response)
+			{
+				$status = $this->response->status;
+			}
+
+			$response = \Response::forge($this->template, $status);
 		}
 
 		return parent::after($response);

--- a/classes/controller/template.php
+++ b/classes/controller/template.php
@@ -51,14 +51,8 @@ abstract class Controller_Template extends \Controller {
 		// If the response is a Response object, we don't want to create a new one
 		if ($this->auto_render === true and ! $response instanceof \Response)
 		{
-			$status = null; // it should set to 200 when given null
-
-			if ($this->response instanceof \Response)
-			{
-				$status = $this->response->status;
-			}
-
-			$response = \Response::forge($this->template, $status);
+			$response = $this->response; 
+			$response->body = $this->template;
 		}
 
 		return parent::after($response);

--- a/classes/response.php
+++ b/classes/response.php
@@ -202,7 +202,7 @@ class Response {
 		if ( ! headers_sent())
 		{
 			// Send the protocol/status line first, FCGI servers need different status header
-			if (!empty($_SERVER['FCGI_SERVER_VERSION']))
+			if ( ! empty($_SERVER['FCGI_SERVER_VERSION']))
 			{
 				header('Status: '.$this->status.' '.static::$statuses[$this->status]);
 			}

--- a/classes/response.php
+++ b/classes/response.php
@@ -202,7 +202,7 @@ class Response {
 		if ( ! headers_sent())
 		{
 			// Send the protocol/status line first, FCGI servers need different status header
-			if (empty($_SERVER['FCGI_SERVER_VERSION']))
+			if (!empty($_SERVER['FCGI_SERVER_VERSION']))
 			{
 				header('Status: '.$this->status.' '.static::$statuses[$this->status]);
 			}


### PR DESCRIPTION
- Allow Response Header Status to be set from Controller_Rest since using auto_render, the final response object is only set from after() method.
- Normal web server should return HTTP 1/1 404 File not found and not Status: 404 File not found and vise versa.
