### PR TITLE
Fixed an issue where the get_browser() function would return an object instead

### DIFF
--- a/classes/agent.php
+++ b/classes/agent.php
@@ -33,62 +33,62 @@ class Agent {
 	 * @var  array  information about the current browser
 	 */
 	protected static $properties = array(
-		'Browser'             => 'unknown',
-		'Version'             => 0,
-		'MajorVer'            => 0,
-		'MinorVer'            => 0,
-		'Platform'            => 'unknown',
-		'Alpha'               => false,
-		'Beta'                => false,
-		'Win16'               => false,
-		'Win32'               => false,
-		'Win64'               => false,
-		'Frames'              => false,
-		'IFrames'             => false,
-		'Tables'              => false,
-		'Cookies'             => false,
-		'BackgroundSounds'    => false,
-		'JavaScript'          => false,
-		'VBScript'            => false,
-		'JavaApplets'         => false,
-		'ActiveXControls'     => false,
-		'isBanned'            => false,
-		'isMobile'            => false,
-		'isSyndicationReader' => false,
-		'Crawler'             => false,
-		'CssVersion'          => 0,
-		'AolVersion'          => 0,
+		'browser'             => 'unknown',
+		'version'             => 0,
+		'majorver'            => 0,
+		'minorver'            => 0,
+		'platform'            => 'unknown',
+		'alpha'               => false,
+		'beta'                => false,
+		'win16'               => false,
+		'win32'               => false,
+		'win64'               => false,
+		'frames'              => false,
+		'iframes'             => false,
+		'tables'              => false,
+		'cookies'             => false,
+		'backgroundsounds'    => false,
+		'javascript'          => false,
+		'vbscript'            => false,
+		'javaapplets'         => false,
+		'activexcontrols'     => false,
+		'isbanned'            => false,
+		'ismobile'            => false,
+		'issyndicationreader' => false,
+		'crawler'             => false,
+		'cssversion'          => 0,
+		'aolversion'          => 0,
 	);
 
 	/**
 	 * @var  array  property to cache key mapping
 	 */
 	protected static $keys = array(
-		'Browser'             => 'A',
-		'Version'             => 'B',
-		'MajorVer'            => 'C',
-		'MinorVer'            => 'D',
-		'Platform'            => 'E',
-		'Alpha'               => 'F',
-		'Beta'                => 'G',
-		'Win16'               => 'H',
-		'Win32'               => 'I',
-		'Win64'               => 'J',
-		'Frames'              => 'K',
-		'IFrames'             => 'L',
-		'Tables'              => 'M',
-		'Cookies'             => 'N',
-		'BackgroundSounds'    => 'O',
-		'JavaScript'          => 'P',
-		'VBScript'            => 'Q',
-		'JavaApplets'         => 'R',
-		'ActiveXControls'     => 'S',
-		'isBanned'            => 'T',
-		'isMobile'            => 'U',
-		'isSyndicationReader' => 'V',
-		'Crawler'             => 'W',
-		'CssVersion'          => 'X',
-		'AolVersion'          => 'Y',
+		'browser'             => 'A',
+		'version'             => 'B',
+		'majorver'            => 'C',
+		'minorver'            => 'D',
+		'platform'            => 'E',
+		'alpha'               => 'F',
+		'beta'                => 'G',
+		'win16'               => 'H',
+		'win32'               => 'I',
+		'win64'               => 'J',
+		'frames'              => 'K',
+		'iframes'             => 'L',
+		'tables'              => 'M',
+		'cookies'             => 'N',
+		'backgroundsounds'    => 'O',
+		'javascript'          => 'P',
+		'vbscript'            => 'Q',
+		'javaapplets'         => 'R',
+		'activexcontrols'     => 'S',
+		'isbanned'            => 'T',
+		'ismobile'            => 'U',
+		'issyndicationreader' => 'V',
+		'crawler'             => 'W',
+		'cssversion'          => 'X',
+		'aolversion'          => 'Y',
 	);
 
 	/**
@@ -194,7 +194,7 @@ class Agent {
 		if (false === $browser = static::get_from_cache())
 		{
 			// if not, try the build in get_browser() method
-			if (ini_get('browscap') == '' or false === $browser = get_browser())
+			if (ini_get('browscap') == '' or false === $browser = get_browser(null, true))
 			{
 				// if all else fails, emulate get_browser()
 				$browser = static::get_from_browscap();
@@ -204,7 +204,7 @@ class Agent {
 		if ($browser)
 		{
 			// save it for future reference
-			static::$properties = $browser;
+			static::$properties = array_change_key_case($browser);
 
 			// store the result in local cache
 			static::add_to_cache();
@@ -220,7 +220,7 @@ class Agent {
 	 */
 	public static function browser()
 	{
-		return static::$properties['Browser'];
+		return static::$properties['browser'];
 	}
 
 	// --------------------------------------------------------------------
@@ -232,7 +232,7 @@ class Agent {
 	 */
 	public static function platform()
 	{
-		return static::$properties['Platform'];
+		return static::$properties['platform'];
 	}
 
 	// --------------------------------------------------------------------
@@ -244,7 +244,7 @@ class Agent {
 	 */
 	public static function version()
 	{
-		return static::$properties['Version'];
+		return static::$properties['version'];
 	}
 
 	// --------------------------------------------------------------------
@@ -256,6 +256,7 @@ class Agent {
 	 */
 	public static function property($property = null)
 	{
+		$property = strtolower($property);
 		return array_key_exists($property, static::$properties) ? static::$properties[$property] : null;
 	}
 
@@ -280,7 +281,7 @@ class Agent {
 	 */
 	public static function is_robot()
 	{
-		return static::$properties['Crawler'];
+		return static::$properties['crawler'];
 	}
 
 	// --------------------------------------------------------------------
@@ -292,7 +293,7 @@ class Agent {
 	 */
 	public static function is_mobile()
 	{
-		return static::$properties['isMobile'];
+		return static::$properties['ismobile'];
 	}
 
 	// --------------------------------------------------------------------
@@ -433,7 +434,7 @@ class Agent {
 			if (preg_match($pattern, static::$user_agent))
 			{
 				// store the browser name
-				$properties['Browser'] = $browser;
+				$properties['browser'] = $browser;
 
 				// fetch possible parent info
 				if (array_key_exists('Parent', $properties))
@@ -445,7 +446,7 @@ class Agent {
 						$properties = array_merge(current($parent), $properties);
 
 						// store the browser name
-						$properties['Browser'] = key($parent);
+						$properties['browser'] = key($parent);
 					}
 				}
 


### PR DESCRIPTION
Fixed an issue where the get_browser() function would return an object instead of an array. The array keys are now lower-cased as the returned array may return an array with lower-cased keys.

Quoting the PHP.net docs:
"The information is returned in an object or an array which will contain various data elements representing, for instance, the browser's major and minor version numbers and ID string; TRUE/FALSE values for features such as frames, JavaScript, and cookies; and so forth."

This issue popped up in Windows7 64bit using xampp1.7.3
