### PR TITLE
Nasty exception fix

### DIFF
--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -91,7 +91,7 @@ abstract class Config_File implements Config_Interface
 			return array_reverse($paths);
 		}
 
-		throw new \FuelException(sprintf('File "%s" does not exist.', $this->file));
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
The config class was throwing fatal exceptions when a config file didn't exist. Core classes were requiring config files that simply don't exist in the core config file (to give you the chance to extending it).

Though this rings bells about why classes are dealing with config themselves (eg the Cookie) class - it should be letting the Config structure deal with overriding things..

Anywho, this just returns an array instead of throwing an exception.
