### PR TITLE
Added create_index and drop_index functions to DBUtil class

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -305,6 +305,55 @@ class DBUtil {
 		}
 		return false;
 	}
+	
+	/**
+	 * Creates an index on that table.
+	 * 
+	 * @access	public
+	 * @static
+	 * @param	string	$table
+	 * @param	string	$index_name
+	 * @param	string	$index (should be 'unique' or 'fulltext')
+	 * @return	bool
+	 * @author	Thomas Edwards
+	 */
+	public static function create_index($table, $index_name, $index = '')
+	{
+		$sql = 'CREATE ';
+		
+		$accepted_index = array('unique', 'fulltext');
+		
+		if ($index !== '')
+		{
+			$sql .= (in_array($index, $accepted_index)) ? strtoupper($index).' ' : '';
+		}
+		
+		$sql .= 'INDEX ';
+		$sql .= DB::quote_identifier($index_name);
+		$sql .= ' ON ';
+		$sql .= DB::quote_identifier(DB::table_prefix($table));
+		$sql .= ' ('.DB::quote_identifier($index_name).')';
+		
+		return \DB::query($sql, \DB::UPDATE)->execute();
+	}
+	
+	/**
+	 * Drop an index from a table.
+	 * 
+	 * @access	public
+	 * @static
+	 * @param	string $table
+	 * @param	string $index_name
+	 * @return	bool
+	 * @author	Thomas Edwards
+	 */
+	public static function drop_index($table, $index_name)
+	{
+		$sql = 'DROP INDEX '.DB::quote_identifier($index_name);
+		$sql .= ' ON '.DB::quote_identifier(DB::table_prefix($table));
+		
+		return \DB::query($sql, \DB::UPDATE)->execute();
+	}
 
 	/*
 	 * Load the db config, the Database_Connection might not have fired jet.


### PR DESCRIPTION
I couldn’t find this anywhere and it’s often something you add as the project grows, so it’s probably better off being completely separate to `create_table()`.

Added two functions:

```
create_index($table, $field, [ $type ] )
```

`$type` might be `unique` or `fulltext`.

```
drop_index($table, $field)
```

Pretty self explanatory.

It gives the index name the same name as the field.
