### PR TITLE
\DB::count_last_query() should be static, allows to use \DB::count_last_query()

### DIFF
--- a/classes/db.php
+++ b/classes/db.php
@@ -303,7 +303,7 @@ class DB {
 	 * @param   string  db connection
 	 * @return  integer
 	 */
-	public function count_last_query($db = null)
+	public static function count_last_query($db = null)
 	{
 		return \Database_Connection::instance($db)->count_last_query();
 	}


### PR DESCRIPTION
As per comment https://github.com/fuel/core/commit/fcd27c1724c1d08e0df293f90ad4a7b7fdd2201d#commitcomment-640297
