### PR TITLE
Fix&Test to Format::_from_xml() and Better suport to customize links in Pagination class

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -314,7 +314,17 @@ class Format {
 	 */
 	protected function _from_xml($string)
 	{
-		return $string ? (array) simplexml_load_string($string, 'SimpleXMLElement', LIBXML_NOCDATA) : array();
+		$_arr = is_string($string) ? simplexml_load_string($string, 'SimpleXMLElement', LIBXML_NOCDATA) : $string;
+		$arr = array();
+		
+		// Convert all objects SimpleXMLElement to array recursively
+		foreach ((array)$_arr as $key => $val)
+		{
+			$val = (is_array($val) or is_object($val)) ? $this->_from_xml($val) : $val;
+			$arr[$key] = $val;
+		}
+		
+		return $arr;
 	}
 
 	/**

--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -51,6 +51,8 @@ class Pagination {
 		'next_mark'      => ' &raquo;',
 		'active_start'   => '<span class="active"> ',
 		'active_end'     => ' </span>',
+		'inactive_start'   => '<span class="inactive"> ',
+		'inactive_end'     => ' </span>',
 	);
 
 	/**
@@ -226,7 +228,7 @@ class Pagination {
 
 		if (static::$current_page == static::$total_pages)
 		{
-			return $value.static::$template['next_mark'];
+			return static::$template['inactive_start'].$value.static::$template['next_mark'].static::$template['inactive_end'];
 		}
 		else
 		{
@@ -253,7 +255,7 @@ class Pagination {
 
 		if (static::$current_page == 1)
 		{
-			return static::$template['previous_mark'].$value;
+			return static::$template['inactive_start'].static::$template['previous_mark'].$value.static::$template['inactive_end'];
 		}
 		else
 		{

--- a/tests/format.php
+++ b/tests/format.php
@@ -58,4 +58,96 @@ line 2","Value 3"',
 	{
 		$this->assertEquals($csv, Format::forge($array)->to_csv());
 	}
+	
+	/**
+	 * Test for Format::forge($foo)->_from_xml()
+	 *
+	 * @test
+	 */
+	public function test__from_xml()
+	{
+		$xml = '<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" stopOnFailure="false" bootstrap="bootstrap_phpunit.php">
+	<php>
+		<server name="doc_root" value="../../"/>
+		<server name="app_path" value="fuel/app"/>
+		<server name="core_path" value="fuel/core"/>
+		<server name="package_path" value="fuel/packages"/>
+	</php>
+	<testsuites>
+		<testsuite name="core">
+			<directory suffix=".php">../core/tests</directory>
+		</testsuite>
+		<testsuite name="packages">
+			<directory suffix=".php">../packages/*/tests</directory>
+		</testsuite>
+		<testsuite name="app">
+			<directory suffix=".php">../app/tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>';
+		
+		$expected = array (
+			'@attributes' => array (
+				'colors' => 'true',
+				'stopOnFailure' => 'false',
+				'bootstrap' => 'bootstrap_phpunit.php',
+			),
+			'php' => array (
+				'server' => array (
+					0 => array (
+						'@attributes' => array (
+							'name' => 'doc_root',
+							'value' => '../../',
+						),
+					),
+					1 => array (
+						'@attributes' => array (
+							'name' => 'app_path',
+							'value' => 'fuel/app',
+						),
+					),
+					2 => array (
+						'@attributes' => array (
+							'name' => 'core_path',
+							'value' => 'fuel/core',
+						),
+					),
+					3 => array (
+						'@attributes' => array (
+							'name' => 'package_path',
+							'value' => 'fuel/packages',
+						),
+					),
+				),
+			),
+			'testsuites' => array (
+				'testsuite' => array (
+					0 => array (
+						'@attributes' => array (
+							'name' => 'core',
+						),
+						'directory' => '../core/tests',
+					),
+					1 => array (
+						'@attributes' =>
+						array (
+							'name' => 'packages',
+						),
+						'directory' => '../packages/*/tests',
+					),
+					2 => array (
+						'@attributes' =>
+						array (
+							'name' => 'app',
+						),
+						'directory' => '../app/tests',
+					),
+				),
+			),
+		);
+		
+		$this->assertEquals(Format::forge($expected)->to_php(), Format::forge($xml, 'xml')->to_php());
+	}
 }


### PR DESCRIPTION
Well, I'm still newbie in git, so forgive-me if I'm doing something wrong.

I made some fixes on my last pull request, but I screw everything up with a bunch of unwanted commits. Now I'm doing as requested by @philsturgeon.

The first is a real fix to issue #432. The actual function Format::_from_xml() convert the XML and its children as SimpleXMLElement objects, instead arrays (as expected).

In my test, I use to_php() to show you clearly that it's really unexpected.

And the commit b41b62f90a5a9fceaf80fe719557d21461d577b2 adds a better support to customize the unclickable links << Previous and Next>> when they're inactive(when you're in first or last page), so we can set a custom CSS class on them.

Thanks.
