### PR TITLE
Fixed missing "type" attr in attributes array ( $fs->field(...)->get_attr

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -98,6 +98,10 @@ class Fieldset_Field
 				unset($attributes[$prop]);
 			}
 		}
+
+		// Add default "type" attribute if not specified
+		if (empty($attributes['type'])) $this->set_type($this->type);
+
 		$this->attributes = array_merge($this->attributes, $attributes);
 
 		// only when non-empty, will overwrite what was given in $name


### PR DESCRIPTION
Fixed missing "type" attr in attributes array ( $fs->field(...)->get_attribute() ) if not manually specified
