### PR TITLE
Migrations - added Module and Package Support

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -313,7 +313,7 @@ class DBUtil
 
 		try
 		{
-			\DB::select()->select_array($columns)->from($table)->limit(1)->execute();
+			\DB::select_array($columns)->from($table)->limit(1)->execute();
 			return true;
 		}
 		catch (\Database_Exception $e)

--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -136,7 +136,7 @@ class DBUtil
 	protected static function alter_fields($type, $table, $fields)
 	{
 		$sql = 'ALTER TABLE '.\DB::quote_identifier(\DB::table_prefix($table)).' ';
-		
+
 		if ($type === 'DROP')
 		{
 			if ( ! is_array($fields))
@@ -156,7 +156,7 @@ class DBUtil
 			$sql .= static::process_fields($fields);
 			$use_brackets and $sql .= ')';
 		}
-		
+
 		return \DB::query($sql, \DB::UPDATE)->execute();
 	}
 
@@ -276,6 +276,50 @@ class DBUtil
 	public static function repair_table($table)
 	{
 		return static::table_maintenance('REPAIR TABLE', $table);
+	}
+
+	/**
+	 * Checks if a given table exists.
+	 *
+	 * @param   string  $table  Table name
+	 * @return  bool
+	 */
+	public static function table_exists($table)
+	{
+		try
+		{
+			\DB::select()->from($table)->limit(1)->execute();
+			return true;
+		}
+		catch (\Database_Exception $e)
+		{
+			return false;
+		}
+	}
+
+	/**
+	 * Checks if given field(s) in a given table exists.
+	 *
+	 * @param   string         $table    Table name
+	 * @param   string|array   $columns  columns to check
+	 * @return  bool
+	 */
+	public static function field_exists($table, $columns)
+	{
+		if ( ! is_array($columns))
+		{
+			$columns = array($columns);
+		}
+
+		try
+		{
+			\DB::select()->select_array($columns)->from($table)->limit(1)->execute();
+			return true;
+		}
+		catch (\Database_Exception $e)
+		{
+			return false;
+		}
 	}
 
 	/*

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -111,9 +111,9 @@ class Migrate
 	 * @access	public
 	 * @return	mixed	true if already current, false if failed, int if upgraded
 	 */
-	public static function current()
+	public static function current($name, $type)
 	{
-		return static::version(\Config::get('migrations.version'));
+		return static::version(\Config::get('migrations.version.'.$type.'.'.$name), $name, $type);
 	}
 
 	// --------------------------------------------------------------------

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -42,15 +42,13 @@ class Migrate
 			'version' => array('type' => 'int', 'constraint' => 11, 'null' => false, 'default' => 0),
 		));
 
-		//get all versions
-
-		// Check if there is a version
+		//get all versions from db
 		$migrations = \DB::select()
 			->from(static::$table)
 			->execute()
 			->as_array();
 
-		foreach($migrations as $migration)
+		foreach ($migrations as $migration)
 		{
 			static::$version[$migration['type']][$migration['name']] = (int) $migration['version'];
 		}
@@ -163,7 +161,6 @@ class Migrate
 			{
 				$f = static::_get_default($i);
 			}
-			//$f = glob(APPPATH . \Config::get('migrations.folder') . str_pad($i, 3, '0', STR_PAD_LEFT) . "_*.php");
 
 			// Only one migration per step is permitted
 			if (count($f) > 1)

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -22,7 +22,7 @@ namespace Fuel\Core;
  */
 class Migrate
 {
-	public static $version = 0;
+	public static $version = array();
 
 	protected static $prefix = '\\Fuel\Migrations\\';
 
@@ -37,22 +37,47 @@ class Migrate
 		static::$table = \Config::get('migrations.table', static::$table);
 
 		\DBUtil::create_table(static::$table, array(
-			'current' => array('type' => 'int', 'constraint' => 11, 'null' => false, 'default' => 0)
+			'name' => array('type' => 'varchar', 'constraint' => 50),
+			'type' => array('type' => 'varchar', 'constraint' => 25),
+			'version' => array('type' => 'int', 'constraint' => 11, 'null' => false, 'default' => 0),
 		));
 
-		// Check if there is a version
-		$current = \DB::select('current')->from(static::$table)->execute()->get('current');
+		//get all versions
 
+		// Check if there is a version
+		$migrations = \DB::select()
+			->from(static::$table)
+			->execute()
+			->as_array();
+
+		foreach($migrations as $migration)
+		{
+			if($migration['type'])
+			{
+				static::$version[$migration['type']][$migration['name']] = (int) $migration['version'];
+			}
+			else
+			{
+				static::$version[$migration['name']] = (int) $migration['version'];
+			}
+		}
+/*
 		// Not set, so we are on 0
 		if ($current === null)
 		{
-			\DB::insert(static::$table)->set(array('current' => '0'))->execute();
+			\DB::insert(static::$table)
+				->set(array(
+					'name' => 'default',
+					'version' => '0'
+				))
+				->execute();
 		}
 
 		else
 		{
 			static::$version = (int) $current;
 		}
+*/
 	}
 
 	/**
@@ -61,9 +86,9 @@ class Migrate
 	 * @access	public
 	 * @return	mixed	true if already latest, false if failed, int if upgraded
 	 */
-	public static function latest()
+	public static function latest($name = null, $type = null)
 	{
-		if ( ! $migrations = static::find_migrations())
+		if ( ! $migrations = static::find_migrations($name, $type))
 		{
 			throw new FuelException('no_migrations_found');
 			return false;
@@ -74,7 +99,8 @@ class Migrate
 		// Calculate the last migration step from existing migration
 		// filenames and procceed to the standard version migration
 		$last_version = intval(substr($last_migration, 0, 3));
-		return static::version($last_version);
+
+		return static::version($last_version, $name, $type);
 	}
 
 	// --------------------------------------------------------------------
@@ -102,17 +128,43 @@ class Migrate
 	 * @param $version integer	Target schema version
 	 * @return	mixed	true if already latest, false if failed, int if upgraded
 	 */
-	public static function version($version)
+	public static function version($version, $name, $type = null)
 	{
-		if (static::$version === $version)
+		if ($type)
 		{
-			return false;
+			if ( ! isset(static::$version[$type][$name]))
+			{
+				\DB::insert(static::$table)
+				->set(array(
+					'name' => $name,
+					'type' => $type,
+					'version' => '0'
+				))
+				->execute();
+				static::$version[$type][$name] = 0;
+			}
+
+			if (static::$version[$type][$name] === $version)
+			{
+				return false;
+			}
+
+			$current_version = static::$version[$type][$name];
+		}
+		else
+		{
+			if (static::$version[$name] === $version)
+			{
+				return false;
+			}
+
+			$current_version = static::$version[$name];
 		}
 
-		$start = static::$version;
+		$start = $current_version;
 		$stop = $version;
 
-		if ($version > static::$version)
+		if ($version > $current_version)
 		{
 			// Moving Up
 			++$start;
@@ -133,7 +185,16 @@ class Migrate
 		// But first let's make sure that everything is the way it should be
 		for ($i = $start; $i != $stop; $i += $step)
 		{
-			$f = glob(\Config::get('migrations.path') . str_pad($i, 3, '0', STR_PAD_LEFT) . "_*.php");
+			if ($type)
+			{
+				$get_method = '_find_'.$type;
+				$f = static::$get_method($name, $i);
+			}
+			else
+			{
+				$f = static::_get_default($i);
+			}
+			//$f = glob(APPPATH . \Config::get('migrations.folder') . str_pad($i, 3, '0', STR_PAD_LEFT) . "_*.php");
 
 			// Only one migration per step is permitted
 			if (count($f) > 1)
@@ -156,10 +217,10 @@ class Migrate
 			}
 
 			$file = basename($f[0]);
-			$name = basename($f[0], '.php');
+			$file_name = basename($f[0], '.php');
 
 			// Filename validations
-			if (preg_match('/^\d{3}_(\w+)$/', $name, $match))
+			if (preg_match('/^\d{3}_(\w+)$/', $file_name, $match))
 			{
 				$match[1] = strtolower($match[1]);
 
@@ -210,13 +271,23 @@ class Migrate
 			$class = static::$prefix . ucfirst($migration);
 			call_user_func(array(new $class, $method));
 
-			static::$version += $step;
-			static::_update_schema_version(static::$version - $step, static::$version);
+			$current_version += $step;
+
+			static::_update_schema_version($current_version - $step, $current_version, $name, $type);
 		}
 
 		logger(Fuel::L_INFO, 'Migrated to ' . static::$version.' successfully.');
 
-		return static::$version;
+		if ($type)
+		{
+			static::$version[$type][$name] = $current_version;
+		}
+		else
+		{
+			static::$version[$name] = $current_version;
+		}
+
+		return $current_version;
 	}
 
 	// --------------------------------------------------------------------
@@ -228,10 +299,18 @@ class Migrate
 	 * @return	mixed	true if already latest, false if failed, int if upgraded
 	 */
 
-	protected static function find_migrations()
+	protected static function find_migrations($name = '', $type = '')
 	{
 		// Load all *_*.php files in the migrations path
-		$files = glob(\Config::get('migrations.path') . '*_*.php');
+		if ($type)
+		{
+			$method = '_find_'.$type;
+			$files = static::$method($name);
+		}
+		else
+		{
+			$files = static::_find_default();
+		}
 		$file_count = count($files);
 
 		for ($i = 0; $i < $file_count; $i++)
@@ -243,8 +322,6 @@ class Migrate
 				$files[$i] = false;
 			}
 		}
-
-		sort($files);
 
 		return $files;
 	}
@@ -258,9 +335,95 @@ class Migrate
 	 * @param $schema_version integer	Schema version reached
 	 * @return	void					Outputs a report of the migration
 	 */
-	private static function _update_schema_version($old_version, $version)
+	private static function _update_schema_version($old_version, $version, $name, $type = '')
 	{
-		\DB::update(static::$table)->set(array('current' => (int) $version))->where('current', '=', (int) $old_version)->execute();
+		\DB::update(static::$table)
+			->set(array(
+				'version' => (int) $version
+			))
+			->where('version', (int) $old_version)
+			->where('name', $name)
+			->where('type', $type)
+			->execute();
+	}
+
+	private static function _find_default($file = null)
+	{
+		if ($file)
+		{
+			if ( ! isset($name))
+			{
+				throw new FuelException('Name must be set to find a specific file');
+				return false;
+			}
+
+			return glob(APPPATH . \Config::get('migrations.folder') . str_pad($file, 3, '0', STR_PAD_LEFT) . "_*.php");;
+		}
+
+		return glob(APPPATH . \Config::get('migrations.folder') . '*_*.php');
+	}
+
+	private static function _find_module($name = null, $file = null)
+	{
+		if ($file)
+		{
+			if ( ! isset($name))
+			{
+				throw new FuelException('Name must be set to find a specific file');
+				return false;
+			}
+
+			foreach (\Config::get('module_paths') as $m)
+			{
+				return glob($m .$name.'/'. \Config::get('migrations.folder') . str_pad($file, 3, '0', STR_PAD_LEFT) . "_*.php");
+			}
+		}
+
+		if ($name)
+		{
+			// find a module
+			foreach (\Config::get('module_paths') as $m)
+			{
+				$files = glob($m .$name.'/'. \Config::get('migrations.folder') . '*_*.php');
+			}
+		}
+		else
+		{
+			// find all modules
+			foreach (\Config::get('module_paths') as $m)
+			{
+				$files = glob($m .'*/'. \Config::get('migrations.folder') . '*_*.php');
+			}
+		}
+
+		return $files;
+	}
+
+	private static function _find_package($name = null, $file = null)
+	{
+		if ($file)
+		{
+			if ( ! isset($name))
+			{
+				throw new FuelException('Name must be set to find a specific file');
+				return false;
+			}
+
+			return glob(PKGPATH .$name.'/'. \Config::get('migrations.folder') . str_pad($file, 3, '0', STR_PAD_LEFT) . "_*.php");;
+		}
+
+		if ($name)
+		{
+			// find a package
+			$files = glob(PKGPATH .$name.'/'. \Config::get('migrations.folder') . '*_*.php');
+		}
+		else
+		{
+			// find all modules
+			$files = glob(PKGPATH .'*/'. \Config::get('migrations.folder') . '*_*.php');
+		}
+
+		return $files;
 	}
 }
 

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -52,32 +52,8 @@ class Migrate
 
 		foreach($migrations as $migration)
 		{
-			if($migration['type'])
-			{
-				static::$version[$migration['type']][$migration['name']] = (int) $migration['version'];
-			}
-			else
-			{
-				static::$version['app'][$migration['name']] = (int) $migration['version'];
-			}
+			static::$version[$migration['type']][$migration['name']] = (int) $migration['version'];
 		}
-/*
-		// Not set, so we are on 0
-		if ($current === null)
-		{
-			\DB::insert(static::$table)
-				->set(array(
-					'name' => 'default',
-					'version' => '0'
-				))
-				->execute();
-		}
-
-		else
-		{
-			static::$version = (int) $current;
-		}
-*/
 	}
 
 	/**
@@ -86,7 +62,7 @@ class Migrate
 	 * @access	public
 	 * @return	mixed	true if already latest, false if failed, int if upgraded
 	 */
-	public static function latest($name = null, $type = 'a[[')
+	public static function latest($name, $type)
 	{
 		if ( ! $migrations = static::find_migrations($name, $type))
 		{
@@ -128,28 +104,35 @@ class Migrate
 	 * @param $version integer	Target schema version
 	 * @return	mixed	true if already latest, false if failed, int if upgraded
 	 */
-	public static function version($version, $name, $type = 'app')
+	public static function version($version, $name, $type)
 	{
+		// if version isn't set
 		if ( ! isset(static::$version[$type][$name]))
 		{
+			// insert into db
 			\DB::insert(static::$table)
 			->set(array(
 				'name' => $name,
 				'type' => $type,
-				'version' => '0'
+				'version' => 0,
 			))
 			->execute();
+
+			// set verstion to 0
 			static::$version[$type][$name] = 0;
 		}
 
+		// return false if current version equals requested version
 		if (static::$version[$type][$name] === $version)
 		{
 			return false;
 		}
 
+		// set vars for loop
 		$start = static::$version[$type][$name];
 		$stop = $version;
 
+		// modify loop vars and add step
 		if ($version > static::$version[$type][$name])
 		{
 			// Moving Up

--- a/config/migrations.php
+++ b/config/migrations.php
@@ -38,7 +38,7 @@ return array(
 	/*
 	| Folder name where migrations are stored relative to App, Module and Package Paths?
 	|
-	|	Default: APPPATH.'migrations/'
+	|	Default: 'migrations/'
 	|
 	*/
 	'folder' => 'migrations/',

--- a/config/migrations.php
+++ b/config/migrations.php
@@ -27,15 +27,19 @@ return array(
 	|	Default: 0
 	|
 	*/
-	'version' => 0,
+	'version' => array(
+		'default' => 0,
+		'module' => array(),
+		'packages' => array()
+	),
 
 	/*
-	| Where are these migrations stored?
+	| Folder name where migrations are stored relative to App, Module and Package Paths?
 	|
 	|	Default: APPPATH.'migrations/'
 	|
 	*/
-	'path' => APPPATH.'migrations/',
+	'folder' => 'migrations/',
 
 	/*
 	| Table name
@@ -46,5 +50,4 @@ return array(
 	'table' => 'migration',
 
 );
-
 

--- a/config/migrations.php
+++ b/config/migrations.php
@@ -28,9 +28,11 @@ return array(
 	|
 	*/
 	'version' => array(
-		'default' => 0,
+		'app' => array(
+			'default' => 0,
+		),
 		'module' => array(),
-		'packages' => array()
+		'package' => array()
 	),
 
 	/*

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -26,10 +26,122 @@ namespace Fuel\Tasks;
 class Migrate
 {
 
+	protected static $default = true;
+	protected static $modules = array();
+	protected static $packages = array();
+	protected static $module_count = 0;
+	protected static $package_count = 0;
+
+	public function __construct()
+	{
+		//load config
+		\Config::load('migrations', true);
+
+		$modules = \Cli::option('modules');
+		$packages = \Cli::option('packages');
+		$default = \Cli::option('default');
+
+		// if modules option set
+		if (!empty($modules))
+		{
+			// if true - get all modules
+			if ($modules === true)
+			{
+				// loop through module paths
+				foreach (\Config::get('module_paths') as $path)
+				{
+					// get all modules that have files in the migration folder
+					foreach (glob($path . '*/') as $m)
+					{
+						if (count(glob($m.\Config::get('migrations.folder').'/*.php')))
+						{
+							static::$modules[] = basename($m);
+						}
+					}
+				}
+			}
+			// else do selected modules
+			else
+			{
+				static::$modules = explode(',', $modules);
+			}
+		}
+
+		// if packages option set
+		if (!empty($packages))
+		{
+			// if true - get all packages
+			if ($packages === true)
+			{
+				// get all packages that have files in the migration folder
+				foreach (glob(PKGPATH . '*/') as $p)
+				{
+					if (count(glob($p.\Config::get('migrations.folder').'/*.php')))
+					{
+						static::$packages[] = basename($p);
+					}
+				}
+			}
+			// else do selected packages
+			else
+			{
+				static::$packages = explode(',', $packages);
+			}
+		}
+
+		if ( (!empty($packages) or !empty($modules)) and empty($default))
+		{
+			static::$default = false;
+		}
+
+		// set count
+		static::$module_count = count(static::$modules);
+		static::$package_count = count(static::$packages);
+	}
+
 	public static function run()
 	{
-		\Config::load('migrations', true);
-		$current_version = \Config::get('migrations.version');
+		// run default migrations if default is true
+		if (static::$default)
+		{
+			static::_run('default');
+		}
+
+		// run modules if passed
+		if (count(static::$modules))
+		{
+			foreach (static::$modules as $module)
+			{
+				static::_run($module, 'module');
+			}
+		}
+
+		//run packages if passed
+		if (count(static::$packages))
+		{
+			foreach (static::$packages as $package)
+			{
+				static::_run($package, 'package');
+			}
+		}
+
+	}
+
+	private static function _run($name, $type = null)
+	{
+		if ($type)
+		{
+			$current_version = \Config::get('migrations.version.'.$type.'.'.$name);
+		}
+		else
+		{
+			$current_version = \Config::get('migrations.version.'.$name);
+		}
+
+		if ( ! $current_version)
+		{
+			$current_version = 0;
+		}
 
 		// -v or --version
 		$version = \Cli::option('v', \Cli::option('version'));
@@ -38,6 +150,13 @@ class Migrate
 		if ($version === true)
 		{
 			\Cli::write('Currently on migration: ' . $current_version .'.', 'green');
+			return;
+		}
+
+		// If version has a value, make sure only 1 item was passed
+		else if ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
+		{
+			throw new \Oil\Exception('Migration: version only excepts 1 item.');
 			return;
 		}
 
@@ -53,14 +172,14 @@ class Migrate
 		// Specific version
 		if (is_numeric($version) and $version >= 0)
 		{
-			if (\Migrate::version($version) === false)
+			if (\Migrate::version($version, $name, $type) === false)
 			{
 				throw new \Oil\Exception('Migration ' . $version .' could not be found.');
 			}
 
 			else
 			{
-				static::_update_version($version);
+				static::_update_version($version, 'default');
 				\Cli::write('Migrated to version: ' . $version .'.', 'green');
 			}
 		}
@@ -68,14 +187,14 @@ class Migrate
 		// Just go to the latest
 		else
 		{
-			if (($result = \Migrate::latest()) === false)
+			if (($result = \Migrate::latest($name, $type)) === false)
 			{
 				throw new \Oil\Exception("Could not migrate to latest version, still using {$current_version}.");
 			}
 
 			else
 			{
-				static::_update_version($result);
+				static::_update_version($result, 'default');
 				\Cli::write('Migrated to latest version: ' . $result .'.', 'green');
 			}
 		}
@@ -84,12 +203,11 @@ class Migrate
 
 	public static function up()
 	{
-		\Config::load('migrations', true);
-		$version = \Config::get('migrations.version') + 1;
+		$version = \Config::get('migrations.version.default') + 1;
 
 		if ($foo = \Migrate::version($version))
 		{
-			static::_update_version($version);
+			static::_update_version($version, 'default');
 			\Cli::write('Migrated to version: ' . $version .'.', 'green');
 		}
 		else
@@ -100,16 +218,14 @@ class Migrate
 
 	public static function down()
 	{
-		\Config::load('migrations', true);
-
-		if (($version = \Config::get('migrations.version') - 1) < 0)
+		if (($version = \Config::get('migrations.version.default') - 1) < 0)
 		{
 			throw new \Oil\Exception('You are already on the first migration.');
 		}
 
 		if (\Migrate::version($version) !== false)
 		{
-			static::_update_version($version);
+			static::_update_version($version, 'default');
 			\Cli::write("Migrated to version: {$version}.", 'green');
 		}
 		else
@@ -118,6 +234,40 @@ class Migrate
 		}
 	}
 
+	private static function _update_version($version, $name, $type = null)
+	{
+		// if migrations config doesn't exist in app/config
+		if ( ! file_exists($path = APPPATH.'config'.DS.'migrations.php'))
+		{
+			// make sure it exists in core/config and copy to app/config
+			if (file_exists($core_path = COREPATH.'config'.DS.'migrations.php'))
+			{
+				$contents = file_get_contents($core_path);
+			}
+			else
+			{
+				throw new Exception('Config file core/config/migrations.php is missing.');
+				exit;
+			}
+
+			file_put_contents($path, $contents);
+		}
+
+		// set config version
+		if ($type)
+		{
+			\Config::set('migrations.version.'.$type.'.'.$name, $version);
+		}
+		else
+		{
+			\Config::set('migrations.version.'.$name, $version);
+		}
+
+		\Config::save('migrations', 'migrations');
+
+	}
+
+/*
 	private static function _update_version($version)
 	{
 		if (file_exists($path = APPPATH.'config'.DS.'migrations.php'))
@@ -134,11 +284,11 @@ class Migrate
 			exit;
 		}
 
-		$contents = preg_replace("#('version'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
+		$contents = preg_replace("#('default'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
 
 		file_put_contents($path, $contents);
 	}
-
+*/
 	public static function current()
 	{
 		\Migrate::current();
@@ -153,6 +303,13 @@ Usage:
 Fuel options:
     -v, [--version]  # Migrate to a specific version
 
+    # The following disable default migrations unless you add --default to the command
+    --default # re-enables default migration
+    --modules # Migrates all modules
+    --modules=item1,item2 # Migrates specific modules
+    --packages # Migrates all packages
+    --packages=item1,item2 # Migrates specific modules
+
 Description:
     The migrate task can run migrations. You can go up, down or by default go to the current migration marked in the config file.
 
@@ -166,5 +323,6 @@ Examples:
 HELP;
 
 	}
+
 }
 

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -37,7 +37,7 @@ class Migrate {
 	 */
 	public function __construct()
 	{
-		//load config
+		// load config
 		\Config::load('migrations', true);
 
 		// get Cli options
@@ -46,7 +46,7 @@ class Migrate {
 		$default = \Cli::option('default');
 
 		// if modules option set
-		if (!empty($modules))
+		if ( ! empty($modules))
 		{
 			// if true - get all modules
 			if ($modules === true)
@@ -72,7 +72,7 @@ class Migrate {
 		}
 
 		// if packages option set
-		if (!empty($packages))
+		if ( ! empty($packages))
 		{
 			// if true - get all packages
 			if ($packages === true)
@@ -93,7 +93,7 @@ class Migrate {
 			}
 		}
 
-		if ( (!empty($packages) or !empty($modules)) and empty($default))
+		if ( ( ! empty($packages) or !empty($modules)) and empty($default))
 		{
 			static::$default = false;
 		}
@@ -151,21 +151,21 @@ class Migrate {
 		// version is used as a flag, so show it
 		if ($version === true)
 		{
-			\Cli::write('Currently on migration: ' . $current_version .' for '.$type.':'.$name.'.', 'green');
+			\Cli::write('Currently on migration: '.$current_version.' for '.$type.':'.$name.'.', 'green');
 			return;
 		}
 
 		// If version has a value, make sure only 1 item was passed
-		else if ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
+		elseif ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
 		{
 			\Cli::write('Migration: version only excepts 1 item.');
 			return;
 		}
 
 		// Not a lot of point in this
-		else if ( ! is_null($version) and $version == $current_version)
+		elseif ( ! is_null($version) and $version == $current_version)
 		{
-			\Cli::write('Migration: ' . $version .' already in use for '.$type.':'.$name.'.');
+			\Cli::write('Migration: '.$version.' already in use for '.$type.':'.$name.'.');
 			return;
 		}
 
@@ -268,7 +268,7 @@ class Migrate {
 		$version = \Migrate::current($name, $type);
 
 		// if version is a number
-		if(is_numeric($version))
+		if (is_numeric($version))
 		{
 			// show what version the item migrated to
 			\Cli::write('Migrated to version: '.$version.' for '.$type.':'.$name.'.');

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -25,17 +25,22 @@ namespace Fuel\Tasks;
 
 class Migrate {
 
+	/* set vars*/
 	protected static $default = true;
 	protected static $modules = array();
 	protected static $packages = array();
 	protected static $module_count = 0;
 	protected static $package_count = 0;
 
+	/**
+	 * Sets vars by grabbing Cli options
+	 */
 	public function __construct()
 	{
 		//load config
 		\Config::load('migrations', true);
 
+		// get Cli options
 		$modules = \Cli::option('modules');
 		$packages = \Cli::option('packages');
 		$default = \Cli::option('default');
@@ -98,44 +103,42 @@ class Migrate {
 		static::$package_count = count(static::$packages);
 	}
 
-	public static function run()
+	/**
+	 * Catches requested method call and runs as needed
+	 */
+	public function __call($name, $args)
 	{
-		// run default migrations if default is true
+		// set method name
+		$name = '_'.$name;
+
+		// run app (default) migrations if default is true
 		if (static::$default)
 		{
-			static::_run('default', 'app');
+			static::$name('default', 'app');
 		}
 
 		// run modules if passed
-		if (count(static::$modules))
+		foreach (static::$modules as $module)
 		{
-			foreach (static::$modules as $module)
-			{
-				static::_run($module, 'module');
-			}
+			static::$name($module, 'module');
 		}
 
 		//run packages if passed
-		if (count(static::$packages))
+		foreach (static::$packages as $package)
 		{
-			foreach (static::$packages as $package)
-			{
-				static::_run($package, 'package');
-			}
+			static::$name($package, 'package');
 		}
-
 	}
 
+	/**
+	 * Migrates to the latest version unless -version is specified
+	 *
+	 * @param string
+	 * @param string
+	 */
 	private static function _run($name, $type)
 	{
-		if ($type)
-		{
-			$current_version = \Config::get('migrations.version.'.$type.'.'.$name);
-		}
-		else
-		{
-			$current_version = \Config::get('migrations.version.'.$name);
-		}
+		$current_version = \Config::get('migrations.version.'.$type.'.'.$name);
 
 		if ( ! $current_version)
 		{
@@ -155,14 +158,14 @@ class Migrate {
 		// If version has a value, make sure only 1 item was passed
 		else if ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
 		{
-			throw new \Oil\Exception('Migration: version only excepts 1 item.');
+			\Cli::write('Migration: version only excepts 1 item.');
 			return;
 		}
 
 		// Not a lot of point in this
 		else if ( ! is_null($version) and $version == $current_version)
 		{
-			throw new \Oil\Exception('Migration: ' . $version .' already in use for '.$type.':'.$name.'.');
+			\Cli::write('Migration: ' . $version .' already in use for '.$type.':'.$name.'.');
 			return;
 		}
 
@@ -173,7 +176,7 @@ class Migrate {
 		{
 			if (\Migrate::version($version, $name, $type) === false)
 			{
-				throw new \Oil\Exception('Migration ' . $version .' could not be found.');
+				\Cli::write('Migration ' . $version .' could not be found for '.$type.':'.$name.'.');
 			}
 
 			else
@@ -200,39 +203,90 @@ class Migrate {
 
 	}
 
-	public static function up()
+	/**
+	 * Migrates item up 1 version
+	 *
+	 * @param string
+	 * @param string
+	 */
+	private static function _up($name, $type)
 	{
-		$version = \Config::get('migrations.version.app.default') + 1;
+		// add 1 to the version #
+		$version = \Config::get('migrations.version.'.$type.'.'.$name) + 1;
 
-		if ($foo = \Migrate::version($version, 'default', 'app'))
+		// if migration successful
+		if ($foo = \Migrate::version($version, $name, $type))
 		{
-			static::_update_version($version, 'default', 'app');
-			\Cli::write('Migrated to version: ' . $version .'.', 'green');
+			// update config and output a notice
+			static::_update_version($version, $name, $type);
+			\Cli::write('Migrated to version: ' . $version .' for '.$type.':'.$name.'.', 'green');
 		}
 		else
 		{
-			\Cli::write('Already on latest migration.');
+			// already on last/highest migration
+			\Cli::write('Already on latest migration for '.$type.':'.$name.'.');
 		}
 	}
 
-	public static function down()
+	/**
+	 * Migrates item down 1 version
+	 *
+	 * @param string
+	 * @param string
+	 */
+	private static function _down($name, $type)
 	{
-		if (($version = \Config::get('migrations.version.default') - 1) < 0)
+		// if version - 1 is less than 0
+		if (($version = \Config::get('migrations.version.'.$type.'.'.$name) - 1) < 0)
 		{
-			throw new \Oil\Exception('You are already on the first migration.');
+			// already on first/lowest migration
+			\Cli::write('You are already on the first migration for '.$type.':'.$name.'.');
+			return;
 		}
 
-		if (\Migrate::version($version) !== false)
+		if (\Migrate::version($version, $name, $type) !== false)
 		{
-			static::_update_version($version, 'default');
-			\Cli::write("Migrated to version: {$version}.", 'green');
+			// update config and output a notice to console
+			static::_update_version($version, $name, $type);
+			\Cli::write('Migrated to version: ' . $version .' for '.$type.':'.$name.'.', 'green');
 		}
 		else
 		{
-			throw new \Oil\Exception("Migration {$version} does not exist. How did you get here?");
+			// migration doesn't exist
+			\Cli::write('Migration '.$version.' does not exist for '.$type.':'.$name.'. How did you get here?');
 		}
 	}
 
+	/**
+	 * Migrates item to current config verision
+	 *
+	 * @param string
+	 * @param string
+	 */
+	private static function _current($name, $type)
+	{
+		$version = \Migrate::current($name, $type);
+
+		// if version is a number
+		if(is_numeric($version))
+		{
+			// show what version the item migrated to
+			\Cli::write('Migrated to version: '.$version.' for '.$type.':'.$name.'.');
+		}
+		else
+		{
+			// migration is already on current version
+			\Cli::write('Already on current migration version for '.$type.':'.$name.'.');
+		}
+	}
+
+	/**
+	 * Updates version in migrations config
+	 *
+	 * @param int
+	 * @param string
+	 * @param string
+	 */
 	private static function _update_version($version, $name, $type)
 	{
 		// if migrations config doesn't exist in app/config
@@ -245,47 +299,24 @@ class Migrate {
 			}
 			else
 			{
-				throw new Exception('Config file core/config/migrations.php is missing.');
+				\Cli::write('Config file core/config/migrations.php is missing.');
 				exit;
 			}
 
+			// create the file in app/config folder
 			file_put_contents($path, $contents);
 		}
 
 		// set config version
 		\Config::set('migrations.version.'.$type.'.'.$name, (int) $version);
 
+		// save the config;
 		\Config::save('migrations', 'migrations');
-
 	}
 
-/*
-	private static function _update_version($version)
-	{
-		if (file_exists($path = APPPATH.'config'.DS.'migrations.php'))
-		{
-			$contents = file_get_contents($path);
-		}
-		elseif (file_exists($core_path = COREPATH.'config'.DS.'migrations.php'))
-		{
-			$contents = file_get_contents($core_path);
-		}
-		else
-		{
-			throw new Exception('Config file core/config/migrations.php is missing.');
-			exit;
-		}
-
-		$contents = preg_replace("#('default'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
-
-		file_put_contents($path, $contents);
-	}
-*/
-	public static function current()
-	{
-		\Migrate::current();
-	}
-
+	/**
+	 * Shows basic help instructions for using migrate in oil
+	 */
 	public static function help()
 	{
 		echo <<<HELP
@@ -293,7 +324,7 @@ Usage:
     php oil refine migrate [--version=X]
 
 Fuel options:
-    -v, [--version]  # Migrate to a specific version
+    -v, [--version]  # Migrate to a specific version ( only 1 item at a time)
 
     # The following disable default migrations unless you add --default to the command
     --default # re-enables default migration
@@ -311,6 +342,9 @@ Examples:
     php oil r migrate:up
     php oil r migrate:down
     php oil r migrate --version=10
+    php oil r migrate --modules --packages --default
+    php oil r migrate:up --modules=module1,module2 --packages=package1
+    php oil r migrate --module=module1 -v=3
 
 HELP;
 

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -38,7 +38,7 @@ class Migrate
 	 */
 	public function __construct()
 	{
-		//load config
+		// load config
 		\Config::load('migrations', true);
 
 		// get Cli options
@@ -47,7 +47,7 @@ class Migrate
 		$default = \Cli::option('default');
 
 		// if modules option set
-		if (!empty($modules))
+		if ( ! empty($modules))
 		{
 			// if true - get all modules
 			if ($modules === true)
@@ -73,7 +73,7 @@ class Migrate
 		}
 
 		// if packages option set
-		if (!empty($packages))
+		if ( ! empty($packages))
 		{
 			// if true - get all packages
 			if ($packages === true)
@@ -94,7 +94,7 @@ class Migrate
 			}
 		}
 
-		if ( (!empty($packages) or !empty($modules)) and empty($default))
+		if ( ( ! empty($packages) or !empty($modules)) and empty($default))
 		{
 			static::$default = false;
 		}
@@ -152,21 +152,21 @@ class Migrate
 		// version is used as a flag, so show it
 		if ($version === true)
 		{
-			\Cli::write('Currently on migration: ' . $current_version .' for '.$type.':'.$name.'.', 'green');
+			\Cli::write('Currently on migration: '.$current_version.' for '.$type.':'.$name.'.', 'green');
 			return;
 		}
 
 		// If version has a value, make sure only 1 item was passed
-		else if ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
+		elseif ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
 		{
 			\Cli::write('Migration: version only excepts 1 item.');
 			return;
 		}
 
 		// Not a lot of point in this
-		else if ( ! is_null($version) and $version == $current_version)
+		elseif ( ! is_null($version) and $version == $current_version)
 		{
-			\Cli::write('Migration: ' . $version .' already in use for '.$type.':'.$name.'.');
+			\Cli::write('Migration: '.$version.' already in use for '.$type.':'.$name.'.');
 			return;
 		}
 
@@ -269,7 +269,7 @@ class Migrate
 		$version = \Migrate::current($name, $type);
 
 		// if version is a number
-		if(is_numeric($version))
+		if (is_numeric($version))
 		{
 			// show what version the item migrated to
 			\Cli::write('Migrated to version: '.$version.' for '.$type.':'.$name.'.');

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -45,6 +45,14 @@ class Migrate
 		$modules = \Cli::option('modules');
 		$packages = \Cli::option('packages');
 		$default = \Cli::option('default');
+		$all = \Cli::option('all');
+
+		if ($all)
+		{
+			$modules = true;
+			$packages = true;
+			$default = true;
+		}
 
 		// if modules option set
 		if ( ! empty($modules))
@@ -333,6 +341,7 @@ Fuel options:
     --modules=item1,item2 # Migrates specific modules
     --packages # Migrates all packages
     --packages=item1,item2 # Migrates specific modules
+    --all # shortcut for --modules --packages --default
 
 Description:
     The migrate task can run migrations. You can go up, down or by default go to the current migration marked in the config file.
@@ -346,6 +355,7 @@ Examples:
     php oil r migrate --modules --packages --default
     php oil r migrate:up --modules=module1,module2 --packages=package1
     php oil r migrate --module=module1 -v=3
+    php oil r migrate --all
 
 HELP;
 

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -25,10 +25,122 @@ namespace Fuel\Tasks;
 
 class Migrate {
 
+	protected static $default = true;
+	protected static $modules = array();
+	protected static $packages = array();
+	protected static $module_count = 0;
+	protected static $package_count = 0;
+
+	public function __construct()
+	{
+		//load config
+		\Config::load('migrations', true);
+
+		$modules = \Cli::option('modules');
+		$packages = \Cli::option('packages');
+		$default = \Cli::option('default');
+
+		// if modules option set
+		if (!empty($modules))
+		{
+			// if true - get all modules
+			if ($modules === true)
+			{
+				// loop through module paths
+				foreach (\Config::get('module_paths') as $path)
+				{
+					// get all modules that have files in the migration folder
+					foreach (glob($path . '*/') as $m)
+					{
+						if (count(glob($m.\Config::get('migrations.folder').'/*.php')))
+						{
+							static::$modules[] = basename($m);
+						}
+					}
+				}
+			}
+			// else do selected modules
+			else
+			{
+				static::$modules = explode(',', $modules);
+			}
+		}
+
+		// if packages option set
+		if (!empty($packages))
+		{
+			// if true - get all packages
+			if ($packages === true)
+			{
+				// get all packages that have files in the migration folder
+				foreach (glob(PKGPATH . '*/') as $p)
+				{
+					if (count(glob($p.\Config::get('migrations.folder').'/*.php')))
+					{
+						static::$packages[] = basename($p);
+					}
+				}
+			}
+			// else do selected packages
+			else
+			{
+				static::$packages = explode(',', $packages);
+			}
+		}
+
+		if ( (!empty($packages) or !empty($modules)) and empty($default))
+		{
+			static::$default = false;
+		}
+
+		// set count
+		static::$module_count = count(static::$modules);
+		static::$package_count = count(static::$packages);
+	}
+
 	public static function run()
 	{
-		\Config::load('migrations', true);
-		$current_version = \Config::get('migrations.version');
+		// run default migrations if default is true
+		if (static::$default)
+		{
+			static::_run('default');
+		}
+
+		// run modules if passed
+		if (count(static::$modules))
+		{
+			foreach (static::$modules as $module)
+			{
+				static::_run($module, 'module');
+			}
+		}
+
+		//run packages if passed
+		if (count(static::$packages))
+		{
+			foreach (static::$packages as $package)
+			{
+				static::_run($package, 'package');
+			}
+		}
+
+	}
+
+	private static function _run($name, $type = null)
+	{
+		if ($type)
+		{
+			$current_version = \Config::get('migrations.version.'.$type.'.'.$name);
+		}
+		else
+		{
+			$current_version = \Config::get('migrations.version.'.$name);
+		}
+
+		if ( ! $current_version)
+		{
+			$current_version = 0;
+		}
 
 		// -v or --version
 		$version = \Cli::option('v', \Cli::option('version'));
@@ -37,6 +149,13 @@ class Migrate {
 		if ($version === true)
 		{
 			\Cli::write('Currently on migration: ' . $current_version .'.', 'green');
+			return;
+		}
+
+		// If version has a value, make sure only 1 item was passed
+		else if ( ! is_null($version) and static::$default + static::$module_count + static::$package_count > 1)
+		{
+			throw new \Oil\Exception('Migration: version only excepts 1 item.');
 			return;
 		}
 
@@ -52,14 +171,14 @@ class Migrate {
 		// Specific version
 		if (is_numeric($version) and $version >= 0)
 		{
-			if (\Migrate::version($version) === false)
+			if (\Migrate::version($version, $name, $type) === false)
 			{
 				throw new \Oil\Exception('Migration ' . $version .' could not be found.');
 			}
 
 			else
 			{
-				static::_update_version($version);
+				static::_update_version($version, 'default');
 				\Cli::write('Migrated to version: ' . $version .'.', 'green');
 			}
 		}
@@ -67,14 +186,14 @@ class Migrate {
 		// Just go to the latest
 		else
 		{
-			if (($result = \Migrate::latest()) === false)
+			if (($result = \Migrate::latest($name, $type)) === false)
 			{
 				throw new \Oil\Exception("Could not migrate to latest version, still using {$current_version}.");
 			}
 
 			else
 			{
-				static::_update_version($result);
+				static::_update_version($result, 'default');
 				\Cli::write('Migrated to latest version: ' . $result .'.', 'green');
 			}
 		}
@@ -83,12 +202,11 @@ class Migrate {
 
 	public static function up()
 	{
-		\Config::load('migrations', true);
-		$version = \Config::get('migrations.version') + 1;
+		$version = \Config::get('migrations.version.default') + 1;
 
 		if ($foo = \Migrate::version($version))
 		{
-			static::_update_version($version);
+			static::_update_version($version, 'default');
 			\Cli::write('Migrated to version: ' . $version .'.', 'green');
 		}
 		else
@@ -99,16 +217,14 @@ class Migrate {
 
 	public static function down()
 	{
-		\Config::load('migrations', true);
-
-		if (($version = \Config::get('migrations.version') - 1) < 0)
+		if (($version = \Config::get('migrations.version.default') - 1) < 0)
 		{
 			throw new \Oil\Exception('You are already on the first migration.');
 		}
 
 		if (\Migrate::version($version) !== false)
 		{
-			static::_update_version($version);
+			static::_update_version($version, 'default');
 			\Cli::write("Migrated to version: {$version}.", 'green');
 		}
 		else
@@ -117,6 +233,40 @@ class Migrate {
 		}
 	}
 
+	private static function _update_version($version, $name, $type = null)
+	{
+		// if migrations config doesn't exist in app/config
+		if ( ! file_exists($path = APPPATH.'config'.DS.'migrations.php'))
+		{
+			// make sure it exists in core/config and copy to app/config
+			if (file_exists($core_path = COREPATH.'config'.DS.'migrations.php'))
+			{
+				$contents = file_get_contents($core_path);
+			}
+			else
+			{
+				throw new Exception('Config file core/config/migrations.php is missing.');
+				exit;
+			}
+
+			file_put_contents($path, $contents);
+		}
+
+		// set config version
+		if ($type)
+		{
+			\Config::set('migrations.version.'.$type.'.'.$name, $version);
+		}
+		else
+		{
+			\Config::set('migrations.version.'.$name, $version);
+		}
+
+		\Config::save('migrations', 'migrations');
+
+	}
+
+/*
 	private static function _update_version($version)
 	{
 		if (file_exists($path = APPPATH.'config'.DS.'migrations.php'))
@@ -133,11 +283,11 @@ class Migrate {
 			exit;
 		}
 
-		$contents = preg_replace("#('version'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
+		$contents = preg_replace("#('default'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
 
 		file_put_contents($path, $contents);
 	}
-
+*/
 	public static function current()
 	{
 		\Migrate::current();
@@ -152,6 +302,13 @@ Usage:
 Fuel options:
     -v, [--version]  # Migrate to a specific version
 
+    # The following disable default migrations unless you add --default to the command
+    --default # re-enables default migration
+    --modules # Migrates all modules
+    --modules=item1,item2 # Migrates specific modules
+    --packages # Migrates all packages
+    --packages=item1,item2 # Migrates specific modules
+
 Description:
     The migrate task can run migrations. You can go up, down or by default go to the current migration marked in the config file.
 
@@ -165,5 +322,6 @@ Examples:
 HELP;
 
 	}
+
 }
 

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -104,7 +104,7 @@ class Migrate
 		// run default migrations if default is true
 		if (static::$default)
 		{
-			static::_run('default');
+			static::_run('default', 'app');
 		}
 
 		// run modules if passed
@@ -127,7 +127,7 @@ class Migrate
 
 	}
 
-	private static function _run($name, $type = null)
+	private static function _run($name, $type)
 	{
 		if ($type)
 		{
@@ -149,7 +149,7 @@ class Migrate
 		// version is used as a flag, so show it
 		if ($version === true)
 		{
-			\Cli::write('Currently on migration: ' . $current_version .'.', 'green');
+			\Cli::write('Currently on migration: ' . $current_version .' for '.$type.':'.$name.'.', 'green');
 			return;
 		}
 
@@ -163,7 +163,7 @@ class Migrate
 		// Not a lot of point in this
 		else if ( ! is_null($version) and $version == $current_version)
 		{
-			throw new \Oil\Exception('Migration: ' . $version .' already in use.');
+			throw new \Oil\Exception('Migration: ' . $version .' already in use for '.$type.':'.$name.'.');
 			return;
 		}
 
@@ -179,8 +179,8 @@ class Migrate
 
 			else
 			{
-				static::_update_version($version, 'default');
-				\Cli::write('Migrated to version: ' . $version .'.', 'green');
+				static::_update_version($version, $name, $type);
+				\Cli::write('Migrated '.$type.':'.$name.' version: ' . $version .'.', 'green');
 			}
 		}
 
@@ -189,13 +189,13 @@ class Migrate
 		{
 			if (($result = \Migrate::latest($name, $type)) === false)
 			{
-				throw new \Oil\Exception("Could not migrate to latest version, still using {$current_version}.");
+				\Cli::write('Already on latest migration for '.$type.':'.$name.'.');
 			}
 
 			else
 			{
-				static::_update_version($result, 'default');
-				\Cli::write('Migrated to latest version: ' . $result .'.', 'green');
+				static::_update_version($result, $name, $type);
+				\Cli::write('Migrated '.$type.':'.$name.' to latest version: ' . $result .'.', 'green');
 			}
 		}
 
@@ -203,16 +203,16 @@ class Migrate
 
 	public static function up()
 	{
-		$version = \Config::get('migrations.version.default') + 1;
+		$version = \Config::get('migrations.version.app.default') + 1;
 
-		if ($foo = \Migrate::version($version))
+		if ($foo = \Migrate::version($version, 'default', 'app'))
 		{
-			static::_update_version($version, 'default');
+			static::_update_version($version, 'default', 'app');
 			\Cli::write('Migrated to version: ' . $version .'.', 'green');
 		}
 		else
 		{
-			throw new \Oil\Exception('Already on latest migration.');
+			\Cli::write('Already on latest migration.');
 		}
 	}
 
@@ -234,7 +234,7 @@ class Migrate
 		}
 	}
 
-	private static function _update_version($version, $name, $type = null)
+	private static function _update_version($version, $name, $type)
 	{
 		// if migrations config doesn't exist in app/config
 		if ( ! file_exists($path = APPPATH.'config'.DS.'migrations.php'))
@@ -254,14 +254,7 @@ class Migrate
 		}
 
 		// set config version
-		if ($type)
-		{
-			\Config::set('migrations.version.'.$type.'.'.$name, $version);
-		}
-		else
-		{
-			\Config::set('migrations.version.'.$name, $version);
-		}
+		\Config::set('migrations.version.'.$type.'.'.$name, (int) $version);
 
 		\Config::save('migrations', 'migrations');
 

--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -253,16 +253,15 @@ else {
 		foreach($output['queries'] as $query) {
 			$return_output .='<tr>
 				<td class="'.$class.'">'.$query['sql'];
+			$return_output .='<em>';
 			if(isset($query['explain'])) {
-					$return_output .='<em>
-						Possible keys: <b>'.$query['explain']['possible_keys'].'</b> &middot;
+					$return_output .='Possible keys: <b>'.$query['explain']['possible_keys'].'</b> &middot;
 						Key Used: <b>'.$query['explain']['key'].'</b> &middot;
 						Type: <b>'.$query['explain']['type'].'</b> &middot;
-						Rows: <b>'.$query['explain']['rows'].'</b> &middot;
-						Speed: <b>'.$query['time'].'</b>
-					</em>';
+						Rows: <b>'.$query['explain']['rows'].'</b> &middot;';
 			}
-			$return_output .='</td></tr>';
+			$return_output .='Speed: <b>'.$query['time'].'</b>
+					</em></td></tr>';
 			if($class == '') $class = 'alt';
 			else $class = '';
 		}


### PR DESCRIPTION
Added module and package support for migrations.

Modules accessible by adding --modules option for all modules or --modules=name1,name2 for specific modules.

Packages work the same as modules.

adding --modules or --packages disabled the default migration unless you add in the --default option.

Works for all commands, though specifying a version only allows you to update 1 item per command.

Edit:

removed edit - methods now default to the apps default migration folder
