### PR TITLE
Real fix+test to issue #432 Format::_from_xml()

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -315,7 +315,16 @@ class Format
 	 */
 	protected function _from_xml($string)
 	{
-		return $string ? (array) simplexml_load_string($string, 'SimpleXMLElement', LIBXML_NOCDATA) : array();
+		$_arr = is_string($string) ? simplexml_load_string($string, 'SimpleXMLElement', LIBXML_NOCDATA) : $string;
+		$arr = array();
+		
+		// Convert all objects SimpleXMLElement to array recursively
+		foreach ((array)$_arr as $key => $val)
+		{
+			$arr[$key] = (is_array($val) or is_object($val)) ? $this->_from_xml($val) : $val;
+		}
+		
+		return $arr;
 	}
 
 	/**

--- a/tests/format.php
+++ b/tests/format.php
@@ -59,4 +59,96 @@ line 2","Value 3"',
 	{
 		$this->assertEquals($csv, Format::forge($array)->to_csv());
 	}
+	
+	/**
+	 * Test for Format::forge($foo)->_from_xml()
+	 *
+	 * @test
+	 */
+	public function test__from_xml()
+	{
+		$xml = '<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" stopOnFailure="false" bootstrap="bootstrap_phpunit.php">
+	<php>
+		<server name="doc_root" value="../../"/>
+		<server name="app_path" value="fuel/app"/>
+		<server name="core_path" value="fuel/core"/>
+		<server name="package_path" value="fuel/packages"/>
+	</php>
+	<testsuites>
+		<testsuite name="core">
+			<directory suffix=".php">../core/tests</directory>
+		</testsuite>
+		<testsuite name="packages">
+			<directory suffix=".php">../packages/*/tests</directory>
+		</testsuite>
+		<testsuite name="app">
+			<directory suffix=".php">../app/tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>';
+		
+		$expected = array (
+			'@attributes' => array (
+				'colors' => 'true',
+				'stopOnFailure' => 'false',
+				'bootstrap' => 'bootstrap_phpunit.php',
+			),
+			'php' => array (
+				'server' => array (
+					0 => array (
+						'@attributes' => array (
+							'name' => 'doc_root',
+							'value' => '../../',
+						),
+					),
+					1 => array (
+						'@attributes' => array (
+							'name' => 'app_path',
+							'value' => 'fuel/app',
+						),
+					),
+					2 => array (
+						'@attributes' => array (
+							'name' => 'core_path',
+							'value' => 'fuel/core',
+						),
+					),
+					3 => array (
+						'@attributes' => array (
+							'name' => 'package_path',
+							'value' => 'fuel/packages',
+						),
+					),
+				),
+			),
+			'testsuites' => array (
+				'testsuite' => array (
+					0 => array (
+						'@attributes' => array (
+							'name' => 'core',
+						),
+						'directory' => '../core/tests',
+					),
+					1 => array (
+						'@attributes' =>
+						array (
+							'name' => 'packages',
+						),
+						'directory' => '../packages/*/tests',
+					),
+					2 => array (
+						'@attributes' =>
+						array (
+							'name' => 'app',
+						),
+						'directory' => '../app/tests',
+					),
+				),
+			),
+		);
+		
+		$this->assertEquals(Format::forge($expected)->to_php(), Format::forge($xml, 'xml')->to_php());
+	}
 }


### PR DESCRIPTION
Real fix to issue #432. The actual function Format::_from_xml() convert the XML and its children as SimpleXMLElement objects, instead arrays (as expected).
