### PR TITLE
Fixed default behaviour when using ::find_one_by should return single obj

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -83,8 +83,14 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 			$config['where'] = array($column => array($operator, $value));
 		}
 
-		return static::find($config);
+		$result = static::find($config);
 
+		if ( ! is_null($result))
+		{
+			return current($result);
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Fixed default behaviour when using ::find_one_by should return single object, not an array
