### PR TITLE
Fixed Lang::get() - now returns original line, if nothing found.

### DIFF
--- a/classes/lang.php
+++ b/classes/lang.php
@@ -82,12 +82,11 @@ class Lang
 	 *
 	 * @param   string  key for the line
 	 * @param   array   array of params to str_replace
-	 * @param   mixed   default value to return
-	 * @return  bool|string  either the line or false when not found
+	 * @return  string  The line
 	 */
-	public static function get($line, array $params = array(), $default = null)
+	public static function get($line, array $params = array())
 	{
-		return \Str::tr(\Arr::get(static::$lines, $line, $default), $params);
+		return \Str::tr(\Arr::get(static::$lines, $line, $line), $params);
 	}
 
 	/**


### PR DESCRIPTION
Now Lang::get() is more usable. If you write something like

``` php
<h1><?php echo __('All Users'); ?></h1>
```

and "All Users" is not translated, it will return 'All Users' instead of nothing...
