### PR TITLE
Fixed __() - now returns original line, if nothing found.

### DIFF
--- a/base.php
+++ b/base.php
@@ -170,7 +170,7 @@ if ( ! function_exists('__'))
 	{
 		$default === false and $default = $string;
 		
-		return \Lang::get($string, $params, $string);
+		return \Lang::get($string, $params, $default);
 	}
 }
 

--- a/base.php
+++ b/base.php
@@ -159,14 +159,17 @@ if ( ! function_exists('render'))
 /**
  * A wrapper function for Lang::get()
  *
- * @param	mixed	The string to translate
- * @param	array	The parameters
- * @return	string
+ * @param   mixed   The string to translate
+ * @param   array   The parameters
+ * @param   mixed   The default value. If false, it will be set to first param
+ * @return  string
  */
 if ( ! function_exists('__'))
 {
-	function __($string, $params = array())
+	function __($string, $params = array(), $default = null)
 	{
+		$default === false and $default = $string;
+		
 		return \Lang::get($string, $params, $string);
 	}
 }

--- a/base.php
+++ b/base.php
@@ -165,9 +165,9 @@ if ( ! function_exists('render'))
  */
 if ( ! function_exists('__'))
 {
-	function __($string, $params = array(), $default = null)
+	function __($string, $params = array())
 	{
-		return \Lang::get($string, $params, $default);
+		return \Lang::get($string, $params, $string);
 	}
 }
 


### PR DESCRIPTION
Now `__()` is more usable. If you write something like

``` php
<h1><?php echo __('All Users'); ?></h1>
```

and "All Users" is not translated, it will return 'All Users' instead of nothing...
