### PR TITLE
Only unset $this->_config['connection'] if the connection is successful. 

### DIFF
--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -53,9 +53,6 @@ class Database_PDO_Connection extends \Database_Connection
 			'persistent' => false,
 		));
 
-		// Clear the connection parameters for security
-		unset($this->_config['connection']);
-
 		// determine db type
 		$_dsn_find_collon = strpos($dsn, ':');
 		$this->_db_type = $_dsn_find_collon ? substr($dsn, 0, $_dsn_find_collon) : null;
@@ -73,6 +70,9 @@ class Database_PDO_Connection extends \Database_Connection
 		{
 			// Create a new PDO connection
 			$this->_connection = new \PDO($dsn, $username, $password, $attrs);
+
+			// Clear the connection parameters for security
+			unset($this->_config['connection']);
 		}
 		catch (\PDOException $e)
 		{


### PR DESCRIPTION
Only unset $this->_config['connection'] if the connection is successful. This is to ensure any subsequent request occur (mostly Exception would exit but when \Database_Exception is catched by the Application for instance from Unit Testing) it generate a shitload of error.

```
php oil t
Tests Running...This may take a few moments.
PHP Fatal error:  Unsupported operand types in /fuel/core/classes/database/pdo/connection.php on line 54
Notice - Undefined index: connection in COREPATH/classes/database/pdo/connection.php on line 49
Error - Unsupported operand types in COREPATH/classes/database/pdo/connection.php on line 54
```
