### PR TITLE
Added _clear() to Mongo_Db get() method to reset the default settings

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -632,7 +632,9 @@ class Mongo_Db
 				$returns[] = $doc;
 			}
 		}
-
+		
+		$this->_clear();
+		
 		return $returns;
 	}
 


### PR DESCRIPTION
When calling twice get() in Mongo_Db method the default settings wasn't reseted like it's done on count(), for example.
