### PR TITLE
Make sure multiple Selects work in connection with Fieldsets

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -702,8 +702,13 @@ class Form
 				break;
 			case 'select':
 				$attributes = $field->attributes;
+				$name = $field->name;
+				if (in_array('multiple', $attributes))
+				{
+					$name .= '[]';
+				}
 				unset($attributes['type']);
-				$build_field = static::select($field->name, $field->value, $field->options, $attributes);
+				$build_field = static::select($name, $field->value, $field->options, $attributes);
 				break;
 			case 'textarea':
 				$attributes = $field->attributes;


### PR DESCRIPTION
There is a problem when dealing with multiple selects in fieldsets. If you want to have multiple selects work, you have to name it like `somewhat[]` - so that PHP returns an array. However, it will be returned without the braces. This screws the behavior of `Fieldset` if you want it to validate against `required` as `Fieldset` loops through its known field names and expects the name including braces.

`Form` is now aware of the attribute `multiple` and extends the name of the element if present.

For testing purposes I extended the default `View_Welcome_Hello` `ViewModel`:

``` PHP
public function view()
{
    // minimal example for fuel-multi
    $fs = \Fieldset::forge('foobar');

    $fs->add('multi', 'multilabel', array
    (
        'type' => 'select',
        'options' => array
        (
            1 => 'foo',
            2 => 'bar'
        ),

        // this line is important
        'multiple' => 'multiple',   
    ),
    array
    (
        array('required')
    ));

    $fs->add('submit', '', array
    (
        'type' => 'submit',
        'value' => 'try'
    ));

    $fs->repopulate();

    var_dump($fs->validation()->run());

    $this->set('form', $fs, false);
    $this->name = $this->request()->param('name', 'World');
}
```
