### PR TITLE
Override default 404 route.

### DIFF
--- a/classes/request.php
+++ b/classes/request.php
@@ -458,8 +458,15 @@ class Request
 			}
 			else
 			{
-				static::reset_request();
-				throw new \HttpNotFoundException();
+                                if (method_exists($controller, 'action_404'))
+                                {
+                                        $controller->action_404();
+                                }
+                                else
+                                {
+				        static::reset_request();
+				        throw new \Request404Exception();
+                                }
 			}
 		}
 


### PR DESCRIPTION
If `Controller` has it's own `action_404()` and method that doesn't exists inside controller will be called `Controller->action_404()` method will be executed instead default `_404_` route.
I don't know Fuel very well so no idea if that's the best way of doing that.
