### PR TITLE
Added a referer() function alongside referrer() to reflect the spelling of

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -211,11 +211,21 @@ class Input
 	}
 
 	/**
-	 * Return's the referrer
+	 * Return's the referer
 	 *
 	 * @return  string
 	 */
 	public static function referrer($default = '')
+	{
+		return static::server('HTTP_REFERER', $default);
+	}
+
+	/**
+	 * Return's the (php spelt) referer
+	 *
+	 * @return string
+	 */
+	public static function referer($default = '')
 	{
 		return static::server('HTTP_REFERER', $default);
 	}


### PR DESCRIPTION
Added a referer() function alongside referrer() to reflect the spelling of PHP HTTP_REFERER. The spelling difference will likely get people annoyed when they're used to "referer" (it did me).
