### PR TITLE
Changed the return type for add_field to the correct one.

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -168,7 +168,7 @@ class Validation
 	 * @param   string      Field name
 	 * @param   string      Field label
 	 * @param   string      Rules as a piped string
-	 * @return  Validation  $this to allow chaining
+	 * @return  Fieldset_Field  $this to allow chaining
 	 */
 	public function add_field($name, $label, $rules)
 	{


### PR DESCRIPTION
Since add_field returns the newly created field and not $this, the return type in the documentation is wrong.
