### PR TITLE
Remove deprecated Input::get_post() call

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -248,7 +248,7 @@ class Format
 	 */
 	public function to_jsonp($data = null)
 	{
-		 $callback = \Input::get_post('callback', null);
+		 $callback = \Input::param('callback');
 		 is_null($callback) and $callback = 'response';
 
 		 return $callback.'('.$this->to_json($data).')';


### PR DESCRIPTION
Remove deprecated Input::get_post() call
