### PR TITLE
Fixed "Fatal error: Class 'FuelException' not found"

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -20,7 +20,7 @@ class FuelException extends \Exception {}
 /**
  * @deprecated  Keep until v1.2
  */
-class Fuel_Exception extends \FuelException {}
+class Fuel_Exception extends FuelException {}
 
 /**
  * The core of the framework.


### PR DESCRIPTION
It may be deprecated, but the current with the default config doesn't work. Autoloader is not registered yet so we can't use \FuelException from the global namespace here, it won't be found.
