### PR TITLE
Feature: Allow sub-directories in config files

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -53,7 +53,6 @@ class Config
 		{
 			$info = pathinfo($file);
 			$type = isset($info['extension']) ? $info['extension'] : 'php';
-			$file = $info['filename'];
 			$class = '\\Config_'.ucfirst($type);
 
 			if (class_exists($class))

--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -58,7 +58,7 @@ abstract class Config_File implements Config_Interface
 	 */
 	public function group()
 	{
-		return pathinfo($this->file, PATHINFO_FILENAME);
+		return $this->file;
 	}
 
 	/**


### PR DESCRIPTION
This disappeared since the Config driver refactoring. Not sure why.
