### PR TITLE
Added support to BMP in Image class

### DIFF
--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -18,7 +18,7 @@ class Image_Imagemagick extends \Image_Driver
 {
 
 	private $image_temp = null;
-	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
+	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg', 'bmp');
 	private $size_cache = null;
 	private $im_path = null;
 

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -17,7 +17,7 @@ namespace Fuel\Core;
 class Image_Imagick extends \Image_Driver
 {
 
-	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
+	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg', 'bmp');
 	private $imagick = null;
 
 	public function load($filename, $return_data = false)


### PR DESCRIPTION
I added GD functions to handle BMP images, as it's still a image format very used. Imagick and Imagemagick drivers has native support.

I don't see a point excluding BMP support just because GD doesn't support it.
