### PR TITLE
Several bugfixes / documented but missing features in Image class

### DIFF
--- a/classes/image.php
+++ b/classes/image.php
@@ -274,6 +274,11 @@ class Image
 		return static::instance()->sizes($filename);
 	}
 
+	/**
+	 * Reloads the image.
+	 *
+	 * @return  Image_Driver
+	 */
 	public static function reload()
 	{
 		return static::instance()->reload();

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -121,7 +121,7 @@ abstract class Image_Driver
 		if (file_exists($filename))
 		{
 			// Check the extension
-			$ext = $this->check_extension($filename);;
+			$ext = $this->check_extension($filename);
 			if ($ext !== false)
 			{
 				$return = array_merge($return, array(
@@ -694,6 +694,50 @@ abstract class Image_Driver
 	 * Adds a background to the image using the 'bgcolor' config option.
 	 */
 	abstract protected function add_background();
+
+	/**
+	 * Creates a new color usable by all drivers.
+	 *
+	 * @param   string   $hex    The hex code of the color
+	 * @return  array    rgba representation of the hex and alpha values.
+	 */
+	protected function create_hex_color($hex)
+	{
+		if ($hex == null)
+		{
+			$red = 0;
+			$green = 0;
+			$blue = 0;
+		}
+		else
+		{
+			// Check if theres a # in front
+			if (substr($hex, 0, 1) == '#')
+			{
+				$hex = substr($hex, 1);
+			}
+
+			// Break apart the hex
+			if (strlen($hex) == 6)
+			{
+				$red   = hexdec(substr($hex, 0, 2));
+				$green = hexdec(substr($hex, 2, 2));
+				$blue  = hexdec(substr($hex, 4, 2));
+			}
+			else
+			{
+				$red   = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
+				$green = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
+				$blue  = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
+			}
+		}
+		
+		return array(
+			'red' => $red,
+			'green' => $green,
+			'blue' => $blue,
+		);
+	}
 
 	/**
 	 * Checks if the extension is accepted by this library, and if its valid sets the $this->image_extension variable.

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -351,7 +351,7 @@ class Image_Gd extends \Image_Driver
 	 */
 	protected function create_color(&$image, $hex, $alpha)
 	{
-		export($this->create_hex_color($hex));
+		extract($this->create_hex_color($hex));
 		
 		// Handling alpha is different among drivers
 		if ($hex == null)

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -17,7 +17,7 @@ namespace Fuel\Core;
 class Image_Gd extends \Image_Driver
 {
 
-	private $image_data = null;
+	protected $image_data = null;
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
 	protected $gdresizefunc = "imagecopyresampled";
 
@@ -351,37 +351,18 @@ class Image_Gd extends \Image_Driver
 	 */
 	protected function create_color(&$image, $hex, $alpha)
 	{
+		export($this->create_hex_color($hex));
+		
+		// Handling alpha is different among drivers
 		if ($hex == null)
 		{
-			$red = 0;
-			$green = 0;
-			$blue = 0;
 			$alpha = 127;
 		}
 		else
 		{
-			// Check if theres a # in front
-			if (substr($hex, 0, 1) == '#')
-			{
-				$hex = substr($hex, 1);
-			}
-
-			// Break apart the hex
-			if (strlen($hex) == 6)
-			{
-				$red   = hexdec(substr($hex, 0, 2));
-				$green = hexdec(substr($hex, 2, 2));
-				$blue  = hexdec(substr($hex, 4, 2));
-			}
-			else
-			{
-				$red   = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
-				$green = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
-				$blue  = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
-			}
 			$alpha = 127 - floor($alpha * 1.27);
 		}
-
+		
 		// Check if the transparency is allowed
 		return imagecolorallocatealpha($image, $red, $green, $blue, $alpha);
 	}

--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -197,7 +197,7 @@ class Image_Imagemagick extends \Image_Driver
 		$old = '"'.$this->image_temp.'"';
 		$new = '"'.$filename.'"';
 		
-		if(($filetype == 'jpeg' || $filetype == 'jpg') and $this->config['quality'] != 100)
+		if(($filetype == 'jpeg' or $filetype == 'jpg') and $this->config['quality'] != 100)
 		{
 			$quality = '"'.$this->config['quality'].'%"';
 			$this->exec('convert', $old.' -quality '.$quality.' '.strtolower($filetype).' '.$new);
@@ -224,7 +224,7 @@ class Image_Imagemagick extends \Image_Driver
 		
 		$image = '"'.$this->image_temp.'"';
 		
-		if(($filetype == 'jpeg' || $filetype == 'jpg') and $this->config['quality'] != 100)
+		if(($filetype == 'jpeg' or $filetype == 'jpg') and $this->config['quality'] != 100)
 		{
 			$quality = '"'.$this->config['quality'].'%"';
 			$this->exec('convert', $image.' -quality '.$quality.' '.strtolower($filetype).':-', true);

--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -17,10 +17,10 @@ namespace Fuel\Core;
 class Image_Imagemagick extends \Image_Driver
 {
 
-	private $image_temp = null;
+	protected $image_temp = null;
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
-	private $size_cache = null;
-	private $im_path = null;
+	protected $size_cache = null;
+	protected $im_path = null;
 
 	public function load($filename, $return_data = false)
 	{
@@ -192,10 +192,20 @@ class Image_Imagemagick extends \Image_Driver
 
 		$this->run_queue();
 		$this->add_background();
-
+		
+		$filetype = $this->image_extension;
 		$old = '"'.$this->image_temp.'"';
 		$new = '"'.$filename.'"';
-		$this->exec('convert', $old.' '.$new);
+		
+		if(($filetype == 'jpeg' || $filetype == 'jpg') and $this->config['quality'] != 100)
+		{
+			$quality = '"'.$this->config['quality'].'%"';
+			$this->exec('convert', $old.' -quality '.$quality.' '.strtolower($filetype).' '.$new);
+		}
+		else
+		{
+			$this->exec('convert', $old.' '.$new);
+		}
 
 		if ($this->config['persistence'] === false)
 		{
@@ -211,13 +221,19 @@ class Image_Imagemagick extends \Image_Driver
 
 		$this->run_queue();
 		$this->add_background();
-
-		if (substr($this->image_temp, -1 * strlen($filetype)) != $filetype)
+		
+		$image = '"'.$this->image_temp.'"';
+		
+		if(($filetype == 'jpeg' || $filetype == 'jpg') and $this->config['quality'] != 100)
 		{
-			$old = '"'.$this->image_temp.'"';
+			$quality = '"'.$this->config['quality'].'%"';
+			$this->exec('convert', $image.' -quality '.$quality.' '.strtolower($filetype).':-', true);
+		}
+		elseif (substr($this->image_temp, -1 * strlen($filetype)) != $filetype)
+		{
 			if ( ! $this->config['debug'])
 			{
-				$this->exec('convert', $old.' '.strtolower($filetype).':-', true);
+				$this->exec('convert', $image.' '.strtolower($filetype).':-', true);
 			}
 		}
 		else
@@ -272,10 +288,6 @@ class Image_Imagemagick extends \Image_Driver
 		$this->im_path = realpath($this->config['imagemagick_dir'].$program);
 		if ( ! $this->im_path)
 		{
-			$this->im_path = realpath($this->config['imagemagick_dir'].$program);
-		}
-		if ( ! $this->im_path)
-		{
 			$this->im_path = realpath($this->config['imagemagick_dir'].$program.'.exe');
 		}
 		if ( ! $this->im_path)
@@ -292,7 +304,6 @@ class Image_Imagemagick extends \Image_Driver
 
 		if ($code != 0)
 		{
-			$message = implode('\n', $output);
 			throw new \FuelException("imagemagick failed to edit the image. Returned with $code.<br /><br />Command:\n <code>$command</code>");
 		}
 
@@ -308,34 +319,7 @@ class Image_Imagemagick extends \Image_Driver
 	 */
 	protected function create_color($hex, $alpha)
 	{
-		if ($hex == null)
-		{
-			$red = 0;
-			$green = 0;
-			$blue = 0;
-		}
-		else
-		{
-			// Check if theres a # in front
-			if (substr($hex, 0, 1) == '#')
-			{
-				$hex = substr($hex, 1);
-			}
-
-			// Break apart the hex
-			if (strlen($hex) == 6)
-			{
-				$red   = hexdec(substr($hex, 0, 2));
-				$green = hexdec(substr($hex, 2, 2));
-				$blue  = hexdec(substr($hex, 4, 2));
-			}
-			else
-			{
-				$red   = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
-				$green = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
-				$blue  = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
-			}
-		}
+		export($this->create_hex_color($hex));
 		return "\"rgba(".$red.", ".$green.", ".$blue.", ".round($alpha / 100, 2).")\"";
 	}
 

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -181,9 +181,21 @@ class Image_Imagick extends \Image_Driver
 
 		$filetype = $this->image_extension;
 
+		if ($filetype == 'jpg' or $filetype == 'jpeg')
+		{
+			$filetype = 'jpeg';
+		}
+		
 		if ($this->imagick->getImageFormat() != $filetype)
 		{
 			$this->imagick->setImageFormat($filetype);
+		}
+		
+		if($this->imagick->getImageFormat() == 'jpeg' and $this->config['quality'] != 100)
+		{
+			$this->imagick->setImageCompression(\Imagick::COMPRESSION_JPEG); 
+			$this->imagick->setImageCompressionQuality($this->config['quality']); 
+			$this->imagick->stripImage(); 
 		}
 
 		file_put_contents($filename, $this->imagick->getImageBlob());
@@ -202,10 +214,22 @@ class Image_Imagick extends \Image_Driver
 
 		$this->run_queue();
 		$this->add_background();
+		
+		if ($filetype == 'jpg' or $filetype == 'jpeg')
+		{
+			$filetype = 'jpeg';
+		}
 
 		if ($this->imagick->getImageFormat() != $filetype)
 		{
 			$this->imagick->setImageFormat($filetype);
+		}
+		
+		if($this->imagick->getImageFormat() == 'jpeg')
+		{
+			$this->imagick->setImageCompression(\Imagick::COMPRESSION_JPEG); 
+			$this->imagick->setImageCompressionQuality($this->config['quality']); 
+			$this->imagick->stripImage(); 
 		}
 
 		if ( ! $this->config['debug'])
@@ -218,15 +242,18 @@ class Image_Imagick extends \Image_Driver
 
 	protected function add_background()
 	{
-		$tmpimage = new \Imagick();
-		$sizes = $this->sizes();
-		$tmpimage->newImage($sizes->width, $sizes->height, $this->create_color($this->config['bgcolor'], $this->config['bgcolor'] == null ? 0 : 100), 'png');
-		$tmpimage->compositeImage($this->imagick, \Imagick::COMPOSITE_DEFAULT, 0, 0);
-		$this->imagick = $tmpimage;
+		if($this->config['bgcolor'] != null)
+		{
+			$tmpimage = new \Imagick();
+			$sizes = $this->sizes();
+			$tmpimage->newImage($sizes->width, $sizes->height, $this->create_color($this->config['bgcolor'], $this->config['bgcolor'] == null ? 0 : 100), 'png');
+			$tmpimage->compositeImage($this->imagick, \Imagick::COMPOSITE_DEFAULT, 0, 0);
+			$this->imagick = $tmpimage;
+		}
 	}
 
 	/**
-	 * Creates a new color usable by ImageMagick.
+	 * Creates a new color usable by Imagick.
 	 *
 	 * @param  string   $hex    The hex code of the color
 	 * @param  integer  $alpha  The alpha of the color, 0 (trans) to 100 (opaque)
@@ -234,34 +261,7 @@ class Image_Imagick extends \Image_Driver
 	 */
 	protected function create_color($hex, $alpha)
 	{
-		if ($hex == null)
-		{
-			$red = 0;
-			$green = 0;
-			$blue = 0;
-		}
-		else
-		{
-			// Check if theres a # in front
-			if (substr($hex, 0, 1) == '#')
-			{
-				$hex = substr($hex, 1);
-			}
-
-			// Break apart the hex
-			if (strlen($hex) == 6)
-			{
-				$red   = hexdec(substr($hex, 0, 2));
-				$green = hexdec(substr($hex, 2, 2));
-				$blue  = hexdec(substr($hex, 4, 2));
-			}
-			else
-			{
-				$red   = hexdec(substr($hex, 0, 1).substr($hex, 0, 1));
-				$green = hexdec(substr($hex, 1, 1).substr($hex, 1, 1));
-				$blue  = hexdec(substr($hex, 2, 1).substr($hex, 2, 1));
-			}
-		}
+		export($this->create_hex_color($hex));
 		return new \ImagickPixel('rgba('.$red.', '.$green.', '.$blue.', '.round($alpha / 100, 2).')');
 	}
 }

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -225,7 +225,7 @@ class Image_Imagick extends \Image_Driver
 			$this->imagick->setImageFormat($filetype);
 		}
 		
-		if($this->imagick->getImageFormat() == 'jpeg')
+		if($this->imagick->getImageFormat() == 'jpeg' and $this->config['quality'] != 100)
 		{
 			$this->imagick->setImageCompression(\Imagick::COMPRESSION_JPEG); 
 			$this->imagick->setImageCompressionQuality($this->config['quality']); 


### PR DESCRIPTION
I made a few fixes in Image and Drivers classes, nothing new, just what should be.

Added docblocks to Image::reload()
Changed visibility of image drivers vars to protected, allowing extensions/plugins
Added real support to JPEG quality to Imagemagick and Imagick drivers
Removed a duplicated checking on exec command in ImageMagick::exec()
Removed unused var in ImageMagick::exec()
Improved create_color code (all drivers uses the same function, why this was written 3 times?)
Little fix on Imagick::add_background: it was suposed to add a bg only if bgcolor is set (like other drivers)
Fixed a mispell in Imagic::create_color docblock
