### PR TITLE
Log directories creation fixes

### DIFF
--- a/classes/log.php
+++ b/classes/log.php
@@ -113,7 +113,6 @@ class Log
 			$old = umask(0);
 			
 			mkdir($filepath, \Config::get('file.chmod.folders', 0777), true);
-			chmod($filepath, \Config::get('file.chmod.folders', 0777));
 			umask($old);
 		}
 

--- a/config/file.php
+++ b/config/file.php
@@ -71,12 +71,12 @@ return array(
 		/**
 		 * Permissions for newly created files
 		 */
-		'files'  => '0666',
+		'files'  => 0666,
 
 		/**
 		 * Permissions for newly created directories
 		 */
-		'folders'  => '0777',
+		'folders'  => 0777,
 	),
 
 );


### PR DESCRIPTION
- chmod values in config file should be octal not 'string'. Fixes an issue with Log::write() creating directories
- No need for chmod() line after mkdir() created the directory structure with 0777 or whatever in config
