### PR TITLE
fixed Response driver's get_headers, now correctly returns array

### DIFF
--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -191,7 +191,7 @@ abstract class Request_Driver
 		$headers = array();
 		foreach ($this->headers as $key => $value)
 		{
-			$headers = is_int($key) ? $value : $key.': '.$value;
+			$headers[] = is_int($key) ? $value : $key.': '.$value;
 		}
 
 		return $headers;


### PR DESCRIPTION
Small syntax error prevented request driver's get_headers returning an array.

Rob :)
