### PR TITLE
Respect the common strategy to signify a SSL reverse proxying

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -192,7 +192,9 @@ class Input
 	public static function protocol()
 	{
 		if ((static::server('HTTPS') !== null and static::server('HTTPS') != 'off')
-			or (static::server('HTTPS') === null and static::server('SERVER_PORT') == 443))
+			or (static::server('HTTPS') === null and static::server('SERVER_PORT') == 443)
+			or (static::server('HTTP_X_FORWARDED_PROTO') === 'https')
+			or (static::server('HTTP_FRONT_END_HTTPS') === 'on'))
 		{
 			return 'https';
 		}


### PR DESCRIPTION
I'm using FuelPHP on an host behind a proxy. Users connect with HTTPS on the proxy which then relays the request with HTTP. A classic SSL reverse proxy situation.

The problem is that `Input::protocol()` returns `http` where, in my sense, it should return `https`. The following patch resolve the problem by using two of the more common strategies used in these kind of proxying. An issues opened against Drupal explains this a little better : http://drupal.org/node/313145

(My original problem was that the actions of the forms where pointing to the http version of the site, and I traced down this "issue" to this.)
