### PR TITLE
Fix display of fatal error in modules

### DIFF
--- a/views/errors/php_fatal_error.php
+++ b/views/errors/php_fatal_error.php
@@ -52,7 +52,7 @@
 				$debug_lines = \Debug::file_lines($trace['file'], $trace['line']);
 		?>
 			<li>
-				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>');return false;"><?php echo Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
+				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>');return false;"><?php echo \Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
 				<div id="backtrace_<?php echo $id; ?>" class="backtrace_block">
 <pre class="fuel_debug_source"><?php foreach ($debug_lines as $line_num => $line_content): ?>
 <span<?php echo ($line_num == $trace['line']) ? ' class="fuel_line fuel_current_line"' : ' class="fuel_line"'; ?>><span class="fuel_line_number"><?php echo str_pad($line_num, (strlen(count($debug_lines))), ' ', STR_PAD_LEFT); ?></span><span class="fuel_line_content"><?php echo $line_content . PHP_EOL; ?>


### PR DESCRIPTION
When a fatal error is encountered in a module, the error page's reference to the `Fuel` class is using a relative namespace, and thus failing.
