### PR TITLE
Moved prep_values to after validation.  This allows for adding/removing v

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -334,7 +334,7 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 			throw new \Exception('Cannot modify a frozen row.');
 		}
 
-		$vars = $this->prep_values($this->to_array());
+		$vars = $this->to_array();
 
 		// Set default if there are any
 		isset(static::$_defaults) and $vars = $vars + static::$_defaults;
@@ -352,6 +352,8 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 				return false;
 			}
 		}
+		
+		$vars = $this->prep_values($vars);
 
 		if ($this->is_new())
 		{


### PR DESCRIPTION
Moved prep_values to after validation.  This allows for adding/removing vars in the prep_values method. Useful for combining multiple input fields into 1 field, like time and hour into a timestamp for database input when time and hour need to be validated.
