### PR TITLE
Added Mongo_Db::get_one() to obtain only one document.

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -639,6 +639,26 @@ class Mongo_Db
 	}
 
 	/**
+	* Get one document based upon the passwed parameters
+	 *
+	 *	@param	string	$collection		the collection name
+	 *	@usage	$mongodb->get('foo');
+	 */
+	 public function get_one($collection = "")
+	{
+		if (empty($collection))
+		{
+			throw new \Mongo_DbException("In order to retrieve documents from MongoDB");
+		}
+
+		$returns = $this->db->{$collection}->findOne($this->wheres, $this->selects);
+
+		$this->_clear();
+
+		return $returns;
+	}
+
+	/**
 	 *	Count the documents based upon the passed parameters
 	 *
 	 *	@param	string	$collection		the collection name


### PR DESCRIPTION
I have added `Mongo_Db::get_one()` that uses `MongoCollection::findOne` just for performance reasons: findOne is faster than find with a limit of 1.

I have done tests of 10.000 executions and that is what I've:

> Excuted in 1.0861890316 seconds, with an average of 0.00010861890316 sec/each
> Excuted in 1.19088315964 seconds, with an average of 0.000119088315964 sec/each
