### PR TITLE
Repsonse: allow headers to be set when creating the request

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -68,9 +68,9 @@ class Response
 		509 => 'Bandwidth Limit Exceeded'
 	);
 
-	public static function forge($body = null, $status = 200)
+	public static function forge($body = null, $status = 200, array $headers = array())
 	{
-		return new static($body, $status);
+		return new static($body, $status, $headers);
 	}
 
 	/**
@@ -136,8 +136,12 @@ class Response
 	 * @param  string  $body    The response body
 	 * @param  string  $status  The response status
 	 */
-	public function __construct($body = null, $status = 200)
+	public function __construct($body = null, $status = 200, array $headers = array())
 	{
+		foreach($headers as $k=>$v)
+		{
+			$this->set_header($k, $v);
+		}
 		$this->body = $body;
 		$this->status = $status;
 	}


### PR DESCRIPTION
Changed forge() and __construct() to allow headers to be set while forging a request
