### PR TITLE
modified forge() and __construct() of Response so that headers can be set while forging a response

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -137,7 +137,7 @@ class Response {
 	 */
 	public function __construct($body = null, $status = 200, array $headers = array())
 	{
-		foreach($headers as $k=>$v)
+		foreach($headers as $k => $v)
 		{
 			$this->set_header($k, $v);
 		}

--- a/classes/response.php
+++ b/classes/response.php
@@ -67,9 +67,9 @@ class Response {
 		509 => 'Bandwidth Limit Exceeded'
 	);
 
-	public static function forge($body = null, $status = 200)
+	public static function forge($body = null, $status = 200, array $headers = array())
 	{
-		return new static($body, $status);
+		return new static($body, $status, $headers);
 	}
 
 	/**
@@ -135,8 +135,12 @@ class Response {
 	 * @param  string  $body    The response body
 	 * @param  string  $status  The response status
 	 */
-	public function __construct($body = null, $status = 200)
+	public function __construct($body = null, $status = 200, array $headers = array())
 	{
+		foreach($headers as $k=>$v)
+		{
+			$this->set_header($k, $v);
+		}
 		$this->body = $body;
 		$this->status = $status;
 	}


### PR DESCRIPTION
Added spaces b/w $k, => , and $v in order to match fuel's coding standards
