### PR TITLE
added static::$_table_name to 'select'.  This makes it so if you use join

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -166,7 +166,7 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 		else
 		{
 			$config = $config + array(
-				'select' => array('*'),
+				'select' => array(static::$_table_name.'.*'),
 				'where' => array(),
 				'order_by' => array(),
 				'limit' => null,


### PR DESCRIPTION
added static::$_table_name to 'select'.  This makes it so if you use joins in anyway it doesn't select the entire joined
 table automatically.
