### PR TITLE
HTTP_ACCEPT is always checked to detect REST format by default

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -162,7 +162,7 @@ abstract class Controller_Rest extends \Controller
 		}
 
 		// Otherwise, check the HTTP_ACCEPT (if it exists and we are allowed)
-		if (\Config::get('rest.ignore_http_accept', false) !== false and \Input::server('HTTP_ACCEPT'))
+		if (\Config::get('rest.ignore_http_accept') === false and \Input::server('HTTP_ACCEPT'))
 		{
 			// Check all formats against the HTTP_ACCEPT header
 			foreach (array_keys($this->_supported_formats) as $format)

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -162,7 +162,7 @@ abstract class Controller_Rest extends \Controller
 		}
 
 		// Otherwise, check the HTTP_ACCEPT (if it exists and we are allowed)
-		if (\Config::get('rest.ignore_http_accept') !== false and \Input::server('HTTP_ACCEPT'))
+		if (\Config::get('rest.ignore_http_accept', false) !== false and \Input::server('HTTP_ACCEPT'))
 		{
 			// Check all formats against the HTTP_ACCEPT header
 			foreach (array_keys($this->_supported_formats) as $format)


### PR DESCRIPTION
Config::get('rest.ignore_http_accept') by default is not set, which would return null, therefore the condition would return true and additional checking is require. We should add a default value to avoid overhead with the additional checking unless specifically requested

Signed-off-by: crynobone crynobone@gmail.com
