### PR TITLE
required attribute failing W3C Validator.

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -215,7 +215,7 @@ class Fieldset_Field
 		// Set required setting for forms when rule was applied
 		if ($callback === 'required')
 		{
-			$this->set_attribute('required', true);
+			$this->set_attribute('required', 'required');
 		}
 
 		return $this;


### PR DESCRIPTION
Ideally the required attribute should just be

```
<input type="text" required />
```

But it is not possible to do that with $this->set_attribute().

It can also be defined as

```
<input type="text" required="required" />
```

Which is what this change does.
