### PR TITLE
Migrate down fixes

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -230,7 +230,6 @@ class Migrate
 			{
 				if ($end_version === null or $version <= $end_version)
 				{
-					$direction === 'down' and --$version;
 					$migrations[$version] = $full_paths[$index];
 				}
 			}
@@ -239,6 +238,16 @@ class Migrate
 
 		if ($direction === 'down')
 		{
+			$keys = array_keys($migrations);
+
+			$replacement = $keys;
+			array_unshift($replacement, $start_version);
+
+			for ($i=0; $i < count($keys); $i++) {
+				$keys[$i] = $replacement[$i];
+			}
+
+			$migrations = array_combine($keys, $migrations);
 			$migrations = array_reverse($migrations, true);
 		}
 

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -178,11 +178,12 @@ class Migrate
 			static::$version[$type][$name] = $ver;
 		}
 
-		// If we are migrating down to 0, but the lowest migration is above that
-		// we need to make sure we update the DB to say we are at 0
-		if ($version === 0 and static::$version[$type][$name] != $version)
+		// When migrating down the version is always one below the last called migration
+		if ($method === 'down')
 		{
-			static::_update_schema_version(static::$version[$type][$name], $version, $name, $type);
+			--$ver;
+			static::_update_schema_version(static::$version[$type][$name], $ver, $name, $type);
+			static::$version[$type][$name] = $ver;
 		}
 
 		logger(Fuel::L_INFO, 'Migrated to '.$ver.' successfully.');

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -178,14 +178,6 @@ class Migrate
 			static::$version[$type][$name] = $ver;
 		}
 
-		// When migrating down the version is always one below the last called migration
-		if ($method === 'down')
-		{
-			--$ver;
-			static::_update_schema_version(static::$version[$type][$name], $ver, $name, $type);
-			static::$version[$type][$name] = $ver;
-		}
-
 		logger(Fuel::L_INFO, 'Migrated to '.$ver.' successfully.');
 
 		return static::$version[$type][$name];
@@ -238,6 +230,7 @@ class Migrate
 			{
 				if ($end_version === null or $version <= $end_version)
 				{
+					$direction === 'down' and --$version;
 					$migrations[$version] = $full_paths[$index];
 				}
 			}

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -228,7 +228,6 @@ class Migrate
 			$end_version = $temp_version;
 		}
 
-
 		$migrations = array();
 		foreach ($files as $index => $file)
 		{
@@ -246,7 +245,7 @@ class Migrate
 
 		if ($direction === 'down')
 		{
-			$migrations = array_reverse($migrations);
+			$migrations = array_reverse($migrations, true);
 		}
 
 		return $migrations;


### PR DESCRIPTION
This fixes couple bugs when migrating down.

First the `find_migrations` when the array was reversed, the keys were not preserved.
Second when migrating down, the version is always one below the last migration run.
