### PR TITLE
Add chainable set_param() to Request

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -50,6 +50,17 @@ abstract class Controller
 	{
 		return $response;
 	}
+	/**
+	 * Sets a named parameter
+	 *
+	 * @param   string  $param    Name of the parameter
+	 * @param   mixed   $value  New value
+	 * @return  mixed
+	 */
+	public function set_param($param, $value)
+	{
+		$this->request->set_param($param, $value);
+	}
 
 	/**
 	 * This method returns the named parameter requested, or all of them

--- a/classes/request.php
+++ b/classes/request.php
@@ -557,6 +557,20 @@ class Request
 		return $this->paths;
 	}
 
+
+	/**
+	 * Sets a named parameter
+	 *
+	 * @param   string  $param    Name of the parameter
+	 * @param   mixed   $value  New value
+	 * @return  mixed
+	 */
+	public function set_param($param, $value)
+	{
+		$this->named_params[$param] = $value;
+		return $this;
+	}
+
 	/**
 	 * Gets a specific named parameter
 	 *


### PR DESCRIPTION
Supports setting named parameters in a chain, for example

```
$request = Request::forge('foo/bar')->set_param('foo', 'bar')->execute();
```

Maybe there should be support for passing in an array of parameters this way?
