### PR TITLE
Add AFTER and FIRST option for ALTER TABLE

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -166,7 +166,7 @@ class DBUtil
 		}
 		else
 		{
-			$use_brackets = ! in_array($type, array('CHANGE', 'MODIFY'));
+			$use_brackets = ! in_array($type, array('ADD', 'CHANGE', 'MODIFY'));
 			$use_brackets and $sql .= $type.' ';
 			$use_brackets and $sql .= '(';
 			$sql .= static::process_fields($fields, (( ! $use_brackets) ? $type.' ' : ''));
@@ -302,6 +302,16 @@ class DBUtil
 			{
 				$sql .= ' AUTO_INCREMENT';
 			}
+
+			if (array_key_exists('FIRST', $attr) and $attr['FIRST'] === true)
+			{
+				$sql .= ' FIRST';
+			}
+			elseif (array_key_exists('AFTER', $attr) and strval($attr['AFTER']))
+			{
+				$sql .= ' AFTER '.\DB::quote_identifier($attr['AFTER']);
+			}
+			
 			$sql_fields[] = $sql;
 		}
 


### PR DESCRIPTION
This changeset allow to specific use of `FIRST` and `AFTER` in `ALTER TABLE`.
# DBUtil example

```
\DBUtil::add_fields('users_meta', array(
    'website_personal' => array('constraint' => 255, 'type' => 'varchar', 'default' => '', 'after' => 'availability_id'),
    'website_company'  => array('constraint' => 255, 'type' => 'varchar', 'default' => '', 'after' => 'website_personal'),
    'profile_status'   => array('constraint' => 3, 'type' => 'tinyint', 'default' => 0, 'after' => 'website_company'),
)); 
```

will output the following SQL

```
ALTER TABLE `users_meta` 
    ADD `website_personal` varchar(255) DEFAULT '' AFTER `availability_id`,
    ADD `website_company` varchar(255) DEFAULT '' AFTER `website_personal`,
    ADD `profile_status` tinyint(3) DEFAULT '0' AFTER `profile_status
```

Signed-off-by: crynobone crynobone@gmail.com
