### PR TITLE
Fixed database query profiler timing display

### DIFF
--- a/classes/profiler.php
+++ b/classes/profiler.php
@@ -55,7 +55,7 @@ class Profiler
 
 	public static function stop($text)
 	{
-		static::$query['time'] = static::$profiler->getMicroTime() - static::$query['time'];
+		static::$query['time'] = (static::$profiler->getMicroTime() - static::$query['time']) *1000;
 		array_push(static::$profiler->queries, static::$query);
 		static::$profiler->queryCount++;
 	}


### PR DESCRIPTION
The calculation currently puts the values in the wrong units.  To see this bug, use the following code with the profiler turned on:

``` php
Profiler::start("database", "select fields from table");
sleep(1);
Profiler::stop("select fields from table");
```

should make the query time extremely close to 1 second.  The current profiler shows "1.001 ms" in my tests rather than "1.001 s".  The calculation is off in the Fuel Profiler class rather than the code in PQP.
