### PR TITLE
Changed the parameter order in Database_Query_Builder_Select::_construct()

### DIFF
--- a/classes/database/query/builder/select.php
+++ b/classes/database/query/builder/select.php
@@ -53,7 +53,7 @@ class Database_Query_Builder_Select extends \Database_Query_Builder_Where
 		}
 
 		// Start the query with no actual SQL statement
-		parent::__construct(\DB::SELECT, '');
+		parent::__construct('', \DB::SELECT);
 	}
 
 	/**


### PR DESCRIPTION
The parameter in the parent constructor are the other way around. Thus, the type of the query isn't set correctly at the creation of the Query builder.

This is problematic when you try to do an "INSERT INTO ... SELECT" like this :

```
 \DB::insert('table1')->select(\DB::select('id', 'username')->from('table2))->execute();
```

The following error is thrown actually :

```
 Only SELECT queries can be combined with INSERT queries in COREPATH/classes/database/query/builder/insert.php on line 123
```
