### PR TITLE
Added support for before and after attributes in the Fieldset class, e.g...

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -207,7 +207,17 @@ class Form
 			$attributes['id'] = \Config::get('form.auto_id_prefix', 'form_').$attributes['name'];
 		}
 
-		return html_tag('input', static::attr_to_string($attributes));
+		if (!empty($attributes['before']) || !empty($attributes['after']))
+		{
+			$attributes['before'] = !isset($attributes['before']) ? $attributes['before'] = '' : $attributes['before'];
+			$attributes['after'] = !isset($attributes['after']) ? $attributes['after'] = '' : $attributes['after'];
+
+			return html_tag('label', array(), $attributes['before'].' '.html_tag('input', static::attr_to_string($attributes)).' '.$attributes['after']);
+		} 
+		else 
+		{
+			return html_tag('input', static::attr_to_string($attributes));
+		}
 	}
 
 	/**


### PR DESCRIPTION
$login_form->add('cookie', '', array('type' => 'checkbox', 'after' => 'Remember me for 2 weeks'));

So you could now have something like this for checkboxes/radio's:

Hello    |     Hi [ x ] Bye
