### PR TITLE
Allows for DB::expressions with order_by

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -183,9 +183,16 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 				$query->where($where);
 			}
 
-			foreach ($order_by as $_field => $_direction)
+			if (is_array($order_by))
 			{
-				$query->order_by($_field, $_direction);
+				foreach ($order_by as $_field => $_direction)
+				{
+					$query->order_by($_field, $_direction);
+				}
+			}
+			else
+			{
+				$query->order_by($order_by);
 			}
 
 			if ($limit !== null)


### PR DESCRIPTION
Allows for DB::expr() in order_by so you can return random results by doing

'order_by' => DB::expr('RAND()')

or

'order_by' => 'id' (which would default to ASC)
