### PR TITLE
Fix for passing rest.valid_logins array by value rather than reference in rest controller error

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -249,7 +249,7 @@ abstract class Controller_Rest extends \Controller
 			return false;
 		}
 
-		$valid_logins = & \Config::get('rest.valid_logins');
+		$valid_logins = \Config::get('rest.valid_logins');
 
 		if (!array_key_exists($username, $valid_logins))
 		{


### PR DESCRIPTION
When using auth in rest controllers the following error is given:

ErrorException [ Runtime Notice ]: Only variables should be assigned by reference

COREPATH/classes/controller/rest.php @ line 252:

This is due to an array being passed by reference, this pull request fixes that.
