### PR TITLE
Separate each piece of the WWW-Authenticate header for digest requests with a comma

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -354,7 +354,7 @@ abstract class Controller_Rest extends \Controller
 		}
 		elseif (\Config::get('rest.auth') == 'digest')
 		{
-			header('WWW-Authenticate: Digest realm="' . \Config::get('rest.realm') . '" qop="auth" nonce="' . $nonce . '" opaque="' . md5(\Config::get('rest.realm')) . '"');
+			header('WWW-Authenticate: Digest realm="' . \Config::get('rest.realm') . '", qop="auth", nonce="' . $nonce . '", opaque="' . md5(\Config::get('rest.realm')) . '"');
 		}
 
 		exit('Not authorized.');


### PR DESCRIPTION
This brings it into compliance with [RFC 2617](http://tools.ietf.org/html/rfc2617#page-18) and makes it work with the browsers I am testing with (Chrome and IE 9).
