### PR TITLE
Fix ViewModel referencing from outside a request context

### DIFF
--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -44,7 +44,8 @@ abstract class ViewModel
 	 */
 	public static function forge($viewmodel, $method = 'view', $auto_filter = null)
 	{
-		$class = ucfirst(\Request::active()->module).'\\View_'.ucfirst(str_replace(array('/', DS), '_', $viewmodel));
+		$namespace = \Request::active() ? ucfirst(\Request::active()->module) : '';
+		$class = $namespace.'\\View_'.ucfirst(str_replace(array('/', DS), '_', $viewmodel));
 
 		if ( ! class_exists($class))
 		{


### PR DESCRIPTION
Ran into an issue when trying to create a ViewModel from outside of a controller. 
https://github.com/fuel/core/blob/1.1/develop/classes/viewmodel.php#L47 assumes that there is an active request, but I was instantiating a ViewModel in a class loaded before the request.
