### PR TITLE
Fix for a small issue on labels on scaffold generation.

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -535,7 +535,11 @@ class Form
 			isset($attributes['id']) and $id = $attributes['id'];
 		}
 
-		$attributes['for'] = $id;
+		if (empty($attributes['for']) && \Config::get('form.auto_id', false) == true)
+		{
+			$attributes['for'] = \Config::get('form.auto_id_prefix', 'form_').$id;
+		}
+		
 		unset($attributes['label']);
 		unset($attributes['id']);
 


### PR DESCRIPTION
With previous code, when generating code with scaffold for example, the "for" attribute of labels is different of the id of the associated inputs, therefore when clicking on the label the input isn't selected. It seems also more convenient to add the prefix on the "for" attribute by default, and let the user overwrite it if necessary.
