### PR TITLE
added a $literal parameter to update() and update_all() to allow the use of modifiers

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -707,7 +707,7 @@ class Mongo_Db
 	 *	@param	array	$options		an associative array of options
 	 *	@usage	$mongodb->update('foo', $data = array());
 	 */
-	public function update($collection = '', $data = array(), $options = array())
+	public function update($collection = '', $data = array(), $options = array(), $literal = false)
 	{
 		if (empty($collection))
 		{
@@ -722,7 +722,7 @@ class Mongo_Db
 		try
 		{
 			$options = array_merge($options, array('fsync' => true, 'multiple' => false));
-			$this->db->{$collection}->update($this->wheres, array('$set' => $data), $options);
+			$this->db->{$collection}->update($this->wheres, (($literal) ? $data : array('$set' => $data)), $options);
 			$this->_clear();
 			return true;
 		}
@@ -739,7 +739,7 @@ class Mongo_Db
 	 *	@param	array	$data			an associative array of values, array(field => value)
 	 *	@usage	$mongodb->update_all('foo', $data = array());
 	 */
-	public function update_all($collection = "", $data = array())
+	public function update_all($collection = "", $data = array(), $literal = false)
 	{
 		if (empty($collection))
 		{
@@ -753,7 +753,7 @@ class Mongo_Db
 
 		try
 		{
-			$this->db->{$collection}->update($this->wheres, array('$set' => $data), array('fsync' => true, 'multiple' => true));
+			$this->db->{$collection}->update($this->wheres, (($literal) ? $data : array('$set' => $data)), array('fsync' => true, 'multiple' => true));
 			$this->_clear();
 			return true;
 		}


### PR DESCRIPTION
added a $literal parameter to update() and update_all() to allow the use of modifiers like $inc, $push, $pull, etc. It defaults to the normal $set operation, if you need to do a special modifier you just set literal to true, and provide an array such as

```
$mongoinstance->update('users', array('$set' => array('name' => 'John'), '$inc' => array('children' => 1)), array(), true);
```

This fixes issue #669.
