### PR TITLE
adds in ftp upload option in the upload class

### DIFF
--- a/classes/ftp.php
+++ b/classes/ftp.php
@@ -54,8 +54,8 @@ class Ftp
 	 *
 	 *     $ftp = static::forge('group');
 	 *
-	 * @param   string  Ftp filename
-	 * @param   array   array of values
+	 * @param   string|array  The name of the config group to use, or a configuration array.
+	 * @param   bool          Automatically connect to this server.
 	 * @return  Ftp
 	 */
 	public static function forge($config = 'default', $connect = true)
@@ -71,8 +71,8 @@ class Ftp
 	/**
 	 * Sets the initial Ftp filename and local data.
 	 *
-	 * @param   string  Ftp filename
-	 * @param   array   array of values
+	 * @param   string|array  The name of the config group to use, or a configuration array.
+	 * @param   bool          Automatically connect to this server.
 	 * @return  void
 	 */
 	public function __construct($config = 'default')

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -428,8 +428,8 @@ class Upload
 	/**
 	 * Upload files with Ftp
 	 *
-	 * @param   string  Ftp filename
-	 * @param   array   array of values
+	 * @param   string|array  The name of the config group to use, or a configuration array.
+	 * @param   bool          Automatically connect to this server.
 	 */
 	public static function with_ftp($config = 'default', $connect = true)
 	{


### PR DESCRIPTION
Adds in the ability to do ftp uploads with the upload class.

usage:

$config = array(
 'path'                => 'some/path' // this is the path to upload to
 'ftp_mode'         => 'auto',
 'ftp_permission' => '0777',
 // other upload configuration goes here as well
 'normalize'        => true
);

Upload::process($config);
Upload::with_ftp(); // this tells upload to use ftp - can pass same params you would with Ftp::forge();
if (Upload::is_valid())
{
 Upload::save(); // uploads the file to ftp server with the designated config path
}
