### PR TITLE
Added the methods collection() and set() for easy usage of Mongo_Db

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -686,7 +686,7 @@ class Mongo_Db
 	}
 
 	/**
-	* Get one document based upon the passwed parameters
+	* Get one document based upon the passed parameters
 	 *
 	 *	@param	string	$collection		the collection name
 	 *	@usage	$mongodb->get('foo');
@@ -719,7 +719,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No MongoDB collection selected in order to retrieve a count of documents");
 		}
 
 		$count = $this->db->{$collection}->find($this->wheres)->limit((int) $this->limit)->skip((int) $this->offset)->count($foundonly);
@@ -786,7 +786,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection selected to update");
 		}
 
 		$values = (empty($data) OR ! is_array($data)) ? $this->values : $data;
@@ -822,7 +822,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection selected to update");
 		}
 
 		$values = (empty($data) OR ! is_array($data)) ? $this->values : $data;
@@ -856,7 +856,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection selected to delete from");
 		}
 
 		try
@@ -883,7 +883,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection selected to delete from");
 		}
 
 		try
@@ -935,7 +935,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection specified to add index to");
 		}
 
 		if (empty($keys) or ! is_array($keys))
@@ -981,7 +981,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection specified to remove index from");
 		}
 
 		if (empty($keys) or ! is_array($keys))
@@ -1012,7 +1012,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection specified to remove all indexes from");
 		}
 
 		$this->db->{$collection}->deleteIndexes();
@@ -1032,7 +1032,7 @@ class Mongo_Db
 
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to insert into");
+			throw new \Mongo_DbException("No Mongo collection specified to list all indexes from");
 		}
 
 		return ($this->db->{$collection}->getIndexInfo());

--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -686,13 +686,16 @@ class Mongo_Db
 	}
 
 	/**
-	* Get one document based upon the passed parameters
+	 * Get one document based upon the passed parameters. The collection parameter
+	 * is optional if we used $mongo->collection('name').
 	 *
 	 *	@param	string	$collection		the collection name
-	 *	@usage	$mongodb->get('foo');
+	 *	@usage	$mongodb->get_one('foo');
 	 */
 	 public function get_one($collection = "")
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+		
 		if (empty($collection))
 		{
 			throw new \Mongo_DbException("In order to retrieve documents from MongoDB");

--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -45,6 +45,11 @@ class Mongo_Db
 	protected $db;
 
 	/**
+	 * @var $collection Holds the name of the collection to use
+	 */
+	protected $collection = false;
+
+	/**
 	 * Whether to use a persistent connection
 	 *
 	 * @var  bool
@@ -594,6 +599,23 @@ class Mongo_Db
 	}
 
 	/**
+	 * Set the collection name to be used when get, insert, update...
+	 *
+	 * @param string $collection The collection name
+	 */
+	public function collection($collection = "")
+	{
+		if (empty($collection))
+		{
+			throw new \Mongo_DbException("You can not set an empty collection to MongoDB");
+		}
+
+		$this->collection = $collection;
+
+		return $this;
+	}
+
+	/**
 	 *	Get the documents based upon the passed parameters
 	 *
 	 *	@param	string	$collection		the collection name
@@ -607,13 +629,16 @@ class Mongo_Db
 	}
 
 	/**
-	 *	Get the documents based upon the passed parameters
+	 *	Get the documents based upon the passed parameters. The collection parameter
+	 * is optional if we used $mongo->collection('name').
 	 *
 	 *	@param	string	$collection		the collection name
 	 *	@usage	$mongodb->get('foo', array('bar' => 'something'));
 	 */
 	 public function get($collection = "")
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+		
 		if (empty($collection))
 		{
 			throw new \Mongo_DbException("In order to retrieve documents from MongoDB");
@@ -648,9 +673,11 @@ class Mongo_Db
 
 	public function count($collection = '', $foundonly = false)
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("In order to retrieve a count of documents from MongoDB");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		$count = $this->db->{$collection}->find($this->wheres)->limit((int) $this->limit)->skip((int) $this->offset)->count($foundonly);
@@ -671,6 +698,8 @@ class Mongo_Db
 	 */
 	public function insert($collection = '', $insert = array())
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
 			throw new \Mongo_DbException("No Mongo collection selected to insert into");
@@ -709,9 +738,11 @@ class Mongo_Db
 	 */
 	public function update($collection = '', $data = array(), $options = array())
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to update");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		if (empty($data) or ! is_array($data))
@@ -741,9 +772,11 @@ class Mongo_Db
 	 */
 	public function update_all($collection = "", $data = array())
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to update");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		if (empty($data) or ! is_array($data))
@@ -771,9 +804,11 @@ class Mongo_Db
 	 */
 	public function delete($collection = '')
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to delete from");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		try
@@ -796,9 +831,11 @@ class Mongo_Db
 	 */
 	public function delete_all($collection = '')
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection selected to delete from");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		try
@@ -846,9 +883,11 @@ class Mongo_Db
 	 */
 	public function add_index($collection = '', $keys = array(), $options = array())
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection specified to add index to");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		if (empty($keys) or ! is_array($keys))
@@ -890,9 +929,11 @@ class Mongo_Db
 	 */
 	public function remove_index($collection = '', $keys = array())
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection specified to remove index from");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		if (empty($keys) or ! is_array($keys))
@@ -919,10 +960,13 @@ class Mongo_Db
 	 */
 	public function remove_all_indexes($collection = '')
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection specified to remove all indexes from");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
+
 		$this->db->{$collection}->deleteIndexes();
 		$this->_clear();
 		return $this;
@@ -936,9 +980,11 @@ class Mongo_Db
 	 */
 	public function list_indexes($collection = '')
 	{
+		$collection = (empty($collection)) ? $this->collection : $collection;
+
 		if (empty($collection))
 		{
-			throw new \Mongo_DbException("No Mongo collection specified to remove all indexes from");
+			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
 		return ($this->db->{$collection}->getIndexInfo());

--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -64,6 +64,11 @@ class Mongo_Db
 	protected $selects = array();
 
 	/**
+	 * @var $values Holds all the values to be inserted/updated
+	 */
+	protected $values = array();
+
+	/**
 	 * Holds all the where options.
 	 *
 	 * @var  array
@@ -288,6 +293,23 @@ class Mongo_Db
 	 		}
 	 	}
 	 	return $this;
+	}
+
+	/**
+	 * Set the values to be inserted or updated. The $values array should be an associative
+	 * array with the field as key and the value as the search criteria.
+	 *
+	 *	@param	array	$values		an associative array with conditions, array(field => value)
+	 *	@usage	$mongodb->set(array('foo' => 'bar'))->insert('foobar');
+	 */
+	public function set($values = array())
+	{
+		foreach ($values as $va => $val)
+		{
+			$this->values[$va] = $val;
+		}
+
+		return $this;
 	}
 
 	/**

--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -727,17 +727,19 @@ class Mongo_Db
 			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
-		if (empty($insert) or ! is_array($insert))
+		$values = (empty($insert) OR ! is_array($insert)) ? $this->values : $insert;
+
+		if (empty($values) or ! is_array($values))
 		{
 			throw new \Mongo_DbException("Nothing to insert into Mongo collection or insert is not an array");
 		}
 
 		try
 		{
-			$this->db->{$collection}->insert($insert, array('fsync' => true));
-			if (isset($insert['_id']))
+			$this->db->{$collection}->insert($values, array('fsync' => true));
+			if (isset($values['_id']))
 			{
-				return $insert['_id'];
+				return $values['_id'];
 			}
 			else
 			{
@@ -767,7 +769,9 @@ class Mongo_Db
 			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
-		if (empty($data) or ! is_array($data))
+		$values = (empty($data) OR ! is_array($data)) ? $this->values : $data;
+
+		if (empty($values) or ! is_array($values))
 		{
 			throw new \Mongo_DbException("Nothing to update in Mongo collection or update is not an array");
 		}
@@ -775,7 +779,7 @@ class Mongo_Db
 		try
 		{
 			$options = array_merge($options, array('fsync' => true, 'multiple' => false));
-			$this->db->{$collection}->update($this->wheres, array('$set' => $data), $options);
+			$this->db->{$collection}->update($this->wheres, array('$set' => $values), $options);
 			$this->_clear();
 			return true;
 		}
@@ -801,14 +805,16 @@ class Mongo_Db
 			throw new \Mongo_DbException("No Mongo collection selected to insert into");
 		}
 
-		if (empty($data) or ! is_array($data))
+		$values = (empty($data) OR ! is_array($data)) ? $this->values : $data;
+
+		if (empty($values) or ! is_array($values))
 		{
 			throw new \Mongo_DbException("Nothing to update in Mongo collection or update is not an array");
 		}
 
 		try
 		{
-			$this->db->{$collection}->update($this->wheres, array('$set' => $data), array('fsync' => true, 'multiple' => true));
+			$this->db->{$collection}->update($this->wheres, array('$set' => $values), array('fsync' => true, 'multiple' => true));
 			$this->_clear();
 			return true;
 		}


### PR DESCRIPTION
Hello,

I have modified the Mongo_Db class and added collection() and set() methods to has it as an optional usage. So we can do something like:

`Mongo_Db::instance()->collection('users')->set(array('name' => 'Isern', 'surname' => 'Palaus'))->insert();`

This will help @tomschlick and me with the development of Mongo_Crud: https://github.com/tomschlick/fuel-mongo-crud and in general to all Mongo_Db users.

Please, @philsturgeon tell us what do you think about.

Thank you!
