### PR TITLE
Return empty array/false if using Finder::locate() with absolute path (when it's not a valid file)

### DIFF
--- a/classes/finder.php
+++ b/classes/finder.php
@@ -275,13 +275,20 @@ class Finder
 	 */
 	public function locate($dir, $file, $ext = '.php', $multiple = false, $cache = true)
 	{
+		$found = $multiple ? array() : false;
+
 		// absolute path requested?
 		if ($file[0] === '/' or $file[1] === ':')
 		{
+			if ( ! is_file($file))
+			{
+				// at this point, found would be either empty array or false
+				return $found;
+			}
+
 			return $multiple ? array($file) : $file;
 		}
 
-		$found = $multiple ? array() : false;
 		$cache_id = $multiple ? 'M.' : 'S.';
 		$paths = array();
 


### PR DESCRIPTION
When using `Finder::search()` with relative path it will check for `is_file()` https://github.com/fuel/core/blob/1.1/develop/classes/finder.php#L332 however the same action doesn't occur when absolute path is provided https://github.com/fuel/core/blob/1.1/develop/classes/finder.php#L279

Signed-off-by: crynobone crynobone@gmail.com
