### PR TITLE
Bugfix read(): Fixed possible session hi-jacking by duplicating previous...

### DIFF
--- a/classes/session/db.php
+++ b/classes/session/db.php
@@ -107,6 +107,8 @@ class Session_Db extends \Session_Driver
 			// record found?
 			if ($this->record->count())
 			{
+                                // previous id used, correctly set session id so it wont be overwritten with previous id.
+                                $this->keys['session_id'] = $this->record->get('session_id');                             
 				$payload = $this->_unserialize($this->record->get('payload'));
 			}
 			else


### PR DESCRIPTION
..._id in database. When previous_id is found it currently overwrites the current session id with previous_id, so the database tables "session_id" & "previous_id" both contain previous_id. If an attacker managed to get the previous_id the owner would be logged out as their session_id is no longer in the database.
