### PR TITLE
fix namespace of HttpException

### DIFF
--- a/classes/httpexception.php
+++ b/classes/httpexception.php
@@ -36,7 +36,7 @@ class HttpNotFoundException extends \Request404Exception
 	}
 }
 
-class HttpServerErrorException extends \HttpException
+class HttpServerErrorException extends HttpException
 {
 	/**
 	 * When this type of exception isn't caught this method is called by


### PR DESCRIPTION
When loading httpexception.php, there is no alias \HttpException yet.
So it causes Class 'HttpException' not found Error.

How to reproduce:

app/myexception.php:

``` php
class MyException extends \HttpException
{
    ...
}
```

``` php
class Controller_Welcome extends Controller
{
    public function action_index()
    {
        throw new MyException('...');
    }
}
```
