### PR TITLE
Fix issue with calling Profiler with profiling off

### DIFF
--- a/classes/profiler.php
+++ b/classes/profiler.php
@@ -14,11 +14,23 @@ class Profiler
 
 	protected static $query = null;
 
+	protected static $initialized = false;
+
+	public static function _init()
+	{
+		static::init();
+	}
+
 	public static function init()
 	{
+		if (static::$initialized)
+		{
+			return;
+		}
 		static::$profiler = new PhpQuickProfiler(FUEL_START_TIME);
 		static::$profiler->queries = array();
 		static::$profiler->queryCount = 0;
+		static::$initialized = true;
 	}
 
 	public static function mark($label)


### PR DESCRIPTION
Having profiling turned off in config, then calling the Profiler, e.g. `\Profiler::mark('Start something');` currently throws an error (`class Console not found`) because the profiler has not yet been initialized. This patch calls `init()` as soon as it's autoloaded.

Ideally, if profiling is turned off, each method would simply return upon being called and the class would never need to be initialized, but it would be ugly to have that code at the beginning of each method. If you think that's a better way to go, I'll gladly make those changes.
