### PR TITLE
Added ANSICON support for color escape sequences on Windows

### DIFF
--- a/classes/cli.php
+++ b/classes/cli.php
@@ -383,7 +383,7 @@ class Cli
 	 */
 	public static function color($text, $foreground, $background = null)
 	{
-		if (static::is_windows())
+		if (static::is_windows() and !Input::server('ANSICON'))
 		{
 			return $text;
 		}


### PR DESCRIPTION
When ANSICON is present in Windows environment variables, the text shall not
be returned immediately when calling Cli::color(), so the escape sequences will be used
to get colors in command line when running on Windows.
