### PR TITLE
Fixed a Bug in Controller_Rest where it was impossible to use overwritten Format

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -146,7 +146,7 @@ abstract class Controller_Rest extends \Controller
 			// Set the correct format header
 			$this->response->set_header('Content-Type', $this->_supported_formats[$this->format]);
 
-			$this->response->body(Format::forge($data)->{'to_'.$this->format}());
+			$this->response->body(\Format::forge($data)->{'to_'.$this->format}());
 		}
 
 		// Format not supported, output directly


### PR DESCRIPTION
Added explicit Namespace `\`, otherwise you are not able to overwrite the `Format` class.
