### PR TITLE
Add the controller_name property to the active Request object.

### DIFF
--- a/classes/request.php
+++ b/classes/request.php
@@ -339,6 +339,7 @@ class Request
 
 		$this->module = $this->route->module;
 		$this->controller = $this->route->controller;
+		$this->controller_name = $this->route->controller_name;
 		$this->action = $this->route->action;
 		$this->method_params = $this->route->method_params;
 		$this->named_params = $this->route->named_params;

--- a/classes/route.php
+++ b/classes/route.php
@@ -46,9 +46,14 @@ class Route
 	public $directory = null;
 
 	/**
-	 * @var  string  controller name
+	 * @var  string  controller class name
 	 */
 	public $controller = null;
+
+	/**
+	 * @var  string  base name of the loaded controller class
+	 */
+	public $controller_name;
 
 	/**
 	 * @var  string  default controller action

--- a/classes/router.php
+++ b/classes/router.php
@@ -147,6 +147,7 @@ class Router
 		if ($info = static::parse_segments($segments, $namespace, $module))
 		{
 			$match->controller = $info['controller'];
+			$match->controller_name = $info['controller_name'];
 			$match->action = $info['action'];
 			$match->method_params = $info['method_params'];
 			return $match;
@@ -163,14 +164,16 @@ class Router
 
 		foreach (array_reverse($segments, true) as $key => $segment)
 		{
-			$class = $namespace.'Controller_'.\Inflector::words_to_upper(implode('_', $temp_segments));
+			$controller_name = implode('_', $temp_segments);
+			$class = $namespace.'Controller_'.\Inflector::words_to_upper($controller_name);
 			array_pop($temp_segments);
 			if (class_exists($class))
 			{
 				return array(
-					'controller'    => $class,
-					'action'        => isset($segments[$key + 1]) ? $segments[$key + 1] : null,
-					'method_params' => array_slice($segments, $key + 2),
+					'controller'      => $class,
+					'controller_name' => $controller_name,
+					'action'          => isset($segments[$key + 1]) ? $segments[$key + 1] : null,
+					'method_params'   => array_slice($segments, $key + 2),
 				);
 			}
 		}


### PR DESCRIPTION
When the controller class name is resolved by the router and saved to the Request
object, this will also save the base controller name along with it.

For example, if the loaded controller class for the request is 'Controller_Welcome',
then the controller_name would be 'welcome'.

It can then be retrieved with the following command :
  Request::active()->controller_name
