### PR TITLE
Validation::add_fields to pass an array containing multiple validation rules at once

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -207,6 +207,28 @@ class Validation
 	}
 
 	/**
+	 * Allows multiple fields to be set with a single array
+	 * @param   string      Field array
+	 * @return  Validation  this, to allow chaining	
+	 */
+	public function add_fields($field_array)
+	{
+		foreach ($field_array as $field)
+		{
+			if (count($field) === 3)
+			{
+				call_user_func_array(array($this, 'add_field'), $field);
+			}
+			else
+			{
+				throw new \InvalidArgumentException('Invalid parameter count for add_fields.');
+			}
+		}
+		
+		return $this;
+	}
+
+	/**
 	 * This will overwrite lang file messages for this validation instance
 	 *
 	 * @param   string


### PR DESCRIPTION
This allows us to add multiple rules to a validation object at once with a single array.

Example:

``` php
$_validation['login'] = array(
    array('username', 'Username', 'required|trim|valid_string[alpha,lowercase,numeric]'),
    array('email', 'Email', 'required|trim|valid_email'),
    array('password', 'Password', 'required|trim')
);

$val = Validation::forge('login')->add_fields($_validation['login']);
if ($val->run())
{
   ...
}


```
