### PR TITLE
fix Log class test not to change log_threshold after running it

### DIFF
--- a/tests/log.php
+++ b/tests/log.php
@@ -21,10 +21,16 @@ namespace Fuel\Core;
 class Test_Log extends TestCase
 {
 
-	public function __construct()
+	public function setUp()
 	{
+		$this->log_threshold = \Config::get('log_threshold');
 		// set the log threshold to a known value
 		\Config::set('log_threshold', Fuel::L_DEBUG);
+	}
+
+	public function tearDown()
+	{
+		\Config::set('log_threshold', $this->log_threshold);
 	}
 
 	/**


### PR DESCRIPTION
Current Log class tests changes log_threshold during testing and does not restore it.
This could change test results which runs after log class tests.
