### PR TITLE
Detect rest accept format by quality

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -191,6 +191,7 @@ abstract class Controller_Rest extends \Controller
 			$next_is_quality = false;
 			foreach ($fragments as $fragment)
 			{
+				$quality = 1;
 				// Skip the fragment if it is a quality score
 				if ($next_is_quality)
 				{
@@ -201,7 +202,6 @@ abstract class Controller_Rest extends \Controller
 				// If next fragment exists and is a quality score, set the quality score
 				elseif ($fragments->hasNext())
 				{
-					$quality = 1;
 					$next = $fragments->getInnerIterator()->current();
 					if (strpos($next, 'q=') === 0)
 					{

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -206,7 +206,6 @@ abstract class Controller_Rest extends \Controller
 					if (strpos($next, 'q=') === 0)
 					{
 						list($key, $quality) = explode('=', $next);
-						$quality = $quality;
 						$next_is_quality = true;
 					}
 				}
@@ -217,8 +216,8 @@ abstract class Controller_Rest extends \Controller
 			// Sort the formats by score in descending order
 			uasort($acceptable, function($a, $b)
 			{
-				$a = (float)$a;
-				$b = (float)$b;
+				$a = (float) $a;
+				$b = (float) $b;
 				return ($a > $b) ? -1 : 1;
 			});
 

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -184,32 +184,56 @@ abstract class Controller_Rest extends \Controller
 		// Otherwise, check the HTTP_ACCEPT (if it exists and we are allowed)
 		if (\Input::server('HTTP_ACCEPT') and \Config::get('rest.ignore_http_accept') !== true)
 		{
-			// Check all formats against the HTTP_ACCEPT header
-			foreach (array_keys($this->_supported_formats) as $format)
+
+			// Split the Accept header and build an array of quality scores for each format
+			$fragments = new \CachingIterator(new \ArrayIterator(preg_split('/[,;]/', \Input::server('HTTP_ACCEPT'))));
+			$acceptable = array();
+			$next_is_quality = false;
+			foreach ($fragments as $fragment)
 			{
-				// Has this format been requested?
-				if (strpos(\Input::server('HTTP_ACCEPT'), $format) !== false)
+				// Skip the fragment if it is a quality score
+				if ($next_is_quality)
 				{
-					// If not HTML or XML assume its right and send it on its way
-					if ($format != 'html' and $format != 'xml')
+					$next_is_quality = false;
+					continue;
+				}
+
+				// If next fragment exists and is a quality score, set the quality score
+				elseif ($fragments->hasNext())
+				{
+					$quality = 1;
+					$next = $fragments->getInnerIterator()->current();
+					if (strpos($next, 'q=') === 0)
+					{
+						list($key, $quality) = explode('=', $next);
+						$quality = $quality;
+						$next_is_quality = true;
+					}
+				}
+
+				$acceptable[$fragment] = $quality;
+			}
+
+			// Sort the formats by score in descending order
+			uasort($acceptable, function($a, $b)
+			{
+				$a = (float)$a;
+				$b = (float)$b;
+				return ($a > $b) ? -1 : 1;
+			});
+
+			// Check each of the acceptable formats against the supported formats
+			foreach ($acceptable as $pattern => $quality)
+			{
+				// The Accept header can contain wildcards in the format
+				$find = array('*', '/');
+				$replace = array('.*', '\/');
+				$pattern = '/^' . str_replace($find, $replace, $pattern) . '$/';
+				foreach ($this->_supported_formats as $format => $mime)
+				{
+					if (preg_match($pattern, $mime))
 					{
 						return $format;
-					}
-
-					// HTML or XML have shown up as a match
-					else
-					{
-						// If it is truly HTML, it wont want any XML
-						if ($format == 'html' and strpos(\Input::server('HTTP_ACCEPT'), 'xml') === false)
-						{
-							return $format;
-						}
-
-						// If it is truly XML, it wont want any HTML
-						elseif ($format == 'xml' and strpos(\Input::server('HTTP_ACCEPT'), 'html') === false)
-						{
-							return $format;
-						}
 					}
 				}
 			}
@@ -381,4 +405,3 @@ abstract class Controller_Rest extends \Controller
 	}
 
 }
-


### PR DESCRIPTION
The current checking of HTTP_ACCEPT only looks to see if a format is in the header but doesn't do anything with the quality scoring.  This makes the search dependent on the order that the formats are defined in `$this->_supported_formats`

This patch will take an Accept header such as:

```
Accept: application/json,application/xml,text/html;q=0.9;text/plain;q=0.8;*/*;q=0.5
```

and assign scores to each format:
- application/json: 1
- application/xml: 1
- text/html: 0.9
- text/plain: 0.8
- _/_: 0.5

The highest scoring format that is supported will be returned.  If multiple supported formats share the same score then the first one is chosen.  Order of same value formats in the Accept header is kept.

Thoughts/comments/merge?
