### PR TITLE
Validation::add_field() should accept an array for list of rules

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -167,14 +167,15 @@ class Validation
 	 *
 	 * @param   string      Field name
 	 * @param   string      Field label
-	 * @param   string      Rules as a piped string
+	 * @param   mixed       Rules as a piped string or an array
 	 * @return  Fieldset_Field  $this to allow chaining
 	 */
 	public function add_field($name, $label, $rules)
 	{
 		$field = $this->add($name, $label);
 
-		$rules = explode('|', $rules);
+		is_string($rules) and $rules = explode('|', $rules);
+
 		foreach ($rules as $rule)
 		{
 			if (($pos = strpos($rule, '[')) !== false)


### PR DESCRIPTION
Instead of preparing each rules as a piped string, it would be nice if we can provide an array.

I had a problem using match_pattern with `|` regex because `Validation::add_field` would assume it a separator between two rule and cause validation can't validate the rules properly.
## Example

```
$val->add_field('gender', 'Gender', 'required|match_pattern[/^(m|f)$/]');
```
## Alternative

I know you can use `$val->add_field('gender', 'Gender')->add_rule('match_pattern', '/^(m|f)$/');` but the pull request should work the same way without much changes.

Signed-off-by: crynobone crynobone@gmail.com
