### PR TITLE
Throws an exception when asset file is not found

### DIFF
--- a/classes/asset/instance.php
+++ b/classes/asset/instance.php
@@ -195,8 +195,13 @@ class Asset_Instance
 			$filename = $item['file'];
 			$attr = $item['attr'];
 
-			if ( ! preg_match('|^(\w+:)?//|', $filename) and ($file = $this->find_file($filename, $type)))
+			if ( ! preg_match('|^(\w+:)?//|', $filename))
 			{
+				if ( ! ($file = $this->find_file($filename, $type)))
+				{
+					throw new \FuelException('Could not find asset: '.$filename);
+				}
+				
 				$raw or $file = $this->_asset_url.$file.($this->_add_mtime ? '?'.filemtime($file) : '');
 			}
 			else


### PR DESCRIPTION
For some reason, the new Asset class no longer throws an exception when asset file is not available. I'm not sure whether this is an expected behavior with the new class but it does help in my use case to be able to do a fallback for asset.

Signed-off-by: crynobone crynobone@gmail.com
