### PR TITLE
Fix an issue with watermark file's extension overriding the original one

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -105,6 +105,9 @@ class Image_Gd extends \Image_Driver
 			$wsizes = $this->sizes($filename);
 			$sizes = $this->sizes();
 
+			// Preserve the previous extension before loading the watermark image
+			$ext = $this->image_extension;
+
 			// Load the watermark preserving transparency
 			$watermark = $this->load($filename, true);
 
@@ -134,6 +137,9 @@ class Image_Gd extends \Image_Driver
 			// Used as a workaround for lack of alpha support in imagecopymerge.
 			$this->debug("Coords for watermark are $x , $y");
 			$this->image_merge($this->image_data, $watermark, $x, $y, $this->config['watermark_alpha']);
+			
+			// Reset the original image extension
+			$this->image_extension = $ext;
 		}
 	}
 


### PR DESCRIPTION
When saving a file with save(), after adding a watermark of any type (e.g. png, gif) makes save() output a file with the same type (but not extension) of the water mark file.
Example:

``` php
<?php
$output = 'filename' // or 'filename.jpg';
Image::forge()->load('file.jpg')->watermark('wm.gif', 'bottom right')->save($output);
Image::forge()->load('file.jpg')->watermark('wm.png', 'bottom right')->save($output);
```

Each would output a a file named filename.jpg but as a gif or png, which happens _only_ when adding a watermark.

So, by simply preserving the extension of the originally loaded file before the watermark function loads its file, the problem is solved.
