### PR TITLE
Fixes

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -65,8 +65,8 @@ abstract class Database_Connection
 				throw new \FuelException("Database type not defined in {$name} configuration");
 			}
 
-			// Set the driver class name
-			$driver = 'Fuel\\Core\\Database_'.ucfirst($config['type']).'_Connection';
+            // Set the driver class name
+            $driver = '\\Database_'.ucfirst($config['type']).'_Connection';
 
 			// Create the database connection instance
 			new $driver($name, $config);

--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -65,8 +65,8 @@ abstract class Database_Connection
 				throw new \FuelException("Database type not defined in {$name} configuration");
 			}
 
-            // Set the driver class name
-            $driver = '\\Database_'.ucfirst($config['type']).'_Connection';
+			// Set the driver class name
+			$driver = '\\Database_' . ucfirst($config['type']) . '_Connection';
 
 			// Create the database connection instance
 			new $driver($name, $config);


### PR DESCRIPTION
Fixed a hard-coded `Fuel\Core\*` class usage for db connection and implmeneted `list_columns()` method on the PDO connection. The implementation was done based on: http://stackoverflow.com/questions/5428262/php-pdo-get-the-columns-name-of-a-table/7091984#7091984
