### PR TITLE
Feature: Support for per-field error messages for validation

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -257,9 +257,10 @@ class Fieldset
 	 * @param   string
 	 * @param   array
 	 * @param   array
+	 * @param   array
 	 * @return  Fieldset_Field
 	 */
-	public function add($name, $label = '', array $attributes = array(), array $rules = array())
+	public function add($name, $label = '', array $attributes = array(), array $rules = array(), array $messages = array())
 	{
 		if ($name instanceof Fieldset_Field)
 		{
@@ -305,7 +306,7 @@ class Fieldset
 			return $field;
 		}
 
-		$this->fields[$name] = new \Fieldset_Field($name, $label, $attributes, $rules, $this);
+		$this->fields[$name] = new \Fieldset_Field($name, $label, $attributes, $rules, $this, $messages);
 
 		return $this->fields[$name];
 	}

--- a/classes/validation/error.php
+++ b/classes/validation/error.php
@@ -86,7 +86,7 @@ class Validation_Error extends \Exception
 
 		if ($msg === false)
 		{
-			$msg = $this->field->fieldset()->validation()->get_message($this->rule);
+			$msg = $this->field->fieldset()->validation()->get_message($this->rule, $this->field, $this->params);
 			$msg = $msg === false
 				? \Lang::get('validation.'.$this->rule) ?: \Lang::get('validation.'.\Arr::get(explode(':', $this->rule), 0))
 				: $msg;


### PR DESCRIPTION
### Messages in general

Messages can be set to the a specific field and specific rule for the field, even a specific combination of rule and rule parameters.

For instance you can set message to just `min_length` or specifically to `min_length[3]`

Set message(s) at the time of declaration of the field.

``` php
$val->add_field('username', 'Your username', 'required|min_length[5]', array(
     'required' => 'We need the username, come on',
     'min_length[5]' => 'More!'
));
```

Or via a method call afterwards:

``` php
$val->add_field('username',  'Your username', 'required|min_length[5]')
    ->set_message('min_length', 'More!');
```

Even if the validation rule is set in another manner:

``` php
$field = $val->add_field('username', 'Your username', 'required')->add_rule('min_length', 5);
$field ->set_message('min_length[5]' ,'More!');
```

If the arguments of the validation rule cannot be represented as a string that's readable to humans (like array, objects,..) than you can:
- write a validator class
- or add a named closure
### Named closure as validator is passed :

``` php
$field->add_rule(array('complex_rule'=>function($val, $arg1, $arg2..){ }));
```

So that you can set a error message for `complex_rule`
