### PR TITLE
Feature: Nested db transactions

### DIFF
--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -42,6 +42,11 @@ class Database_MySQL_Connection extends \Database_Connection
 	protected $_in_transaction = false;
 
 	/**
+	 * @var  bool  Allows nested transactions
+	 */
+	protected $_transaction_level = 0;
+
+	/**
 	 * @var  string  Which kind of DB is used
 	 */
 	public $_db_type = 'mysql';
@@ -412,25 +417,62 @@ class Database_MySQL_Connection extends \Database_Connection
 
 	public function start_transaction()
 	{
-		$this->query(0, 'SET AUTOCOMMIT=0', false);
-		$this->query(0, 'START TRANSACTION', false);
+		if ($this->_transaction_level>0)
+		{
+			//error is never fired
+			$this->query(0, "SAVEPOINT LEVEL{$this->_transaction_level}", false);
+		}
+		else
+		{
+			//error is never fired
+			$this->query(0, 'SET AUTOCOMMIT=0', false);
+			$this->query(0, 'START TRANSACTION', false);
+		}
 		$this->_in_transaction = true;
-		return true;
+		$this->_transaction_level++;
+		return $this->_in_transaction;
 	}
 
 	public function commit_transaction()
 	{
-		$this->query(0, 'COMMIT', false);
-		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
+		$this->_transaction_level--;
+		if ($this->_transaction_level!=0)
+		{
+			//fires an exception if such savepoint doesn't exist
+			$this->exec("RELEASE SAVEPOINT LEVEL{$this->_transaction_level}");
+		}
+		else
+		{
+			$this->_in_transaction = false;
+			//when this method is called without start_transaction before that
+			//_transaction_level is negative
+			$this->_transaction_level = 0;
+			//fire no error if called before start_transaction was called
+			$this->query(0, 'COMMIT', false);
+			$this->query(0, 'SET AUTOCOMMIT=1', false);
+		}
+
 		return true;
 	}
 
 	public function rollback_transaction()
 	{
-		$this->query(0, 'ROLLBACK', false);
-		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
+		$this->_transaction_level--;
+
+		if ($this->_transaction_level!=0)
+		{
+			$this->exec("ROLLBACK TO SAVEPOINT LEVEL{$this->_transaction_level}");
+		}
+		else
+		{
+			$this->_in_transaction = false;
+			//when this method is called without start_transaction before that
+			//_transaction_level is negative
+			$this->_transaction_level = 0;
+			//fires no error if called before start_transaction was called
+			$this->query(0, 'ROLLBACK', false);
+			$this->query(0, 'SET AUTOCOMMIT=1', false);
+		}
 		return true;
 	}
 

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -46,6 +46,11 @@ class Database_MySQLi_Connection extends \Database_Connection
 	protected $_in_transaction = false;
 
 	/**
+	 * @var  bool  Allows nested transactions
+	 */
+	protected $_transaction_level = 0;
+
+	/**
 	 * @var  string  Which kind of DB is used
 	 */
 	public $_db_type = 'mysql';

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -427,25 +427,62 @@ class Database_MySQLi_Connection extends \Database_Connection
 
 	public function start_transaction()
 	{
-		$this->query(0, 'SET AUTOCOMMIT=0', false);
-		$this->query(0, 'START TRANSACTION', false);
+		if ($this->_transaction_level>0)
+		{
+			//error is never fired
+			$this->query(0, "SAVEPOINT LEVEL{$this->_transaction_level}", false);
+		}
+		else
+		{
+			//error is never fired
+			$this->query(0, 'SET AUTOCOMMIT=0', false);
+			$this->query(0, 'START TRANSACTION', false);
+		}
 		$this->_in_transaction = true;
-		return true;
+		$this->_transaction_level++;
+		return $this->_in_transaction;
 	}
 
 	public function commit_transaction()
 	{
-		$this->query(0, 'COMMIT', false);
-		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
+		$this->_transaction_level--;
+		if ($this->_transaction_level!=0)
+		{
+			//fires an exception if such savepoint doesn't exist
+			$this->exec("RELEASE SAVEPOINT LEVEL{$this->_transaction_level}");
+		}
+		else
+		{
+			$this->_in_transaction = false;
+			//when this method is called without start_transaction before that
+			//_transaction_level is negative
+			$this->_transaction_level = 0;
+			//fire no error if called before start_transaction was called
+			$this->query(0, 'COMMIT', false);
+			$this->query(0, 'SET AUTOCOMMIT=1', false);
+		}
+
 		return true;
 	}
 
 	public function rollback_transaction()
 	{
-		$this->query(0, 'ROLLBACK', false);
-		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
+		$this->_transaction_level--;
+
+		if ($this->_transaction_level!=0)
+		{
+			$this->exec("ROLLBACK TO SAVEPOINT LEVEL{$this->_transaction_level}");
+		}
+		else
+		{
+			$this->_in_transaction = false;
+			//when this method is called without start_transaction before that
+			//_transaction_level is negative
+			$this->_transaction_level = 0;
+			//fires no error if called before start_transaction was called
+			$this->query(0, 'ROLLBACK', false);
+			$this->query(0, 'SET AUTOCOMMIT=1', false);
+		}
 		return true;
 	}
 

--- a/classes/db.php
+++ b/classes/db.php
@@ -22,6 +22,16 @@ class DB
 	const UPDATE =  3;
 	const DELETE =  4;
 
+	/**
+	 * Array describing workaround mechanisms for certain type of non-globally supported actions across db types
+	 *
+	 * @var array
+	 */
+	public static $workarounds = array(
+		'nested_transactions' => array(
+			'savepoint' => array('mysql', 'pgsql')
+		)
+	);
 	public static $query_count = 0;
 
 


### PR DESCRIPTION
Allowing the multiple `\DB::start_transaction()` usage, so that saving of objects can be delegated to autonomous methods.
#### Reference:
- http://blog.ekini.net/2010/03/05/zend-framework-how-to-use-nested-transactions-with-zend_db-and-mysql/
- http://framework.zend.com/wiki/display/ZFPROP/Nested+Transaction+Support+for+Zend_Db_Adapter_Abstract+-+Bryce+Lohr
