### PR TITLE
fix Form class dont_prep does not work correctly

### DIFF
--- a/classes/form/instance.php
+++ b/classes/form/instance.php
@@ -213,8 +213,8 @@ class Form_Instance
 		if ($this->get_config('prep_value', true) && empty($attributes['dont_prep']))
 		{
 			$attributes['value'] = $this->prep_value($attributes['value']);
-			unset($attributes['dont_prep']);
 		}
+		unset($attributes['dont_prep']);
 
 		if (empty($attributes['id']) && $this->get_config('auto_id', false) == true)
 		{
@@ -440,8 +440,8 @@ class Form_Instance
 		if ($this->get_config('prep_value', true) && empty($attributes['dont_prep']))
 		{
 			$value = $this->prep_value($value);
-			unset($attributes['dont_prep']);
 		}
+		unset($attributes['dont_prep']);
 
 		if (empty($attributes['id']) && $this->get_config('auto_id', false) == true)
 		{
@@ -499,7 +499,7 @@ class Form_Instance
 		$current_obj =& $this;
 
 		// closure to recusively process the options array
-		$listoptions = function (array $options, $selected, $level = 1) use (&$listoptions, &$current_obj)
+		$listoptions = function (array $options, $selected, $level = 1) use (&$listoptions, &$current_obj, &$attributes)
 		{
 			$input = PHP_EOL;
 			foreach ($options as $key => $val)
@@ -513,13 +513,16 @@ class Form_Instance
 				else
 				{
 					$opt_attr = array('value' => $key, 'style' => 'text-indent: '.(10*($level-1)).'px;');
-					(in_array((string)$key, $selected, TRUE)) && $opt_attr[] = 'selected';
+					(in_array((string)$key, $selected, true)) && $opt_attr[] = 'selected';
 					$input .= str_repeat("\t", $level);
 					$opt_attr['value'] = ($current_obj->get_config('prep_value', true) && empty($attributes['dont_prep'])) ?
 						$current_obj->prep_value($opt_attr['value']) : $opt_attr['value'];
+					$val = ($current_obj->get_config('prep_value', true) && empty($attributes['dont_prep'])) ?
+						$current_obj->prep_value($val) : $val;
 					$input .= html_tag('option', $opt_attr, $val).PHP_EOL;
 				}
 			}
+			unset($attributes['dont_prep']);
 
 			return $input;
 		};

--- a/tests/form.php
+++ b/tests/form.php
@@ -20,5 +20,106 @@ namespace Fuel\Core;
  */
 class Test_Form extends TestCase
 {
- 	public function test_foo() {}
+	/**
+	* Tests Form::input()
+	*
+	* test for data prepping
+	*
+	* @test
+	*/
+	public function test_input_prep()
+	{
+		$output = Form::input('name', '"\'H&M\'"');
+		$expected = '<input name="name" value="&quot;&#39;H&amp;M&#39;&quot;" type="text" id="form_name" />';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	* Tests Form::input()
+	*
+	* test for dont_prep
+	*
+	* @test
+	*/
+	public function test_input_dont_prep()
+	{
+		$output = Form::input('name', '&quot;&#39;H&amp;M&#39;&quot;', array('dont_prep' => true));
+		$expected = '<input name="name" value="&quot;&#39;H&amp;M&#39;&quot;" type="text" id="form_name" />';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	* Tests Form::textarea()
+	*
+	* test for data prepping
+	*
+	* @test
+	*/
+	public function test_textarea_prep()
+	{
+		$output = Form::textarea('name', '"\'H&M\'"');
+		$expected = '<textarea name="name" id="form_name">&quot;&#39;H&amp;M&#39;&quot;</textarea>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	* Tests Form::textarea()
+	*
+	* test for dont_prep
+	*
+	* @test
+	*/
+	public function test_textarea_dont_prep()
+	{
+		$output = Form::textarea('name', '&quot;&#39;H&amp;M&#39;&quot;', array('dont_prep' => true));
+		$expected = '<textarea name="name" id="form_name">&quot;&#39;H&amp;M&#39;&quot;</textarea>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	* Tests Form::select()
+	*
+	* test for data prepping
+	*
+	* @test
+	*/
+	public function test_select_prep()
+	{
+		$output = Form::select('fieldname', null,
+			array(
+						'key_H&M' => 'val_H&M',
+						'key_"\'"' => 'val_"\'"',
+			)
+		);
+		$expected = '<select name="fieldname" id="form_fieldname">
+	<option value="key_H&amp;M" style="text-indent: 0px;">val_H&amp;M</option>
+	<option value="key_&quot;&#39;&quot;" style="text-indent: 0px;">val_&quot;&#39;&quot;</option>
+</select>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	* Tests Form::select()
+	*
+	* test for dont_prep
+	*
+	* @test
+	*/
+	public function test_select_dont_prep()
+	{
+		$output = Form::select('fieldname', null,
+			array(
+						'key_H&amp;M' => 'val_H&amp;M',
+						'key_&quot;&#39;&quot;' => 'val_&quot;&#39;&quot;',
+			),
+			array(
+						'dont_prep' => true,
+			)
+		);
+		$expected = '<select name="fieldname" id="form_fieldname">
+	<option value="key_H&amp;M" style="text-indent: 0px;">val_H&amp;M</option>
+	<option value="key_&quot;&#39;&quot;" style="text-indent: 0px;">val_&quot;&#39;&quot;</option>
+</select>';
+		$this->assertEquals($expected, $output);
+	}
 }


### PR DESCRIPTION
- remove "dont_prep" atrribute shown in output HTML
- fix dont_prep of Form::select does not work
- fix Form::select does not prep option tag contents
- add tests
