### PR TITLE
str_sep for Upload class

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -81,6 +81,7 @@ class Upload
 		'overwrite'       => false,
 		'randomize'       => false,
 		'normalize'       => false,
+		'str_sep'         => '-',
 		'change_case'     => false,
 		'ftp_mode'        => 'auto',
 		'ftp_permissions' => null
@@ -539,7 +540,7 @@ class Upload
 				$filename  = $file['filename'];
 				if ( (bool) static::$config['normalize'])
 				{
-					$filename = \Inflector::friendly_title($filename, '_');
+					$filename = \Inflector::friendly_title($filename, static::$config['str_sep']);
 				}
 			}
 

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -81,7 +81,7 @@ class Upload
 		'overwrite'       => false,
 		'randomize'       => false,
 		'normalize'       => false,
-		'str_sep'         => '_',
+		'normalize_separator' => '_',
 		'change_case'     => false,
 		'ftp_mode'        => 'auto',
 		'ftp_permissions' => null
@@ -540,7 +540,7 @@ class Upload
 				$filename  = $file['filename'];
 				if ( (bool) static::$config['normalize'])
 				{
-					$filename = \Inflector::friendly_title($filename, static::$config['str_sep']);
+					$filename = \Inflector::friendly_title($filename, static::$config['normalize_separator']);
 				}
 			}
 

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -81,7 +81,7 @@ class Upload
 		'overwrite'       => false,
 		'randomize'       => false,
 		'normalize'       => false,
-		'str_sep'         => '-',
+		'str_sep'         => '_',
 		'change_case'     => false,
 		'ftp_mode'        => 'auto',
 		'ftp_permissions' => null


### PR DESCRIPTION
Allows the developer to change the default underscore to something else in the config of the upload file.

[Here’s the Docs](https://github.com/fuel/docs/pull/316) for it.
