### PR TITLE
Curl now responds with something useful if curl succeeds but gets >=400 ...

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -188,6 +188,7 @@ function setup_autoloader()
 		'Fuel\\Core\\Request404Exception'  => COREPATH.'classes/request.php',
 		'Fuel\\Core\\Request_Driver'       => COREPATH.'classes/request/driver.php',
 		'Fuel\\Core\\RequestException'     => COREPATH.'classes/request/driver.php',
+		'Fuel\\Core\\RequestStatusException'    => COREPATH.'classes/request/driver.php',
 		'Fuel\\Core\\Request_Curl'         => COREPATH.'classes/request/curl.php',
 		'Fuel\\Core\\Request_Soap'         => COREPATH.'classes/request/soap.php',
 

--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -163,10 +163,10 @@ class Request_Curl extends \Request_Driver
 			$this->set_defaults();
 			throw new \RequestException(curl_error($connection), curl_errno($connection));
 		}
-		else if ($this->response->status >= 400)
+		elseif ($this->response->status >= 400)
 		{
 			$this->set_defaults();
-			throw new \RequestException($body, $this->response->status);
+			throw new \RequestStatusException($body, $this->response->status);
 		}
 		else
 		{

--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -158,10 +158,15 @@ class Request_Curl extends \Request_Driver
 		$this->set_response($body, $this->response_info('http_code', 200), $mime);
 
 		// Request failed
-		if ($body === false or $this->response->status >= 400)
+		if ($body === false)
 		{
 			$this->set_defaults();
 			throw new \RequestException(curl_error($connection), curl_errno($connection));
+		}
+		else if ($this->response->status >= 400)
+		{
+			$this->set_defaults();
+			throw new \RequestException($body, $this->response->status);
 		}
 		else
 		{

--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -3,7 +3,7 @@
 namespace Fuel\Core;
 
 class RequestException extends \HttpNotFoundException {}
-class RequestStatusException extends RequestException {}
+class RequestStatusException extends \RequestException {}
 
 abstract class Request_Driver
 {

--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -3,6 +3,7 @@
 namespace Fuel\Core;
 
 class RequestException extends \HttpNotFoundException {}
+class RequestStatusException extends RequestException {}
 
 abstract class Request_Driver
 {


### PR DESCRIPTION
...HTTP status

If curl performs correctly but gets, for example, a 401 from the server, there was no way of getting what went wrong just that 'something' went wrong.

If curl performs correctly, it now sets the error message and number when throwing the exception to the request body and http status respectively.

I hope this is the right implementation! It shouldn't break other people's set ups as it just adds more information.

Rob McCann
