### PR TITLE
Fuel constants should be saved as constants not string values in config files

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -126,7 +126,7 @@ class Config
 <?php
 
 CONF;
-		$content .= 'return '.str_replace(array('  ', 'array ('), array("\t", 'array('), var_export($config, true)).";\n";
+		$content .= 'return '.str_replace(array('  ', 'array (', '\''.APPPATH, '\''.DOCROOT, '\''.COREPATH), array("\t", 'array(', 'APPPATH.\'', 'DOCROOT.\'', 'COREPATH.\''), var_export($config, true)).";\n";
 
 		if ( ! $path = \Finder::search('config', $file, '.php'))
 		{


### PR DESCRIPTION
I noticed that while saving configs, constants such as APPPATH are being exported to strings and written in that form in php files.

```
'cache_dir' => 'var/www/fuel/app/cache/',
```

Now, every constant found at the beginning of the string is replaced by its name:

```
'cache_dir' => APPPATH.'cache/',
```
