### PR TITLE
fix for profiler and array of objects

### DIFF
--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -263,13 +263,14 @@ $printarray = function($items, $depth, &$class, &$count) use(&$printarray)
 		{
 			$output .= '<b>null</b>';
 		}
-		elseif( ! is_array($value))
+		elseif( ! is_array($value) AND ! is_object($value))
 		{
 			$output .= '<b>'.$value.'</b>';
 		}
 		$output .= str_repeat('&rsaquo;&nbsp;', $depth).$item.'</td></tr>';
 		if($class == '') $class = 'alt'; else $class = '';
 		is_array($value) and $output .= $printarray($value, $depth + 1, $class, $count);
+		is_object($value) and $output .= $printarray($value, $depth + 1, $class, $count);
 	}
 	return $output;
 };


### PR DESCRIPTION
I was getting an error: 'object can`t be converted to string',  while in session I had array of objects - this is a quick fix for that.
