### PR TITLE
Specify which fields are safe to "expose" in a REST Controller

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -44,38 +44,18 @@ abstract class Controller_Rest extends \Controller
 		'csv' => 'application/csv'
 	);
 
+	/**
+	 * @var  array  contains a list of model fields which can be exposed on an API
+	 */
 	protected $_exposable = array();
 
+	/**
+	 * Exposable computed/dynamic model fields
+	 * 
+	 * @param  Model $model The current model to computed exposable fields on
+	 * @return array computed/dynamic fields to expose
+	 */
 	protected function _exposable($model) {}
-
-	public function expose($models)
-	{
-		$exposed = array();
-		if (is_array($models))
-		{
-			foreach ($models as $model)
-			{
-				$exposed[] = $this->_expose_one($model);
-			}
-		}
-		else {
-			$exposed[] = $this->_expose_one($models);
-		}
-		return $exposed;
-	}
-
-	protected function _expose_one($model)
-	{
-		$exposed = array();
-		foreach ($this->_exposable as $key)
-		{
-			$exposed[$key] = $model->$key;
-		}
-		$dynamic = $this->_exposable($model);
-		if (is_array($dynamic))
-			return array_merge($exposed, $dynamic);
-		return $exposed;
-	}
 
 	public function before()
 	{
@@ -305,6 +285,44 @@ abstract class Controller_Rest extends \Controller
 
 		// Nope, just return the string
 		return $lang;
+	}
+
+	/**
+	 * Expose
+	 * 
+	 * Get exposable data for model(s) provided. Will expose fields specified in the
+	 * $_exposable array and any computed fields returned in an array from the _exposable()
+	 * function
+	 * @param  array/model $models Model(s) to expose
+	 * @return array
+	 */
+	public function expose($models)
+	{
+		$exposed = array();
+		if (is_array($models))
+		{
+			foreach ($models as $model)
+			{
+				$exposed[] = $this->_expose_one($model);
+			}
+		}
+		else {
+			$exposed[] = $this->_expose_one($models);
+		}
+		return $exposed;
+	}
+
+	protected function _expose_one($model)
+	{
+		$exposed = array();
+		foreach ($this->_exposable as $key)
+		{
+			$exposed[$key] = $model->$key;
+		}
+		$dynamic = $this->_exposable($model);
+		if (is_array($dynamic))
+			return array_merge($exposed, $dynamic);
+		return $exposed;
 	}
 
 	// SECURITY FUNCTIONS ---------------------------------------------------------

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -44,12 +44,9 @@ abstract class Controller_Rest extends \Controller
 		'csv' => 'application/csv'
 	);
 
-	protected $exposable = array();
+	protected $_exposable = array();
 
-	protected function exposable($model)
-	{
-		return;
-	}
+	protected function _exposable($model) {}
 
 	public function expose($models)
 	{
@@ -62,7 +59,7 @@ abstract class Controller_Rest extends \Controller
 			}
 		}
 		else {
-			$exposed[] = $this->_expose_one($model);
+			$exposed[] = $this->_expose_one($models);
 		}
 		return $exposed;
 	}
@@ -70,12 +67,14 @@ abstract class Controller_Rest extends \Controller
 	protected function _expose_one($model)
 	{
 		$exposed = array();
-		foreach ($this->exposable as $key)
+		foreach ($this->_exposable as $key)
 		{
 			$exposed[$key] = $model->$key;
 		}
-		$dynamic = $this->exposable($model);
-		return array_merge($exposed, $dynamic);
+		$dynamic = $this->_exposable($model);
+		if (is_array($dynamic))
+			return array_merge($exposed, $dynamic);
+		return $exposed;
 	}
 
 	public function before()

--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -44,6 +44,40 @@ abstract class Controller_Rest extends \Controller
 		'csv' => 'application/csv'
 	);
 
+	protected $exposable = array();
+
+	protected function exposable($model)
+	{
+		return;
+	}
+
+	public function expose($models)
+	{
+		$exposed = array();
+		if (is_array($models))
+		{
+			foreach ($models as $model)
+			{
+				$exposed[] = $this->_expose_one($model);
+			}
+		}
+		else {
+			$exposed[] = $this->_expose_one($model);
+		}
+		return $exposed;
+	}
+
+	protected function _expose_one($model)
+	{
+		$exposed = array();
+		foreach ($this->exposable as $key)
+		{
+			$exposed[$key] = $model->$key;
+		}
+		$dynamic = $this->exposable($model);
+		return array_merge($exposed, $dynamic);
+	}
+
 	public function before()
 	{
 		parent::before();


### PR DESCRIPTION
On a recent project I've been building a RESTful API atop Fuel and we found specifying which database fields to expose via the API painful (writing in multiple places etc.). So I wrote in a few helper methods to allow each of our resources to specify exactly which fields to expose, and even the ability to expose computed/dynamic fields.

As a run-down, imagine we have a Users resource with the following fields:
- id
- username
- email
- password
- location
- first_name
- last_name
- last_login_ip
- created_at
- updated_at

On our API we want to expose this data, but let's say we don't want to expose the `password`, `last_login_ip`, `created_at` or `updated_at` fields. In our Controller we can specify exactly which fields to expose with the `$_exposable` variable:

``` php
<?php
protected $_exposable = array(
    'id',
    'username',
    'email',
    'location',
    'first_name',
    'last_name',
);
```

We can optionally also expose computed/dynamic fields by specifying an `_exposable` _function_ in our Controller which returns an array with additional fields to merge in. For example, let's also expose a `name` field which combines the first and last name fields:

``` php
<?php
protected function _exposable($model)
{
    return array(
        'name' => $model->first_name.' '.$model->last_name,
    );
}
```

Exposing our specified fields is now as simple as doing something like:

``` php
<?php
public function get_index()
{
    $models = Model_User::find_all();
    $expose = Model_User::expose($models);
    return $this->response($expose, 200);
}
```

Looking for any criticisms/feedback on this; I haven't looked into whether I need to write tests, or what sort of documentation to write just yet. I've found this sort of functionality to be incredibly useful when building APIs.
