### PR TITLE
Unnecessary line / variable

### DIFF
--- a/classes/debug.php
+++ b/classes/debug.php
@@ -53,7 +53,6 @@ class Debug
 		}
 
 		$arguments = func_get_args();
-		$total_arguments = count($arguments);
 
 		$callee['file'] = \Fuel::clean_path($callee['file']);
 


### PR DESCRIPTION
The variable isn't used in the dump function because of $count variable.
