### PR TITLE
Save raw SQL for profiler's use with EXPLAIN

### DIFF
--- a/classes/profiler.php
+++ b/classes/profiler.php
@@ -50,6 +50,7 @@ class Profiler
 		if (static::$profiler)
 		{
 			static::$query = array(
+				'raw_sql' => $sql,
 				'sql' => \Security::htmlentities($sql),
 				'time' => static::$profiler->getMicroTime(),
 			);

--- a/vendor/phpquickprofiler/phpquickprofiler.php
+++ b/vendor/phpquickprofiler/phpquickprofiler.php
@@ -132,7 +132,7 @@ class PhpQuickProfiler {
 		{
 			$rs = false;
 			try {
-				$sql = 'EXPLAIN '.$query['sql'];
+				$sql = 'EXPLAIN '.$query['raw_sql'];
 				$rs = \DB::query($sql, \DB::SELECT)->execute();
 			}
 			catch(Exception $e)


### PR DESCRIPTION
Currently PHPQuickProfiler runs an EXPLAIN query for any saved SELECT queries, but it builds the EXPLAIN using the SQL that has already been escaped for output.  This is a simple patch to save the raw SQL and use that instead.
