### PR TITLE
Renders the field based on the tag instead of the type (when specified)

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -392,7 +392,7 @@ class Fieldset_Field
 			$this->set_attribute('id', $auto_id);
 		}
 
-		switch($this->type)
+		switch(!empty($this->attributes['tag']) ? $this->attributes['tag'] : $this->type)
 		{
 			case 'hidden':
 				$build_field = $form->hidden($this->name, $this->value, $this->attributes);

--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -392,7 +392,7 @@ class Fieldset_Field
 			$this->set_attribute('id', $auto_id);
 		}
 
-		switch(!empty($this->attributes['tag']) ? $this->attributes['tag'] : $this->type)
+		switch( ! empty($this->attributes['tag']) ? $this->attributes['tag'] : $this->type)
 		{
 			case 'hidden':
 				$build_field = $form->hidden($this->name, $this->value, $this->attributes);


### PR DESCRIPTION
This is the continuation to allow `<button type="submit">`
