### PR TITLE
changed handling of constraint to cater for easier definition of enums.

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -284,9 +284,20 @@ class DBUtil
 			$sql .= \DB::quote_identifier($field);
 			$sql .= array_key_exists('NAME', $attr) ? ' '.\DB::quote_identifier($attr['NAME']).' ' : '';
 			$sql .= array_key_exists('TYPE', $attr) ? ' '.$attr['TYPE'] : '';
-			$sql .= array_key_exists('CONSTRAINT', $attr) ? '('.$attr['CONSTRAINT'].')' : '';
 			$sql .= array_key_exists('CHARSET', $attr) ? static::process_charset($attr['CHARSET']) : '';
-
+			
+			if(array_key_exists('CONSTRAINT',$attr))
+			{
+				if(is_array($attr['CONSTRAINT']))
+				{
+					$sql .= "('".implode("', '",$attr['CONSTRAINT'])."')";
+				}
+				else
+				{
+					$sql .= '('.$attr['CONSTRAINT'].')';
+				}
+			}
+			
 			if (array_key_exists('UNSIGNED', $attr) and $attr['UNSIGNED'] === true)
 			{
 				$sql .= ' UNSIGNED';


### PR DESCRIPTION
Current syntax for defining an enum in an add fields statement is:

'origin' => array('type' => 'enum','constraint' => "'foo','bar'"),

I don't think this fits correctly in with the way fuel works in pretty much every other case where arguments like those would be specified in an array.
With my change you can specify as follows:

'origin' => array('type' => 'enum','constraint' => array('foo','bar')),
