### PR TITLE
Removing static keyword from radio method.

### DIFF
--- a/classes/form/instance.php
+++ b/classes/form/instance.php
@@ -284,7 +284,7 @@ class Form_Instance
 	 * @param   array
 	 * @return  string
 	 */
-	public static function radio($field, $value = null, $checked = null, array $attributes = array())
+	public function radio($field, $value = null, $checked = null, array $attributes = array())
 	{
 		if (is_array($field))
 		{


### PR DESCRIPTION
# Request

Since a recent update when a Model specifies a form type as radio and the options are then parsed using set_options() and error is triggered because an instance of "$this" doesn't exist statically (similarly to the checkbox update).
# Example

``` php
protected static $_properties = array(
    'visibility' => array(
        'data_type' => 'enum',
        'label' => 'Visibility',
        'default' => '0',
        'validation' => array(
            'required'
        ),
        'form' => array(
            'type' => 'radio', // checkbox is fine (But a radio group is needed).
            'options' => array(0 => 'Invisible', 1 => 'Visible')
        )
    )
);
```
