### PR TITLE
Inflector::words_to_upper() supports others separator types.

### DIFF
--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -341,9 +341,9 @@ class Inflector
 	 * @param   string  separator
 	 * @return  string
 	 */
-	public static function words_to_upper($class, $separator = '_')
+	public static function words_to_upper($class, $sep = '_')
 	{
-		return str_replace(' ', $separator, ucwords(str_replace($separator, ' ', $class)));
+		return str_replace(' ', $sep, ucwords(str_replace($sep, ' ', $class)));
 	}
 
 	/**

--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -338,11 +338,12 @@ class Inflector
 	 * Takes an underscored classname and uppercases all letters after the underscores.
 	 *
 	 * @param   string  classname
+	 * @param   string  separator
 	 * @return  string
 	 */
-	public static function words_to_upper($class)
+	public static function words_to_upper($class, $separator = '_')
 	{
-		return str_replace(' ', '_', ucwords(str_replace('_', ' ', $class)));
+		return str_replace(' ', $separator, ucwords(str_replace($separator, ' ', $class)));
 	}
 
 	/**


### PR DESCRIPTION
This could be useful when you need to ucwords other formats, for example module::method.

Let me know if this will be accepted then i will pull this change to the docs.
