### PR TITLE
Small fixes.

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -135,7 +135,7 @@ class Input
 		if ( ! empty($uri_info['extension']))
 		{
 			static::$detected_ext = $uri_info['extension'];
-			$uri = $uri_info['dirname'].'/'.$uri_info['filename'];
+			$uri =  ltrim($uri_info['dirname'], '\\/').'/'.$uri_info['filename'];
 		}
 
 		// Do some final clean up of the uri

--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -76,6 +76,15 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 	}
 
 	/**
+	 * Access to the table name
+	 *
+	 * @return string The table name
+	 */
+	public static function get_table_name() {
+		return static::$_table_name;
+	}
+
+	/**
 	 * Finds a row with the given primary key value.
 	 *
 	 * @param   mixed  $value  The primary key value to find


### PR DESCRIPTION
### URI

Fixes a problem when an extension is detected in the URI and there is no slashes in the URI besides the first one. In this case `pathinfo()` will return "\" or "/" as "dirname" .
#### Example

If we load a url like `www.example.com/my-first-page.html` we expect the URI to be `/my-first-page.html` but:
- on windows it will be `\/my-first-page.html`
- on unix based platforms it will be `//my-first-page.html`
### The other change

Just adding a getter for the `Model_Crud` `$_table_name`.
