### PR TITLE
return after finding migrations for the specific module, merge the files...

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -472,6 +472,10 @@ class Migrate
 			foreach (\Config::get('module_paths') as $m)
 			{
 				$files = glob($m .$name.'/'.\Config::get('migrations.folder').'*_*.php');
+				if (count($files))
+				{
+					break;
+				}
 			}
 		}
 		else
@@ -479,7 +483,7 @@ class Migrate
 			// find all modules
 			foreach (\Config::get('module_paths') as $m)
 			{
-				$files = glob($m.'*/'.\Config::get('migrations.folder').'*_*.php');
+				$files = array_merge($files, glob($m.'*/'.\Config::get('migrations.folder').'*_*.php'));
 			}
 		}
 


### PR DESCRIPTION
... when getting migrations for all modules.

This fixes the issue that occurs when searching for migrations for a specific module , within many module paths and the files array is overridden with only the result from looking in the last module path.

Also this fixes the problem of only getting the last modules migration files if you are trying to get migration files for all modules.
