### PR TITLE
Look for the file in the list of currently installed migration files.

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -389,7 +389,7 @@ class Migrate
 			if ((is_null($start) or $migration > $start) and (is_null($end) or $migration <= $end))
 			{
 				// see if it is already installed
-				if ( in_array($migration, $current))
+				if ( in_array(basename($file), $current))
 				{
 					// already installed. store it only if we're going down
 					$direction == 'down' and $migrations[$migration] = array('path' => $file);


### PR DESCRIPTION
Fix the issue of 'already on the first migration' when running migrate:down with installed migrations.

Also, are migrate:up and migrate:down meant to only execute a single migration? it currently runs all of the installed migrations - if this is not the desired behavior then I'll fix that with another commit.
