### PR TITLE
fixed array_merge() error in Finder::list_files()

### DIFF
--- a/classes/finder.php
+++ b/classes/finder.php
@@ -257,7 +257,10 @@ class Finder
 		$found = array();
 		foreach ($paths as $path)
 		{
-			$found = array_merge(glob($path.$directory.'/'.$filter), $found);
+			if (($f = glob($path.$directory.DS.$filter)) !== false)
+			{
+				$found = array_merge($f, $found);
+			}
 		}
 
 		return $found;


### PR DESCRIPTION
glob() returns false on error - See [1]. So array_merge() will fail.

[1] http://php.net/manual/en/function.glob.php
