### PR TITLE
Fix for Migrate::_find_migrations when $start or $end are not of the form '00x_...'

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -373,12 +373,14 @@ class Migrate
 		// normalize start and end values
 		if ( ! is_null($start))
 		{
-			$start = ltrim(substr($start, 0, strpos($start, '_')), '0');
+			$start = ($pos = strpos($start, '_')) ? substr($start, 0, $pos) : $start;
+			$start = ltrim(substr($start, 0, strpos($start, '_') || strlen($start)), '0');
 			is_numeric($start) and $start = (int) $start;
 		}
 		if ( ! is_null($end))
 		{
-			$end = ltrim(substr($end, 0, strpos($end, '_')), '0');
+			$end = ($pos = strpos($end, '_')) ? substr($end, 0, $pos) : $end;
+			$end = ltrim($end, '0');
 			is_numeric($end) and $end = (int) $end;
 		}
 


### PR DESCRIPTION
_find_migrations() can receive $start and $end as either ints, a simple number string (007) OR as a migration file name (007_create...).

This should patch the detection of the $start and $end to work when receiving the int / numeric only strings which do not contain the _'s which previously resulted in the $start/$end going to empty strings when no '_' was found
