### PR TITLE
Added a way to change a Fieldset's tag

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -206,6 +206,16 @@ class Fieldset
 	}
 
 	/**
+	 * Set the tag to be used for this fieldset
+	 *
+	 * @param  string  $tag
+	 */
+	public function set_fieldset_tag($tag)
+	{
+		$this->fieldset_tag = $tag;
+	}
+
+	/**
 	 * Set the parent Fieldset instance
 	 *
 	 * @param   Fieldset  parent fieldset to which this belongs


### PR DESCRIPTION
Added a set_fieldset_tag() method to the Fieldset class so that you can change the tag that $fieldset->build() generates.

This allows Fieldsets to be used in more complex situations where you want to be able to use a Fieldset inside another `<form>`.
