### PR TITLE
Added cache config argument to the Cache::forge calls

### DIFF
--- a/classes/agent.php
+++ b/classes/agent.php
@@ -362,7 +362,7 @@ class Agent
 	 */
 	protected static function get_from_browscap()
 	{
-		$cache = \Cache::forge(static::$config['cache']['identifier'].'.browscap');
+		$cache = \Cache::forge(static::$config['cache']['identifier'].'.browscap', static::$config['cache']);
 
 		// load the cached browscap data
 		try
@@ -533,7 +533,7 @@ class Agent
 		// save the result to the cache
 		if ( ! empty($result))
 		{
-			$cache = \Cache::forge(static::$config['cache']['identifier'].'.browscap');
+			$cache = \Cache::forge(static::$config['cache']['identifier'].'.browscap', static::$config['cache']);
 			$cache->set($result, static::$config['cache']['expiry']);
 		}
 


### PR DESCRIPTION
I noticed the `Cache::forge` calls weren't passing in any of the set `static::$config['cache']` params when they were being created, so changing the `cache->driver` option in the `agent.php` config file had no effect.
