### PR TITLE
Allow input params nested in array.

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -357,6 +357,8 @@ class Input
 		{
 			static::hydrate();
 		}
+		
+		$index = str_replace(array('[', ']'), array('.', ''), $index);
 
 		return \Arr::get(static::$input, $index, $default);
 	}


### PR DESCRIPTION
This allows field names to be specified with array syntax e.g. foo[bar], and get these values back out using the input class.
