### PR TITLE
Add $dobule_encode flag to Security::htmlentities()

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -177,11 +177,13 @@ class Security
 		return $value;
 	}
 
-	public static function htmlentities($value, $flags = null)
+	public static function htmlentities($value, $flags = null, $encoding = null, $double_encode = null)
 	{
 		static $already_cleaned = array();
 
 		is_null($flags) and $flags = \Config::get('security.htmlentities_flags', ENT_QUOTES);
+		is_null($encoding) and $encoding = \Fuel::$encoding;
+		is_null($double_encode) and $double_encode = \Config::get('security.htmlentities_double_encode', false);
 
 		// Nothing to escape for non-string scalars, or for already processed values
 		if (is_bool($value) or is_int($value) or is_float($value) or in_array($value, $already_cleaned, true))
@@ -191,7 +193,7 @@ class Security
 
 		if (is_string($value))
 		{
-			$value = htmlentities($value, $flags, \Fuel::$encoding, false);
+			$value = htmlentities($value, $flags, $encoding, $double_encode);
 		}
 		elseif (is_array($value) or ($value instanceof \Iterator and $value instanceof \ArrayAccess))
 		{
@@ -200,7 +202,7 @@ class Security
 
 			foreach ($value as $k => $v)
 			{
-				$value[$k] = static::htmlentities($v, $flags);
+				$value[$k] = static::htmlentities($v, $flags, $encoding, $double_encode);
 			}
 		}
 		elseif ($value instanceof \Iterator or get_class($value) == 'stdClass')
@@ -210,7 +212,7 @@ class Security
 
 			foreach ($value as $k => $v)
 			{
-				$value->{$k} = static::htmlentities($v, $flags);
+				$value->{$k} = static::htmlentities($v, $flags, $encoding, $double_encode);
 			}
 		}
 		elseif (is_object($value))
@@ -235,7 +237,7 @@ class Security
 					'to allow it to be passed unchecked.');
 			}
 
-			$value = static::htmlentities((string) $value, $flags);
+			$value = static::htmlentities((string) $value, $flags, $encoding, $double_encode);
 		}
 
 		return $value;

--- a/tests/security.php
+++ b/tests/security.php
@@ -20,5 +20,69 @@ namespace Fuel\Core;
  */
 class Test_Security extends TestCase
 {
- 	public function test_foo() {}
+	/**
+	* Tests Security::htmlentities()
+	*
+	* @test
+	*/
+	public function test_htmlentities_doublequote_and_ampersand()
+	{
+		$output = Security::htmlentities('"H&M"');
+		$expected = '&quot;H&amp;M&quot;';
+		$this->assertEquals($expected, $output);
+	}
+	
+	/**
+	* Tests Security::htmlentities()
+	*
+	* @test
+	*/
+	public function test_htmlentities_singlequote()
+	{
+		$output = Security::htmlentities("'");
+		$expected = '&#039;';
+		$this->assertEquals($expected, $output);
+	}
+	
+	/**
+	* Tests Security::htmlentities()
+	*
+	* @test
+	*/
+	public function test_htmlentities_charactor_references_no_double_encode()
+	{
+		$output = Security::htmlentities('You must write & as &amp;');
+		$expected = 'You must write &amp; as &amp;';
+		$this->assertEquals($expected, $output);
+	}
+	
+	/**
+	* Tests Security::htmlentities()
+	*
+	* @test
+	*/
+	public function test_htmlentities_charactor_references_double_encode()
+	{
+		$config = \Config::get('security.htmlentities_double_encode');
+		\Config::set('security.htmlentities_double_encode', true);
+		
+		$output = Security::htmlentities('You must write & as &amp;');
+		$expected = 'You must write &amp; as &amp;amp;';
+		$this->assertEquals($expected, $output);
+		
+		\Config::set('security.htmlentities_double_encode', $config);
+	}
+	
+	/**
+	* Tests Security::htmlentities()
+	*
+	* @test
+	*/
+	public function test_htmlentities_double_encode()
+	{
+		$output = Security::htmlentities('"H&M"');
+		$output = Security::htmlentities($output);
+		$expected = '&quot;H&amp;M&quot;';
+		$this->assertEquals($expected, $output);
+	}
 }


### PR DESCRIPTION
Fuel's Security::htmlentities() default is "double encode" is false. PHP's default is "double encode" is true.

Fuel's is OK almost situations, but it sometimes not. It prevents users to input character references as it is.

In short, if I want to write below to my forum,
`You must write & as &amp; in HTML`
I see my post as
`You must write & as & in HTML`

This pull request makes it configurable.
