### PR TITLE
Allow to set "current_page" via $config. If this key is not provided, tr...

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -136,7 +136,7 @@ class Pagination
 	{
 		static::$total_pages = ceil(static::$total_items / static::$per_page) ?: 1;
 
-		static::$current_page = (int) \URI::segment(static::$uri_segment);
+		static::$current_page = (static::$current_page) ?: (int) \URI::segment(static::$uri_segment);
 
 		if (static::$current_page > static::$total_pages)
 		{


### PR DESCRIPTION
...y to get in the url. Useful when using dynamic routes and you don't know exactly what is the url segment for pagination.
