### PR TITLE
Reverse the order asset paths are added to a theme

### DIFF
--- a/classes/theme.php
+++ b/classes/theme.php
@@ -721,8 +721,8 @@ class Theme
 		}
 
 		// add the asset paths to the asset instance
-		empty($this->active['asset_path']) or $this->asset->add_path($this->active['asset_path']);
 		empty($this->fallback['asset_path']) or $this->asset->add_path($this->fallback['asset_path']);
+		empty($this->active['asset_path']) or $this->asset->add_path($this->active['asset_path']);
 
 		return $this->{$type};
 	}


### PR DESCRIPTION
For some reason when using the theme class the fallback theme was taking precedence over the active theme. Reversing the order in which asset paths were added seems to solve the issue.

Signed-off-by: Tom Densham tomdensham@googlemail.com
