### PR TITLE
Fixed requests to Modules

### DIFF
--- a/classes/request.php
+++ b/classes/request.php
@@ -264,12 +264,12 @@ class Request
 		logger(\Fuel::L_INFO, 'Creating a new Request with URI = "'.$this->uri->get().'"', __METHOD__);
 
 		// check if a module was requested
-		if (count($this->uri->segments()) and $module_path = \Module::exists($this->uri->get_segment(0)))
+		if (count($this->uri->get_segments()) and $module_path = \Module::exists($this->uri->get_segment(1)))
 		{
 			// check if the module has routes
 			if (is_file($module_path .= 'config/routes.php'))
 			{
-				$module = $this->uri->segments[0];
+				$module = $this->uri->get_segment(1);
 
 				// load and add the module routes
 				$module_routes = \Fuel::load($module_path);


### PR DESCRIPTION
Requests to Modules failed after updates for the 1.2 release and some Uri methods were not appropriately updated
