### PR TITLE
1.2/develop

### DIFF
--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -181,7 +181,7 @@ class Request_Curl extends \Request_Driver
 			$this->set_defaults();
 						
 			// Only show specific 400 error message with \Exception if not in production mode
-			if(Fuel::$env != 'production')
+			if(Fuel::$env != Fuel::PRODUCTION)
 			{
 				switch($this->response->status)
 				{

--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -179,17 +179,27 @@ class Request_Curl extends \Request_Driver
 		elseif ($this->response->status >= 400)
 		{
 			$this->set_defaults();
-			
-			switch($this->response->status)
+						
+			// Only show specific 400 error message with \Exception if not in production mode
+			if(Fuel::$env != 'production')
 			{
-				case 404:
-					throw new \RequestStatusException($body, $this->response->status);
-				break;
-				
-				default:
-					throw new \Exception($body, $this->response->status);
-				break;
-			}			
+				switch($this->response->status)
+				{
+					case 404:
+						throw new \RequestStatusException($body, $this->response->status);
+					break;
+					
+					default:
+						throw new \Exception($body, $this->response->status);
+					break;
+				}	
+			}
+			
+			// Return as 404 if in production mode
+			else
+			{
+				throw new \RequestStatusException($body, $this->response->status);
+			}
 		}
 		else
 		{

--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -179,7 +179,17 @@ class Request_Curl extends \Request_Driver
 		elseif ($this->response->status >= 400)
 		{
 			$this->set_defaults();
-			throw new \RequestStatusException($body, $this->response->status);
+			
+			switch($this->response->status)
+			{
+				case 404:
+					throw new \RequestStatusException($body, $this->response->status);
+				break;
+				
+				default:
+					throw new \Exception($body, $this->response->status);
+				break;
+			}			
 		}
 		else
 		{


### PR DESCRIPTION
Refine 400 status codes by throwing 'correct' exception(s). 

At the moment, all 400 status codes are thrown as \RequestStatusException. If environment is set to development, all 400 statues bar 404 throw \Exception. This gives the developer more information when debugging, and not just a "Not Found" page!
