### PR TITLE
cURL method param not set

### DIFF
--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -19,8 +19,6 @@ class Request_Curl extends \Request_Driver
 	 */
 	public function __construct($resource, array $options, $method = null)
 	{
-		$method and $this->set_method($method);
-
 		// check if we have libcurl available
 		if ( ! function_exists('curl_init'))
 		{
@@ -38,7 +36,7 @@ class Request_Curl extends \Request_Driver
 		// we want to handle failure ourselves
 		$this->set_option('failonerror', false);
 
-		parent::__construct($resource, $options);
+		parent::__construct($resource, $options, $method);
 	}
 
 	/**

--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -96,7 +96,7 @@ abstract class Request_Driver
 	public function __construct($resource, array $options, $method = null)
 	{
 		$this->resource  = $resource;
-		$this->method    = $method;
+		$method and $this->set_method($method);
 
 		foreach ($options as $key => $value)
 		{


### PR DESCRIPTION
At the moment if you pass a method parameter into a cURL request, it will be overwritten by the parent constructor in Request_Driver. As set_method isn't overwritten in the cURL driver, the patch just passes the parameter to Request_Driver to handle.
