### PR TITLE
Fix precedence in recursive part of Fieldset::field

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -386,7 +386,7 @@ class Fieldset
 		{
 			foreach ($this->fieldset_children as $fieldset)
 			{
-				if (($field = $fieldset->field($name) !== false))
+				if (($field = $fieldset->field($name)) !== false)
 				{
 					return $field;
 				}


### PR DESCRIPTION
Current implementation returns a boolean instead of the object.

See https://github.com/fuel/core/pull/974#issuecomment-5867912 for original pull request
