### PR TITLE
Fix problem with table prefixes in FK definition for DBUtil::create_table

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -471,7 +471,7 @@ class DBUtil
 			$sql = '';
 			! empty($definition['constraint']) and $sql .= " CONSTRAINT ".$definition['constraint'];
 			$sql .= " FOREIGN KEY (".$definition['key'].')';
-			$sql .= " REFERENCES ".$definition['reference']['table'].' (';
+			$sql .= " REFERENCES ".\DB::quote_identifier(\DB::table_prefix($definition['reference']['table'])).' (';
 			if (is_array($definition['reference']['column']))
 			{
 				$sql .= implode(', ', $definition['reference']['column']);

--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -469,16 +469,16 @@ class DBUtil
 			}
 
 			$sql = '';
-			! empty($definition['constraint']) and $sql .= " CONSTRAINT ".$definition['constraint'];
-			$sql .= " FOREIGN KEY (".$definition['key'].')';
+			! empty($definition['constraint']) and $sql .= " CONSTRAINT ".\DB::quote_identifier($definition['constraint']);
+			$sql .= " FOREIGN KEY (".\DB::quote_identifier($definition['key']).')';
 			$sql .= " REFERENCES ".\DB::quote_identifier(\DB::table_prefix($definition['reference']['table'])).' (';
 			if (is_array($definition['reference']['column']))
 			{
-				$sql .= implode(', ', $definition['reference']['column']);
+				$sql .= implode(', ', \DB::quote_identifier($definition['reference']['column']));
 			}
 			else
 			{
-				$sql .= $definition['reference']['column'];
+				$sql .= \DB::quote_identifier($definition['reference']['column']);
 			}
 			$sql .= ')';
 			! empty($definition['on_update']) and $sql .= " ON UPDATE ".$definition['on_update'];


### PR DESCRIPTION
Just inculded prefix and quoting for FK definitions in the DBUtil::create_table method to fix the problem o found below:

---

Using DBUtil to create a supervisors table, linking it to users table with FK options:

``` php
<? ...
\DBUtil::create_table('supervisors', array(
    'id' => array('constraint' => 11, 'type' => 'int', 'auto_increment' => true),
    'user_id' => array('constraint' => 11, 'type' => 'int'),
    'created_at' => array('constraint' => 11, 'type' => 'int'),
    'updated_at' => array('constraint' => 11, 'type' => 'int'),
), array('id'), false, 'InnoDB', null, array(
    array(
        'key' => 'user_id',
        'reference' => array(
            'table' => 'users',
            'column' => 'id'
        ),
        'on_update' => 'CASCADE',
        'on_delete' => 'RESTRICT'
    ),
));
```

considering we have "admin_" as table prefix in db config, will generate this SQL:

``` sql
CREATE TABLE admin_supervisors (
    id int(11) NOT NULL AUTO_INCREMENT,
    user_id int(11) NOT NULL,
    created_at int(11) NOT NULL,
    updated_at int(11) NOT NULL,
    PRIMARY KEY id (id), 
    FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE CASCADE ON DELETE RESTRICT,
) ENGINE = InnoDB  DEFAULT CHARACTER SET utf8
```

referencing "users" instead "admin_users"
