### PR TITLE
Fix problem with table prefixes in FK definition for DBUtil::create_table

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -469,16 +469,16 @@ class DBUtil
 			}
 
 			$sql = '';
-			! empty($definition['constraint']) and $sql .= " CONSTRAINT ".$definition['constraint'];
-			$sql .= " FOREIGN KEY (".$definition['key'].')';
-			$sql .= " REFERENCES ".$definition['reference']['table'].' (';
+			! empty($definition['constraint']) and $sql .= " CONSTRAINT ".\DB::quote_identifier($definition['constraint']);
+			$sql .= " FOREIGN KEY (".\DB::quote_identifier($definition['key']).')';
+			$sql .= " REFERENCES ".\DB::quote_identifier(\DB::table_prefix($definition['reference']['table'])).' (';
 			if (is_array($definition['reference']['column']))
 			{
-				$sql .= implode(', ', $definition['reference']['column']);
+				$sql .= implode(', ', \DB::quote_identifier($definition['reference']['column']));
 			}
 			else
 			{
-				$sql .= $definition['reference']['column'];
+				$sql .= \DB::quote_identifier($definition['reference']['column']);
 			}
 			$sql .= ')';
 			! empty($definition['on_update']) and $sql .= " ON UPDATE ".$definition['on_update'];


### PR DESCRIPTION
Fix to issue [#979](https://github.com/fuel/core/pull/979) for the 1.2/developer branch
