### PR TITLE
Feature: Added optional 'separator' parameter to valid_emails validation method

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -740,14 +740,14 @@ class Validation
 	 * @param   string
 	 * @return  bool
 	 */
-	public function _validation_valid_emails($val)
+	public function _validation_valid_emails($val, $separator = ',')
 	{
 		if ($this->_empty($val))
 		{
 			return true;
 		}
 
-		$emails = explode(',', $val);
+		$emails = explode($separator, $val);
 
 		foreach ($emails as $e)
 		{

--- a/tests/validation.php
+++ b/tests/validation.php
@@ -35,6 +35,7 @@ class Test_Validation extends TestCase
                     'sky' => 'blue',
                     'one' => 'john@doe.com',
                     'two' => 'john@doe.com, jane@doe.com',
+                    'owt' => 'john@doe.com; jane@doe.com',
                     'six' => 6,
                     'ten' => 10,
                     'dns' => '127.0.0.1',
@@ -383,6 +384,24 @@ class Test_Validation extends TestCase
  	{ 	  
  	  $val = Validation::forge(__FUNCTION__);
  	  $val->add_field('two', 'Emails', 'valid_emails');
+ 	  $output = $val->run($input);
+ 	  
+ 	  $expected = true;
+ 	  
+ 	  $this->assertEquals($output, $expected);
+ 	}
+ 	
+ 	/**
+     * Validation:  valid_emails (different separator)
+     * Expecting:   success
+ 	 * 
+ 	 * @dataProvider    form_provider
+ 	 */ 	
+ 	public function test_validation_valid_emails_separator_success($input)
+ 	{ 	  
+ 	  $val = Validation::forge(__FUNCTION__);
+ 	  $val->add_field('owt', 'Emails')
+ 	      ->add_rule('valid_emails', ';');
  	  $output = $val->run($input);
  	  
  	  $expected = true;


### PR DESCRIPTION
...to allow defining own separator (defaults to comma as to not break current functionality)
