### PR TITLE
Allow hybrid hmvc requests to be served as rest requests

### DIFF
--- a/classes/controller/hybrid.php
+++ b/classes/controller/hybrid.php
@@ -23,18 +23,22 @@ namespace Fuel\Core;
  */
 abstract class Controller_Hybrid extends \Controller_Rest
 {
+	/**
+	 * @var string page template
+	 */
+	public $template = 'template';
 
 	/**
-	* @var string page template
-	*/
-	public $template = 'template';
+	 * @var bool - if true, hmvc requests to this class will be served as rest requests
+	 */
+	public $hmvc = false;
 
 	/**
 	 * Load the template and create the $this->template object
 	 */
 	public function before()
 	{
-		if ( ! \Input::is_ajax())
+		if ( ! $this->is_rest())
 		{
 			if ( ! empty($this->template) and is_string($this->template))
 			{
@@ -53,7 +57,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 */
 	public function after($response)
 	{
-		if ( ! \Input::is_ajax())
+		if ( ! $this->is_rest())
 		{
 			// If nothing was returned default to the template
 			if (empty($response))
@@ -88,7 +92,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	public function router($resource, array $arguments)
 	{
 		// if this is an ajax call
-		if (\Input::is_ajax())
+		if ($this->is_rest())
 		{
 			// have the Controller_Rest router deal with it
 			return parent::router($resource, $arguments);
@@ -103,5 +107,16 @@ abstract class Controller_Hybrid extends \Controller_Rest
 
 		// if not, we got ourselfs a genuine 404!
 		throw new \HttpNotFoundException();
+	}
+
+	/**
+	 * Determines whether the request should be processed as
+	 * a rest request or a regular request
+	 *
+	 * @return bool
+	 */
+	protected function is_rest()
+	{
+		return \Input::is_ajax() ? : ($this->hmvc and \Request::main() !== \Request::active());
 	}
 }


### PR DESCRIPTION
setting `$hmvc = true;` in a hybrid controller class would allow any hmvc requests to that class to be processed as rest requests
