### PR TITLE
Request superglobal overrides for HMVC requests

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -61,7 +61,7 @@ class Input
 			static::hydrate_raw_input('json');
 		}
 
-		$json = ($request = \Request::current()) ? $request->get('json') : false;
+		$json = ($request = \Request::active()) ? $request->get('json') : false;
 
 		$json === false and $json =& static::$content;
 
@@ -80,7 +80,7 @@ class Input
 			static::hydrate_raw_input('xml');
 		}
 
-		$xml = ($request = \Request::current()) ? $request->get('xml') : false;
+		$xml = ($request = \Request::active()) ? $request->get('xml') : false;
 
 		$xml === false and $xml =& static::$content;
 

--- a/classes/input.php
+++ b/classes/input.php
@@ -63,7 +63,7 @@ class Input
 
 		$json = ($request = \Request::current()) ? $request->get('json') : false;
 
-		$request === false and $json =& static::$content;
+		$json === false and $json =& static::$content;
 
 		return (func_num_args() === 0) ? $json : \Arr::get($json, $index, $default);
 	}
@@ -82,7 +82,7 @@ class Input
 
 		$xml = ($request = \Request::current()) ? $request->get('xml') : false;
 
-		$request === false and $xml =& static::$content;
+		$xml === false and $xml =& static::$content;
 
 		return (func_num_args() === 0) ? $xml : \Arr::get($xml, $index, $default);
 	}

--- a/classes/input.php
+++ b/classes/input.php
@@ -61,7 +61,11 @@ class Input
 			static::hydrate_raw_input('json');
 		}
 
-		return (func_num_args() === 0) ? static::$content : \Arr::get(static::$content, $index, $default);
+		$json = ($request = \Request::current()) ? $request->get('json') : false;
+
+		$request === false and $json =& static::$content;
+
+		return (func_num_args() === 0) ? $json : \Arr::get($json, $index, $default);
 	}
 
 	/**
@@ -76,7 +80,11 @@ class Input
 			static::hydrate_raw_input('xml');
 		}
 
-		return (func_num_args() === 0) ? static::$content : \Arr::get(static::$content, $index, $default);
+		$xml = ($request = \Request::current()) ? $request->get('xml') : false;
+
+		$request === false and $xml =& static::$content;
+
+		return (func_num_args() === 0) ? $xml : \Arr::get($xml, $index, $default);
 	}
 
 	/**
@@ -299,7 +307,7 @@ class Input
 		}
 
 		// if called before a request is active, fall back to the global server setting
-		return \Input::server('HTTP_X_HTTP_METHOD_OVERRIDE', \Input::server('REQUEST_METHOD', $default));
+		return static::server('HTTP_X_HTTP_METHOD_OVERRIDE', static::server('REQUEST_METHOD', $default));
 	}
 
 	/**
@@ -313,7 +321,7 @@ class Input
 	}
 
 	/**
-	 * Returns all of the GET, POST, PUT and DELETE variables.
+	 * Returns all of the GET, POST, PUT and DELETE variables from the main request
 	 *
 	 * @return  array
 	 */
@@ -336,7 +344,11 @@ class Input
 	 */
 	public static function get($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_GET : \Arr::get($_GET, $index, $default);
+		$get = ($request = \Request::active()) ? $request->get('get') : false;
+		
+		$get === false and $get =& $_GET;
+
+		return (func_num_args() === 0) ? $get : \Arr::get($get, $index, $default);
 	}
 
 	/**
@@ -348,7 +360,11 @@ class Input
 	 */
 	public static function post($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_POST : \Arr::get($_POST, $index, $default);
+		$post = ($request = \Request::active()) ? $request->get('post') : false;
+		
+		$post === false and $post =& $_POST;
+
+		return (func_num_args() === 0) ? $post : \Arr::get($post, $index, $default);
 	}
 
 	/**
@@ -365,7 +381,11 @@ class Input
 			static::hydrate();
 		}
 
-		return (func_num_args() === 0) ? static::$put_delete : \Arr::get(static::$put_delete, $index, $default);
+		$put = ($request = \Request::active()) ? $request->get('put') : false;
+		
+		$put === false and $put =& static::$put_delete;
+
+		return (func_num_args() === 0) ? $put : \Arr::get($put, $index, $default);
 	}
 
 	/**
@@ -382,7 +402,11 @@ class Input
 			static::hydrate();
 		}
 
-		return (is_null($index) and func_num_args() === 0) ? static::$put_delete : \Arr::get(static::$put_delete, $index, $default);
+		$delete = ($request = \Request::active()) ? $request->get('delete') : false;
+		
+		$delete === false and $delete =& static::$put_delete;
+
+		return (is_null($index) and func_num_args() === 0) ? $delete : \Arr::get($delete, $index, $default);
 	}
 
 	/**
@@ -394,11 +418,15 @@ class Input
 	 */
 	public static function file($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_FILES : \Arr::get($_FILES, $index, $default);
+		$files = ($request = \Request::active()) ? $request->get('files') : false;
+		
+		$files === false and $files =& $_FILES;
+
+		return (func_num_args() === 0) ? $files : \Arr::get($files, $index, $default);
 	}
 
 	/**
-	 * Fetch an item from either the GET, POST, PUT or DELETE array
+	 * Fetch an item from either the main request's GET, POST, PUT or DELETE array
 	 *
 	 * @param   string  The index key
 	 * @param   mixed   The default value
@@ -423,7 +451,11 @@ class Input
 	 */
 	public static function cookie($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_COOKIE : \Arr::get($_COOKIE, $index, $default);
+		$cookie = ($request = \Request::active()) ? $request->get('cookie') : false;
+		
+		$cookie === false and $cookie =& $_COOKIE;
+
+		return (func_num_args() === 0) ? $cookie : \Arr::get($cookie, $index, $default);
 	}
 
 	/**
@@ -435,7 +467,11 @@ class Input
 	 */
 	public static function server($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_SERVER : \Arr::get($_SERVER, strtoupper($index), $default);
+		$server = ($request = \Request::active()) ? $request->get('server') : false;
+		
+		$server === false and $server =& $_SERVER;
+
+		return (func_num_args() === 0) ? $server : \Arr::get($server, strtoupper($index), $default);
 	}
 
 	/**

--- a/classes/request.php
+++ b/classes/request.php
@@ -493,9 +493,6 @@ class Request
 	{
 		switch ($type)
 		{
-			case 'request':
-				$this->input_vars['request'] = $inherit_values ? $_REQUEST + $values : $values;
-			break;
 			case 'server':
 				$this->input_vars['server'] = $inherit_values ? $_SERVER + $values : $values;
 			break;
@@ -512,7 +509,7 @@ class Request
 				$this->input_vars['files'] = $inherit_values ? \Arr::merge($_FILES, $values) : $values;
 			break;
 			default:
-				// for json, xml
+				// for json, xml, put, delete
 				$this->input_vars[$type] = $values;
 			break;
 		}

--- a/classes/request.php
+++ b/classes/request.php
@@ -169,11 +169,6 @@ class Request
 	public $route = null;
 
 	/**
-	 * @var  string  $method  request method
-	 */
-	protected $method = null;
-
-	/**
 	 * The current module
 	 *
 	 * @var  string
@@ -244,6 +239,18 @@ class Request
 	protected $children = array();
 
 	/**
+	 * @var  string  $method  request method
+	 */
+	protected $method = null;
+
+	/**
+	 * Request level overwrites for get, post, server, cookie, file, json
+	 *
+	 * @var array
+	 */
+	protected $input_vars = array();
+
+	/**
 	 * Creates the new Request object by getting a new URI object, then parsing
 	 * the uri with the Route class.
 	 *
@@ -259,12 +266,16 @@ class Request
 	public function __construct($uri, $route = true, $method = null)
 	{
 		$this->uri = new \Uri($uri);
-		$this->method = $method;
-
+		
 		logger(\Fuel::L_INFO, 'Creating a new Request with URI = "'.$this->uri->get().'"', __METHOD__);
 
 		// set the request method
 		$this->method = \Input::server('HTTP_X_HTTP_METHOD_OVERRIDE', \Input::server('REQUEST_METHOD', 'GET'));
+
+		if ($method)
+		{
+			$this->set_method($method);
+		}
 
 		// check if a module was requested
 		if (count($this->uri->get_segments()) and $module_path = \Module::exists($this->uri->get_segment(1)))
@@ -467,6 +478,61 @@ class Request
 	public function get_method()
 	{
 		return $this->method;
+	}
+
+
+	/**
+	 * Sets an overwrite for superglobal items at the request level
+	 * (get, post, cookie, server, files, json, xml)
+	 * @param  string  $type    item type to overwrite
+	 * @param  array   $values  values to set for the overwrite
+	 * @param  bool    $inherit_values  whether to merge with the main request superglobal
+	 * @return object  current instance
+	 */
+	public function set($type, $values = array(), $inherit_values = false)
+	{
+		switch ($type)
+		{
+			case 'request':
+				$this->input_vars['request'] = $inherit_values ? $_REQUEST + $values : $values;
+			break;
+			case 'server':
+				$this->input_vars['server'] = $inherit_values ? $_SERVER + $values : $values;
+			break;
+			case 'get':
+				$this->input_vars['get'] = $inherit_values ? \Arr::merge($_GET, $values) : $values;
+			break;
+			case 'post':
+				$this->input_vars['post'] = $inherit_values ? \Arr::merge($_POST, $values) : $values;
+			break;
+			case 'cookie':
+				$this->input_vars['cookie'] = $inherit_values ? \Arr::merge($_COOKIE, $values) : $values;
+			break;
+			case 'files':
+				$this->input_vars['files'] = $inherit_values ? \Arr::merge($_FILES, $values) : $values;
+			break;
+			default:
+				// for json, xml
+				$this->input_vars[$type] = $values;
+			break;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Returns the main input variable overwrites if they have been changed
+	 * @param  string  $type - type of item to get
+	 * @return mixed bool|array
+	 */
+	public function get($type)
+	{
+		if (isset($this->input_vars[$type]))
+		{
+			return $this->input_vars[$type];
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Some proposed additions I was talking through with @jschreuder, which allow HMVC requests to specifically set and override `server, cookie, get, post, put, delete, json, xml` at the request level, in the same way that `set_method()` currently works:

Simulating ajax post request:

``` php

Request::forge('path/to/controller')
   ->set_method('POST')
   ->set('post', array('var' => 'value'))
   ->set('server', array(
      'HTTP_X_REQUESTED_WITH' => 'xmlhttprequest'
   ), true)
   ->execute();

```

The new method `->set($type, $arr, $inherit_values)` would determine which item to set, with values, and  whether values from the main request are inherited.

`Input::all()` and `Input::param()` will still reference the main request's globals, but all other Input methods (`Input::server()`, `Input::post()` etc.) will check the request, and use the override if one is provided, defaulting to the main request input items.
