### PR TITLE
call to set_option only keeping the newly set option and removing all previous options

### DIFF
--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -152,7 +152,7 @@ abstract class Request_Driver
 	 */
 	public function set_options(array $options)
 	{
-		$this->options = $options;
+		$this->options += $options;
 		return $this;
 	}
 


### PR DESCRIPTION
the set_options method of Request_Driver is replacing the current options with the new options array parsed to it but the set_option method is assuming that set_options will add the new option to the options array and not replace existing options.

For example in the Request_Soap class multiple calls are made to set_option but only the very last option to be set is being kept and no any other configuration options.
