### PR TITLE
Make sure that the database is connected before return $_connection.

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -703,6 +703,8 @@ abstract class Database_Connection
 	 */
 	public function connection()
 	{
+		// Make sure the database is connected
+		$this->_connection or $this->connect();
 		return $this->_connection;
 	}
 }


### PR DESCRIPTION
This allows you can get the database connection when not yet connected.
