### PR TITLE
Add: Validation::get_errors()

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -565,6 +565,36 @@ class Validation
 	}
 
 	/**
+	 * Get errors
+	 *
+	 * Returns all errors in array
+	 *
+	 * @param   array  uses keys message_prefix
+	 * @return  array
+	 */
+	public function get_errors($options = array())
+	{
+		$default = array(
+			'message_prefix' => \Config::get('validation.message_prefix', '* '),
+		);
+		$options = array_merge($default, $options);
+
+		if (empty($this->errors))
+		{
+			return array();
+		}
+
+		$array = array();
+
+		foreach($this->errors as $e)
+		{
+			$array[] = $options['message_prefix'].$e->get_message();
+		}
+
+		return $array;
+	}
+
+	/**
 	 * Alias for $this->fieldset->add()
 	 *
 	 * @return  Fieldset_Field


### PR DESCRIPTION
Returns all errors in array.

Signed-off-by: mamor mamor.dev@gmail.com
## 

I think that would be nice to have a function that returns an array.
And This commit is for https://github.com/mp-php/fuel-oil/commit/1313f841eda7166afd15cc359fdea36fde8c9153
