### PR TITLE
Fixes "ErrorException [ Notice ]: Undefined index: extension" when using File_Area and file has no extension

### DIFF
--- a/classes/file/area.php
+++ b/classes/file/area.php
@@ -86,17 +86,18 @@ class File_Area
 			$info = pathinfo($path);
 
 			// check file extension
-			$info = pathinfo($path);
-			if ( ! empty($this->extensions) && ! in_array($info['extension'], $this->extensions))
-			{
-				throw new \FileAccessException('File operation not allowed: disallowed file extension.');
-			}
+			if(isset($info['extension'])) {
+				if ( ! empty($this->extensions) && ! in_array($info['extension'], $this->extensions))
+				{
+					throw new \FileAccessException('File operation not allowed: disallowed file extension.');
+				}
 
-			// create specific handler when available
-			if (array_key_exists($info['extension'], $this->file_handlers))
-			{
-				$class = '\\'.ltrim($this->file_handlers[$info['extension']], '\\');
-				return $class::forge($path, $config, $this);
+				// create specific handler when available
+				if (array_key_exists($info['extension'], $this->file_handlers))
+				{
+					$class = '\\'.ltrim($this->file_handlers[$info['extension']], '\\');
+					return $class::forge($path, $config, $this);
+				}
 			}
 
 			return \File_Handler_File::forge($path, $config, $this);


### PR DESCRIPTION
in COREPATH/classes/file/area.php in the get_handler function, $info['extension'] is used two places (line 89 & 95) with no check whether the index is defined. The index 'extension' is not defined if the file has no extension, as documented at http://php.net/manual/en/function.pathinfo.php

minor notice: I also noticed the line $info = pathinfo($path); is repeated (line 85 & 88).
