### PR TITLE
1.2/develop - Finder prefix error

### DIFF
--- a/classes/finder.php
+++ b/classes/finder.php
@@ -300,7 +300,7 @@ class Finder
 		if ($pos = strripos($file, '::'))
 		{
 			// get the namespace path
-			if ($path = \Autoloader::namespace_path('\\'.ucfirst(substr($file, 0, $pos))))
+			if ($path = \Autoloader::namespace_path(ucfirst(substr($file, 0, $pos))))
 			{
 				$cache_id .= substr($file, 0, $pos);
 


### PR DESCRIPTION
Finder prefixes cross module loading with a backslash. No namespaces in Autoloader is prefixed with a backslash. Removed the prefixing from Finder
