### PR TITLE
A wrapper for Debug::dump() called dd()

### DIFF
--- a/base.php
+++ b/base.php
@@ -172,6 +172,21 @@ if ( ! function_exists('__'))
 }
 
 /**
+ * A wrapper function for Debug::dump()
+ * 
+ * Inspired by Laravel’s dd(), but this one means Debug Dump, rather than Die Dump.
+ * 
+ * @return	string
+ */
+if ( ! function_exists('dd'))
+{
+	function dd()
+	{
+		return \Debug::dump(func_get_args());
+	}
+}
+
+/**
  * Encodes the given string.  This is just a wrapper function for Security::htmlentities()
  *
  * @param	mixed	The string to encode


### PR DESCRIPTION
So I was inspired by Laravel’s `dd()` function which is just a wrapper for `die(var_dump($var))`, but Fuel has a lovely function called Debug::dump() so rather than **D**ie **D**ump, I felt Fuel’s should be **D**ebug **D**ump.

Here’s the docs: https://github.com/fuel/docs/pull/372
