### PR TITLE
Added 'set_global' to ViewModels. This allows to create much cleaner code.

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -30,7 +30,7 @@ class View
 	/**
 	 * @var  array  Global view data
 	 */
-	protected static $global_data = array();
+	static $global_data = array();
 
 	/**
 	 * @var  array  Holds a list of specific filter rules for global variables

--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -261,6 +261,41 @@ abstract class ViewModel
 			return '';
 		}
 	}
+
+
+	/**
+	 * Sets a global variable, similar to [static::set], except that the
+	 * variable will be accessible to all views.
+	 *
+	 *     ViewModel::set_global($name, $value);
+	 *
+	 * @param   string  variable name or an array of variables
+	 * @param   mixed   value
+	 * @param   bool    whether to filter the data or not
+	 * @return  void
+	 */
+	public static function set_global($key, $value = null, $filter = null)
+	{
+		if (is_array($key))
+		{
+			foreach ($key as $name => $value)
+			{
+				if ($filter !== null)
+				{
+					ViewModel::$global_filter[$name] = $filter;
+				}
+				ViewModel::$global_data[$name] = $value;
+			}
+		}
+		else
+		{
+			if ($filter !== null)
+			{
+				ViewModel::$global_filter[$key] = $filter;
+			}
+			ViewModel::$global_data[$key] = $value;
+		}
+	}
 }
 
 


### PR DESCRIPTION
### An example

This change allows users to do like this:

**Controller:**

```
return Response::forge(ViewModel::forge('template/index'));
```

**ViewModel:**

```
<?php

/**
* View-model for index
*/
class View_template_index extends ViewModel
{

    function view()
    {
        //-------------------------------------------------
        // Variables
        //-------------------------------------------------

        $name  = 'blaaargh';

        $this->set_global('baseUrl', Uri::base(0));
        $this->set_global('testImgLink',  $this->baseUrl . 'image/' . 0 . '/'. $name); //Note: $this->baseUrl works!



        //-------------------------------------------------
        // The layout
        //-------------------------------------------------

        $this->header    = View::forge('header');
        $this->search    = View::forge('search');
        $this->imageList = View::forge('image/list');
        $this->footer    = View::forge('footer');
    }
}

?>
```

**View:**

```
<?= $header ?>
<?= $search ?>
<?= $imageList ?>
<?= $footer ?>
```

**What I do: I load every part of my template in the ViewModel. This keeps the controllers and the views clean from irrelevant code. Hope you understand and accept this pull.**

Without this change I need too load everything in either the Controller or the View, that just feels... wrong.

Btw, I think it may would be a good idea to add every function from `classes\view.php` to `classess\viewModel.php`.
