### PR TITLE
Remove return on parent::before() (void method)

### DIFF
--- a/classes/controller/hybrid.php
+++ b/classes/controller/hybrid.php
@@ -43,7 +43,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 			}
 		}
 
-		return parent::before();
+		parent::before();
 	}
 
 	/**


### PR DESCRIPTION
The Controller_Rest don't have the "return".
To be consistent, we have two possibilities:
- Add the "return" in the Controller_Rest
- Remove the "return" in the Controller_Hybrid

I chose the second
