### PR TITLE
Updated the constructor to allow for the replicaset option.

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -144,6 +144,11 @@ class Mongo_Db
 			$options['persist'] = 'fuel_mongo_persist';
 		}
 
+		if ( ! empty($config['replicaset']))
+		{
+			$options['replicaSet'] = $config['replicaset'];
+		}
+
 		$connection_string = "mongodb://";
 
 		if (empty($config['hostname']))
@@ -258,31 +263,31 @@ class Mongo_Db
 	 */
 	public function select($includes = array(), $excludes = array())
 	{
-	 	if ( ! is_array($includes))
-	 	{
-	 		$includes = array($includes);
-	 	}
+		if ( ! is_array($includes))
+		{
+			$includes = array($includes);
+		}
 
-	 	if ( ! is_array($excludes))
-	 	{
-	 		$excludes = array($excludes);
-	 	}
+		if ( ! is_array($excludes))
+		{
+			$excludes = array($excludes);
+		}
 
-	 	if ( ! empty($includes))
-	 	{
-	 		foreach ($includes as $col)
-	 		{
-	 			$this->selects[$col] = 1;
-	 		}
-	 	}
-	 	else
-	 	{
-	 		foreach ($excludes as $col)
-	 		{
-	 			$this->selects[$col] = 0;
-	 		}
-	 	}
-	 	return $this;
+		if ( ! empty($includes))
+		{
+			foreach ($includes as $col)
+			{
+				$this->selects[$col] = 1;
+			}
+		}
+		else
+		{
+			foreach ($excludes as $col)
+			{
+				$this->selects[$col] = 0;
+			}
+		}
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Updated the constructor to allow for the replica set to be set as part of the mongo config config using the $options() array.

array("replicaSet" => "myReplSet"));

http://uk3.php.net/manual/en/mongo.construct.php

Signed-off-by: David Smith david.smith@wirewool.com
