### PR TITLE
Add missing Session_Exception to autoloader in bootstrap.php.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -222,7 +222,8 @@ function setup_autoloader()
 		'Fuel\\Core\\Session_File'       => COREPATH.'classes/session/file.php',
 		'Fuel\\Core\\Session_Memcached'  => COREPATH.'classes/session/memcached.php',
 		'Fuel\\Core\\Session_Redis'      => COREPATH.'classes/session/redis.php',
-
+		'Fuel\\Core\\Session_Exception'  => COREPATH.'classes/session/exception.php',
+		
 		'Fuel\\Core\\Num'       => COREPATH.'classes/num.php',
 
 		'Fuel\\Core\\Str'       => COREPATH.'classes/str.php',


### PR DESCRIPTION
If you somehow mess up your session config, and set the driver to be an empty string, you'll get a fatal error looking for Session_Exception. This adds the exception to the autoloader, so it gets thrown correctly.
