### PR TITLE
Added array-naming to select while presents multiple attribute.

### DIFF
--- a/classes/form/instance.php
+++ b/classes/form/instance.php
@@ -574,6 +574,11 @@ class Form_Instance
 			$attributes['id'] = $this->get_config('auto_id_prefix', '').$attributes['name'];
 		}
 
+		if (isset($attributes['multiple']))
+		{
+			$attributes['name'] .= '[]';
+		}
+
 		return html_tag('select', $this->attr_to_string($attributes), $input);
 	}
 


### PR DESCRIPTION
Class Form didn't allow to post array of values because naming of field didn't check isset of multiple attribute.
