### PR TITLE
Allow image extension to be forced.

### DIFF
--- a/classes/image.php
+++ b/classes/image.php
@@ -96,12 +96,13 @@ class Image
 	/**
 	 * Loads the image and checks if its compatable.
 	 *
-	 * @param   string  $filename  The file to load
+	 * @param   string  $filename							The file to load
+	 * @param   mixed		$force_extension			Whether or not to force the image extension
 	 * @return  Image_Driver
 	 */
-	public static function load($filename)
+	public static function load($filename, $force_extension = false)
 	{
-		return static::instance()->load($filename);
+		return static::instance()->load($filename, false, $force_extension);
 	}
 
 	/**

--- a/classes/image.php
+++ b/classes/image.php
@@ -97,12 +97,13 @@ class Image
 	 * Loads the image and checks if its compatable.
 	 *
 	 * @param   string  $filename							The file to load
+	 * @param   string  $return_data					Decides if it should return the images data, or just "$this".
 	 * @param   mixed		$force_extension			Whether or not to force the image extension
 	 * @return  Image_Driver
 	 */
-	public static function load($filename, $force_extension = false)
+	public static function load($filename, $return_data = false, $force_extension = false)
 	{
-		return static::instance()->load($filename, false, $force_extension);
+		return static::instance()->load($filename, $return_data, $force_extension);
 	}
 
 	/**

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -106,11 +106,12 @@ abstract class Image_Driver
 	/**
 	 * Loads the image and checks if its compatible.
 	 *
-	 * @param   string  $filename     The file to load
-	 * @param   string  $return_data  Decides if it should return the images data, or just "$this".
+	 * @param   string  $filename								The file to load
+	 * @param   string  $return_data						Decides if it should return the images data, or just "$this".
+	 * @param   mixed   $force_extension				Decides if it should force the extension witht this (or false)
 	 * @return  Image_Driver
 	 */
-	public function load($filename, $return_data = false)
+	public function load($filename, $return_data = false, $force_extension = false)
 	{
 		// First check if the filename exists
 		$filename = realpath($filename);
@@ -121,7 +122,7 @@ abstract class Image_Driver
 		if (file_exists($filename))
 		{
 			// Check the extension
-			$ext = $this->check_extension($filename, false);
+			$ext = $this->check_extension($filename, false, $force_extension);
 			if ($ext !== false)
 			{
 				$return = array_merge($return, array(
@@ -743,12 +744,19 @@ abstract class Image_Driver
 	 * Checks if the extension is accepted by this library, and if its valid sets the $this->image_extension variable.
 	 *
 	 * @param   string   $filename
-	 * @param   boolean  $writevar  Decides if the extension should be written to $this->image_extension
+	 * @param   boolean  $writevar					Decides if the extension should be written to $this->image_extension
+	 * @param   mixed		 $force_extension		Decides if the extension should be overridden with this (or false)
 	 * @return  boolean
 	 */
-	protected function check_extension($filename, $writevar = true)
+	protected function check_extension($filename, $writevar = true, $force_extension = false)
 	{
 		$return = false;
+		
+		if ($force_extension !== false and in_array($force_extension, $this->accepted_extensions))
+		{
+			return $force_extension;			
+		}
+		
 		foreach ($this->accepted_extensions as $ext)
 		{
 			if (strtolower(substr($filename, strlen($ext) * -1)) == strtolower($ext))
@@ -837,7 +845,7 @@ abstract class Image_Driver
 	public function reload()
 	{
 		$this->debug("Reloading was called!");
-		$this->load($this->image_fullpath);
+		$this->load($this->image_fullpath, false, $this->image_extension);
 		return $this;
 	}
 

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -21,9 +21,9 @@ class Image_Gd extends \Image_Driver
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
 	protected $gdresizefunc = "imagecopyresampled";
 
-	public function load($filename, $return_data = false)
+	public function load($filename, $return_data = false, $force_extension = false)
 	{
-		extract(parent::load($filename, $return_data));
+		extract(parent::load($filename, $return_data, $force_extension));
 		$return = false;
 		$image_extension == 'jpg' and $image_extension = 'jpeg';
 


### PR DESCRIPTION
At the moment you can only pass in a filename with a valid file extension. This prevents you from passing a temporary file or an otherwise "invalid" file. This commit will allow you to pass an additional parameter to force (or override) the file extension so it is processed correctly. It can be useful when when manipulating images directly from a file upload via the <code>Upload</code> class.
