### PR TITLE
Autoload "Init" class after module loading

### DIFF
--- a/classes/module.php
+++ b/classes/module.php
@@ -96,6 +96,10 @@ class Module
 			$ns  => $path.'classes'.DS,
 		), true);
 
+		// try to execute $ns\Init::_init()
+		// this trick allows to initialize the module
+		\Autoloader::load($ns.'\\Init');
+
 		static::$modules[$module] = $path;
 
 		return true;


### PR DESCRIPTION
Line 99: Try to execute \$namespace\Init::_init() after loading a module. This trick allows to initialize the module.
NB: The method _init() is called by the autoloader if class exists.
