### PR TITLE
Fully remove $response property on controllers.

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -21,21 +21,13 @@ abstract class Controller
 	public $request;
 
 	/**
-	 * @var  Response  The current Response object
-	 * @deprecated  until v1.2
-	 */
-	public $response;
-
-	/**
 	 * Sets the controller request object.
 	 *
 	 * @param   Request   The current request object
-	 * @param   Response  The current response object
 	 */
-	public function __construct(\Request $request, \Response $response)
+	public function __construct(\Request $request)
 	{
 		$this->request = $request;
-		$this->response = $response;
 	}
 
 	/**
@@ -48,6 +40,12 @@ abstract class Controller
 	 */
 	public function after($response)
 	{
+		// Make sure the $response is a Response object
+		if ( ! $response instanceof \Response)
+		{
+			$response = \Response::forge($response);
+		}
+
 		return $response;
 	}
 

--- a/classes/controller/template.php
+++ b/classes/controller/template.php
@@ -56,14 +56,6 @@ abstract class Controller_Template extends \Controller
 			$response = $this->template;
 		}
 
-		// If the response isn't a Response object, embed in the available one for BC
-		// @deprecated  can be removed when $this->response is removed
-		if ( ! $response instanceof Response)
-		{
-			$this->response->body = $response;
-			$response = $this->response;
-		}
-
 		return parent::after($response);
 	}
 

--- a/classes/request.php
+++ b/classes/request.php
@@ -389,7 +389,7 @@ class Request
 				}
 
 				// Create a new instance of the controller
-				$this->controller_instance = $class->newInstance($this, new \Response);
+				$this->controller_instance = $class->newInstance($this);
 
 				$this->action = $this->action ?: ($class->hasProperty('default_action') ? $class->getProperty('default_action')->getValue($this->controller_instance) : 'index');
 				$method = $method_prefix.$this->action;
@@ -436,17 +436,13 @@ class Request
 
 
 		// Get the controller's output
-		if (is_null($response))
-		{
-			throw new \FuelException(get_class($this->controller_instance).'::'.$method.'() or the controller after() method must return a Response object.');
-		}
-		elseif ($response instanceof \Response)
+		if ($response instanceof \Response)
 		{
 			$this->response = $response;
 		}
 		else
 		{
-			$this->response = \Response::forge($response, 200);
+			throw new \FuelException(get_class($this->controller_instance).'::'.$method.'() or the controller after() method must return a Response object.');
 		}
 
 		static::reset_request();


### PR DESCRIPTION
It was deprecated, but not removed in 1.2 because a proper alternative wasn't found. This is my
suggested alternative.

According to the docs, the controller should make sure a Response object should be returned. Its
not the Requests job to do that.

Signed-off-by: Gizzmo justgiz@gmail.com
