### PR TITLE
- Added ability to overwrite the options in the field completely

### DIFF
--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -336,7 +336,7 @@ class Fieldset_Field
 	 *
 	 * @param   string|array  one option value, or multiple value=>label pairs in an array
 	 * @param   string
-	 * @param   bool            Whether or not to replace the current optiions
+	 * @param   bool            Whether or not to replace the current options
 	 * @return  Fieldset_Field  this, to allow chaining
 	 */
 	public function set_options($value, $label = null, $replace_options = false)
@@ -362,7 +362,7 @@ class Fieldset_Field
 			}
 		};
 
-		($replace_options || empty($this->options)) ? $this->options = $value : $merge($this->options, $value, $merge);
+		($replace_options or empty($this->options)) ? $this->options = $value : $merge($this->options, $value, $merge);
 
 		return $this;
 	}

--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -336,9 +336,10 @@ class Fieldset_Field
 	 *
 	 * @param   string|array  one option value, or multiple value=>label pairs in an array
 	 * @param   string
+	 * @param   bool            Whether or not to replace the current optiions
 	 * @return  Fieldset_Field  this, to allow chaining
 	 */
-	public function set_options($value, $label = null)
+	public function set_options($value, $label = null, $replace_options = false)
 	{
 		if ( ! is_array($value))
 		{
@@ -361,7 +362,7 @@ class Fieldset_Field
 			}
 		};
 
-		empty($this->options) ? $this->options = $value : $merge($this->options, $value, $merge);
+		($replace_options || empty($this->options)) ? $this->options = $value : $merge($this->options, $value, $merge);
 
 		return $this;
 	}


### PR DESCRIPTION
When using the ORM and the fieldset generation based on the Model, I
have found sometimes it is necessary to overwrite a select field's
options after being initialised by an init function completely
(different load conditions for the select perhaps based on a user action).

This small tweak will allow that, but the default behaviour stays the
same.
