### PR TITLE
Added condition on find_file when path is absolute

### DIFF
--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -120,9 +120,9 @@ abstract class Config_File implements Config_Interface
 		$paths = \Finder::search('config', $this->file, $this->ext, true);
 
 		// absolute path requested?
-		if ($this->file[0] === '/' or (isset($this->file[1]) and $this->file[1] === ':'))
+		if (count($paths) > 0 && ($this->file[0] === '/' or (isset($this->file[1]) and $this->file[1] === ':')))
 		{
-			// don't search further, load only the requested file
+			// if the file exists, don't search further, load only the requested file
 			return $paths;
 		}
 


### PR DESCRIPTION
I think we should check if the file exists even if its path is absolute
