### PR TITLE
Add loading of env specific module configs from main config dir

### DIFF
--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -126,7 +126,14 @@ abstract class Config_File implements Config_Interface
 			return $paths;
 		}
 
+		// look for environment module configs in app/modules/mod/config/env/...
 		$paths = array_merge(\Finder::search('config/'.\Fuel::$env, $this->file, $this->ext, true), $paths);
+
+		// look for environment module configs in app/config/env/modules/mod/...
+		if ($pos = strripos($this->file, '::'))
+		{
+			$paths = array_merge(\Finder::search('config/'.\Fuel::$env.'/modules/'.substr($this->file, 0,$pos), substr($this->file, $pos + 2), $this->ext, true), $paths);
+		}
 
 		if (count($paths) > 0)
 		{


### PR DESCRIPTION
To keep the environment specific code for modules centralized, I added the option to place them in the main app config directory.  This will keep all the environment specific configs near each other, instead of buried throughout the file system.

This change allows configs for modules to be located in:
/fuel/app/module/modname/config/cfg.php
/fuel/app/module/modname/config/environment/cfg.php
..and now..
/fuel/app/config/environment/module/modname/cfg.php

Signed-off-by: Ian Turgeon iturgeon@gmail.com
