### PR TITLE
Added loading of env specific module configs from main config dir

### DIFF
--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -117,6 +117,7 @@ abstract class Config_File implements Config_Interface
 	 */
 	protected function find_file()
 	{
+		// search for configs in packages,modules,and the main app
 		$paths = \Finder::search('config', $this->file, $this->ext, true);
 
 		// absolute path requested?
@@ -127,6 +128,12 @@ abstract class Config_File implements Config_Interface
 		}
 
 		$paths = array_merge(\Finder::search('config/'.\Fuel::$env, $this->file, $this->ext, true), $paths);
+
+		// for modules, also look for environment configs in app/config/env/modules/mymodule/
+		if ($pos = strripos($this->file, '::'))
+		{
+			$paths = array_merge(\Finder::search('config/'.\Fuel::$env.'/modules/'.substr($this->file, 0,$pos), substr($this->file, $pos + 2), $this->ext, true), $paths);
+		}
 
 		if (count($paths) > 0)
 		{


### PR DESCRIPTION
Adds loading of environment specific configurations for modules in to the main app config directory.

This will allow all of the environment/project specific configuration to be in the same location instead of partially buried inside each module's own configuration folder.

Added to 1.3/develop instead of 1.2/develop as requested (functional change not a bug fix)

There is also a pull request for updates to the documentation related to this addition inbound
Signed-off-by: Ian Turgeon iturgeon@gmail.com
