### PR TITLE
Disables dump and inspect in production mode

### DIFF
--- a/classes/debug.php
+++ b/classes/debug.php
@@ -49,7 +49,7 @@ class Debug
 				var_dump($arg);
 			}
 		}
-		else
+		else if (\Fuel::$env !== 'production')
 		{
 			$backtrace = debug_backtrace();
 
@@ -102,45 +102,48 @@ JS;
 	 */
 	public static function inspect()
 	{
-		$backtrace = debug_backtrace();
-
-		// If being called from within, show the file above in the backtrack
-		if (strpos($backtrace[0]['file'], 'core/classes/debug.php') !== FALSE)
+		if (\Fuel::$env !== 'production')
 		{
-			$callee = $backtrace[1];
-			$label = \Inflector::humanize($backtrace[1]['function']);
-		}
-		else
-		{
-			$callee = $backtrace[0];
-			$label = 'Debug';
-		}
+			$backtrace = debug_backtrace();
 
-		$arguments = func_get_args();
-		$total_arguments = count($arguments);
+			// If being called from within, show the file above in the backtrack
+			if (strpos($backtrace[0]['file'], 'core/classes/debug.php') !== FALSE)
+			{
+				$callee = $backtrace[1];
+				$label = \Inflector::humanize($backtrace[1]['function']);
+			}
+			else
+			{
+				$callee = $backtrace[0];
+				$label = 'Debug';
+			}
 
-		$callee['file'] = \Fuel::clean_path($callee['file']);
+			$arguments = func_get_args();
+			$total_arguments = count($arguments);
 
-		if ( ! static::$js_displayed)
-		{
-			echo <<<JS
+			$callee['file'] = \Fuel::clean_path($callee['file']);
+
+			if ( ! static::$js_displayed)
+			{
+				echo <<<JS
 <script type="text/javascript">function fuel_debug_toggle(a){if(document.getElementById){if(document.getElementById(a).style.display=="none"){document.getElementById(a).style.display="block"}else{document.getElementById(a).style.display="none"}}else{if(document.layers){if(document.id.display=="none"){document.id.display="block"}else{document.id.display="none"}}else{if(document.all.id.style.display=="none"){document.all.id.style.display="block"}else{document.all.id.style.display="none"}}}};</script>
 JS;
-			static::$js_displayed = true;
-		}
-		echo '<div style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;">';
-		echo '<h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">'.$callee['file'].' @ line: '.$callee['line'].'</h1>';
-		echo '<pre style="overflow:auto;font-size:100%;">';
-		$i = 0;
-		foreach ($arguments as $argument)
-		{
-			echo '<strong>'.$label.' #'.(++$i).' of '.$total_arguments.'</strong>:<br />';
-				echo static::format('...', $argument);
-			echo '<br />';
-		}
+				static::$js_displayed = true;
+			}
+			echo '<div style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;">';
+			echo '<h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">'.$callee['file'].' @ line: '.$callee['line'].'</h1>';
+			echo '<pre style="overflow:auto;font-size:100%;">';
+			$i = 0;
+			foreach ($arguments as $argument)
+			{
+				echo '<strong>'.$label.' #'.(++$i).' of '.$total_arguments.'</strong>:<br />';
+					echo static::format('...', $argument);
+				echo '<br />';
+			}
 
-		echo "</pre>";
-		echo "</div>";
+			echo "</pre>";
+			echo "</div>";
+		}
 	}
 
 	/**


### PR DESCRIPTION
We might forget some Debug::dump() and do not want to see the outputs in production mode.
