### PR TITLE
added Input::param_valid($key, $array)

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -424,6 +424,25 @@ class Input
 	}
 
 	/**
+	 * Fetch an item from either the GET, POST, PUT or DELETE array restricting to a specific set of values
+	 * 
+	 * @param  string $key           The index key
+	 * @param  array  $valid_values  The array of values that are permissible, if one is not selected, picks first
+	 * @return mixed  The value
+	 */
+	public static function param_valid($key, $valid_values)
+	{
+		settype($valid_values, 'array');
+		$valid_values = array_merge(array_unique($valid_values));
+		$value = static::param($key);
+		if (!in_array($value, $valid_values)) 
+		{
+			return $valid_values[0];
+		}
+		return $value;
+	}
+
+	/**
 	 * Hydrates the input array
 	 *
 	 * @return  void


### PR DESCRIPTION
Taken from Flourish:
http://flourishlib.com/docs/fRequest#RestrictingValidValues

The method param_valid() simplifies the process a great deal by taking
exactly two parameters, $key, the key to request the value for and
$valid_values, an array of permissible values. If the value is not one
of the valid value, the first valid value will be picked. Here is an
example:

<?php
// $action will get the value 'list' if no value was present
$action = Input::param_valid('action', array('list', 'search'));
?>
