### PR TITLE
Don't cache Config defaults

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -170,9 +170,9 @@ class Config
 		}
 		elseif ( ! isset(static::$itemcache[$item]))
 		{
-			$val = \Fuel::value(\Arr::get(static::$items, $item, null));
+			$val = \Fuel::value(\Arr::get(static::$items, $item, hex2bin('DEADBEEFCAFE')));
 			
-			if ($val === null)
+			if ($val === hex2bin('DEADBEEFCAFE'))
 			{
 				return $default;
 			}

--- a/classes/config.php
+++ b/classes/config.php
@@ -170,7 +170,14 @@ class Config
 		}
 		elseif ( ! isset(static::$itemcache[$item]))
 		{
-			static::$itemcache[$item] = \Fuel::value(\Arr::get(static::$items, $item, $default));
+			$val = \Fuel::value(\Arr::get(static::$items, $item, null));
+			
+			if ($val === null)
+			{
+				return $default;
+			}
+			
+			static::$itemcache[$item] = $val;
 		}
 
 		return static::$itemcache[$item];

--- a/classes/config.php
+++ b/classes/config.php
@@ -164,15 +164,17 @@ class Config
 	 */
 	public static function get($item, $default = null)
 	{
+		static $default_check_value = hex2bin('DEADBEEFCAFE');
+		
 		if (isset(static::$items[$item]))
 		{
 			return static::$items[$item];
 		}
 		elseif ( ! isset(static::$itemcache[$item]))
 		{
-			$val = \Fuel::value(\Arr::get(static::$items, $item, hex2bin('DEADBEEFCAFE')));
+			$val = \Fuel::value(\Arr::get(static::$items, $item, $default_check_value));
 			
-			if ($val === hex2bin('DEADBEEFCAFE'))
+			if ($val === $default_check_value)
 			{
 				return $default;
 			}


### PR DESCRIPTION
Fixes #1119

The default value does not want to be saved in `static::$itemcache`, the best way I can think to do this is detect when `null` (or any other value that is fairly uncommon) is returned by the `Arr::get()` and return the default without caching it.

I also thought about using the actual default in the `Arr::get()` and checking the value returned against `$default`, but imo this is more likely to stop an actual value from being cached than checking null.
