### PR TITLE
Made non-custom URLs routing case-sensitive

### DIFF
--- a/classes/router.php
+++ b/classes/router.php
@@ -257,9 +257,13 @@ class Router
 	protected static function parse_segments($segments, $namespace = '', $module = false)
 	{
 		$temp_segments = $segments;
+        $case_sensitive = \Config::get('routing.case_sensitive', true);
 
 		foreach (array_reverse($segments, true) as $key => $segment)
 		{
+            if (($case_sensitive) && ($segment != mb_strtolower($segment))) {
+                return false;
+            }
 			$class = $namespace.static::$prefix.\Inflector::words_to_upper(implode('_', $temp_segments));
 			array_pop($temp_segments);
 			if (class_exists($class))


### PR DESCRIPTION
I have modified the `parse_segments` function in the `Fuel\Core\Router` class so it checks each segment of the URL to route. If one of these segments isn't all lowercase, the function will return `false` which will result in a 404.

This additional constraint on non-custom URLs will be triggered depending on the current value of the `routing.case_sensitive` config parameter, which is involved in the similar behavior for custom (routed) URLs.

The aim of this modification is to avoid duplicate content (having multiple URLs targetting the exact same page) for SEO.
