### PR TITLE
Model_CRUD : Set empty values to NULL

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -420,6 +420,11 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 
 		$vars = $this->to_array();
 
+		// Set empty values to NULL
+		foreach ($vars as &$var) {
+			$var = !empty($var) ? $var : null;
+		}
+
 		// Set default if there are any
 		isset(static::$_defaults) and $vars = $vars + static::$_defaults;
 


### PR DESCRIPTION
I noticed that the Model_CRUD was not updating the database field when an empty value was set().

```
$my_model_crud->set(array( 
    'name'      => Input::param('name'), 
    'birthdate'     => Input::param('birthdate'),  
    'language'      => Input::param('language'),  // Value is empty ($_POST['language'] exists)
))->save();
```

This commit set empty properties to NULL.
