### PR TITLE
Added check if path key exists while iterating

### DIFF
--- a/classes/finder.php
+++ b/classes/finder.php
@@ -149,8 +149,8 @@ class Finder
 	public function remove_path($path)
 	{
 		for ($i = 0, $count = count($this->paths); $i < $count; $i++)
-		{
-			if ($this->paths[$i] === $path)
+		{			
+			if (array_key_exists($i, $this->paths) && $this->paths[$i] === $path)
 			{
 				unset($this->paths[$i]);
 				break;


### PR DESCRIPTION
If a path with position lower than any other in iteration, it will throw a notice due to non-existing key.
