### PR TITLE
Adding support for Themes to be Module Aware

### DIFF
--- a/config/theme.php
+++ b/config/theme.php
@@ -40,4 +40,9 @@ return array(
 	 * The theme info file name
 	 */
 	'info_file_name' => 'themeinfo.php',
+	
+	/**
+	 * If the theme will be module aware
+	 */
+	'module_aware' => false,
 );


### PR DESCRIPTION
Making Theme Module Aware we can keep all views on the modules and only extend the views we need to change in certain theme.

Example:

If use it on a module:

```
$data['content'] = Theme::instance()->view('index'); // with $module_aware = true in config
```

or

```
\Theme::instance()->set_partial('content', 'index', true, true);
```

It will do the following search:

```
themes/<theme>/<module>/index
modules/<module>/views/index
```

Let me know your thoughts.
