### PR TITLE
Update classes/database/pdo/connection.php

### DIFF
--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -341,5 +341,10 @@ class Database_PDO_Connection extends \Database_Connection
 		$this->_in_transaction = false;
 		return $this->_connection->rollBack();
 	}
+	
+	public function error_info()
+    	{
+        	return $this->_connection->errorInfo();
+    	}
 
 }


### PR DESCRIPTION
Manual: http://www.php.net/manual/en/pdo.errorinfo.php - PHP 5 >= 5.1.0
Inclusion of method 'error_info()' to support the method 'PDO::errorInfo()' that returns an array of information about the last error that occurred operation performed by the database.
