### PR TITLE
Model_Crud accepts now composite primary keys

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -83,7 +83,14 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 	 */
 	public static function find_by_pk($value)
 	{
-		return static::find_one_by(static::primary_key(), $value);
+		if (is_array(static::primary_key())) 
+		{
+			return static::find_one_by($value);
+		} 
+		else
+		{
+			return static::find_one_by(static::primary_key(), $value);
+		}
 	}
 
 	/**
@@ -240,7 +247,21 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 	 */
 	public static function count($column = null, $distinct = true, $where = array(), $group_by = null)
 	{
-		$select = $column ?: static::primary_key();
+		if ($column) 
+		{
+			$select = $column;
+		}
+		else {
+			if (is_array(static::primary_key()))
+			{
+				$primary_keys	=& static::primary_key();
+				$select			= $primary_keys[0];
+			}
+			else 
+			{
+				$select = static::primary_key();
+			}
+		}
 
 		// Get the database group / connection
 		$connection = isset(static::$_connection) ? static::$_connection : null;
@@ -363,9 +384,28 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 	 */
 	public function __construct(array $data = array())
 	{
-		if (isset($this->{static::primary_key()}))
+
+		if (is_array(static::primary_key()))
 		{
-			$this->is_new(false);
+			foreach (static::primary_key() as $pk)
+			{
+				if (isset($this->{$pk})) 
+				{
+					$this->is_new(false);
+				} 
+				else
+				{
+					$this->is_new(true);
+					break;
+				}
+			}
+		}
+		else
+		{
+			if (isset($this->{static::primary_key()}))
+			{
+				$this->is_new(false);
+			}	
 		}
 
 		if ( ! empty($data))
@@ -483,12 +523,34 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 			if ($result[1] > 0)
 			{
 				// workaround for PDO connections not returning the insert_id
-				if ($result[0] === false and isset($vars[static::primary_key()]))
+				if ($result[0] === false)
 				{
-					$result[0] = $vars[static::primary_key()];
+					if (is_array(static::primary_key()))
+					{	
+						// TODO
+					}
+					else 
+					{
+						if (isset($vars[static::primary_key()]))
+						{
+							$result[0] = $vars[static::primary_key()];
+						}
+					}
 				}
+
 				$this->set($vars);
-				empty($result[0]) or $this->{static::primary_key()} = $result[0];
+
+				if (!empty($result[0]))
+				{
+					if (is_array(static::primary_key()))
+					{
+						// TODO: does mysql returns composite insert pk?
+					}
+					else
+					{
+						$this->{static::primary_key()} = $result[0];
+					}
+				}
 				$this->is_new(false);
 			}
 
@@ -496,8 +558,20 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 		}
 
 		$query = \DB::update(static::$_table_name)
-		         ->set($vars)
-		         ->where(static::primary_key(), '=', $this->{static::primary_key()});
+		         ->set($vars);
+
+		// composite primary key   
+		if (is_array(static::primary_key()))
+		{
+			foreach (static::primary_key() as $pk)
+			{
+				$query->where($pk, '=', $this->{$pk});
+			}
+		}
+		else 
+		{				
+			$query->where(static::primary_key(), '=', $this->{static::primary_key()});
+		}
 
 		$this->pre_update($query);
 		$result = $query->execute(isset(static::$_connection) ? static::$_connection : null);
@@ -514,8 +588,20 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess {
 	public function delete()
 	{
 		$this->frozen(true);
-		$query = \DB::delete(static::$_table_name)
-		            ->where(static::primary_key(), '=', $this->{static::primary_key()});
+		$query = \DB::delete(static::$_table_name);
+
+		// composite primary key   
+		if (is_array(static::primary_key()))
+		{
+			foreach (static::primary_key() as $pk)
+			{
+				$query->where($pk, '=', $this->{$pk});
+			}
+		}
+		else 
+		{				
+			$query->where(static::primary_key(), '=', $this->{static::primary_key()});
+		}
 
 		$this->pre_delete($query);
 		$result = $query->execute(isset(static::$_connection) ? static::$_connection : null);


### PR DESCRIPTION
The Model_Crud accepts a composite primary keys with this commit:

```
 protected static $_primary_key = array('user_id', 'friend_id');
```

So the model crud will correctly saves, updates and deletes tables with multiple/composite primary keys.
$_primary_key and find_by_pk accepts an array (too) now :

```
 \MyModel::find_by_pk(array(
      'user_id'  => 10,
      'friend_id' => 14,
 ));
```

See todos: I didn't figure out how to returns ids since:
- I don't know if it should returns an array  
- I use postgresql which causes model_crud/orm not returning ids anyway.
