### PR TITLE
Must get the cookie via post

### DIFF
--- a/classes/session/driver.php
+++ b/classes/session/driver.php
@@ -453,7 +453,7 @@ abstract class Session_Driver
 	 protected function _get_cookie()
 	 {
 		// was the cookie posted?
-		$cookie = \Input::cookie($this->config['post_cookie_name'], false);
+		$cookie = \Input::post($this->config['post_cookie_name'], false);
 
 		// if not found, fetch the regular cookie
 		if ($cookie === false)


### PR DESCRIPTION
It seems that this line of code has changed from (1.2/master)

$cookie = \Input::param($this->config['post_cookie_name'], false);

to (1.3/master)

$cookie = \Input::cookie($this->config['post_cookie_name'], false);

but the code that works is:

$cookie = \Input::post($this->config['post_cookie_name'], false);

In order to work with uploadify who sends the session cookie vía post variable.
