### PR TITLE
Fix auto_rename file checking logic

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -605,9 +605,20 @@ class Upload
 					do
 					{
 						$save_as[3] = '_'.++$counter;
-						$fp = @fopen($path.implode('', $save_as), 'x');
 					}
-					while ($fp === false);
+					while (file_exists($path.implode('', $save_as)));
+
+					// create file to ensure that there is no file after checking above
+					$fp = @fopen($path.implode('', $save_as), 'x');
+					if ($fp === false)
+					{
+						do
+						{
+							$save_as[3] = '_'.++$counter;
+							$fp = @fopen($path.implode('', $save_as), 'x');
+						}
+						while ($fp === false);
+					}
 				}
 				else
 				{

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -596,7 +596,8 @@ class Upload
 
 
 			// check if the file already exists
-			if (file_exists($path.implode('', $save_as)))
+			$fp = @fopen($path.implode('', $save_as), 'x');
+			if ($fp === false)
 			{
 				if ( (bool) static::$config['auto_rename'])
 				{
@@ -604,8 +605,9 @@ class Upload
 					do
 					{
 						$save_as[3] = '_'.++$counter;
+						$fp = @fopen($path.implode('', $save_as), 'x');
 					}
-					while (file_exists($path.implode('', $save_as)));
+					while ($fp === false);
 				}
 				else
 				{
@@ -617,6 +619,7 @@ class Upload
 					}
 				}
 			}
+			fclose($fp);
 
 			// no need to store it as an array anymore
 			$save_as = implode('', $save_as);


### PR DESCRIPTION
There is a bug if there are uploadings with the same filename at the same time, uploaded files may be overwritten even if set auto_rename true.

Fix it by creating file with fopen 'x' and ensure not to be overwritten.
