### PR TITLE
Make Hybrid Controller's rest/template switching logic easily customizable.

### DIFF
--- a/classes/controller/hybrid.php
+++ b/classes/controller/hybrid.php
@@ -34,7 +34,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 */
 	public function before()
 	{
-		if ( ! $this->shall_return_restful())
+		if ( ! $this->is_restful())
 		{
 			if ( ! empty($this->template) and is_string($this->template))
 			{
@@ -53,7 +53,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 */
 	public function after($response)
 	{
-		if ( ! $this->shall_return_restful())
+		if ( ! $this->is_restful())
 		{
 			// If nothing was returned default to the template
 			if (empty($response))
@@ -88,7 +88,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	public function router($resource, array $arguments)
 	{
 		// if this is an ajax call
-		if ($this->shall_return_restful())
+		if ($this->is_restful())
 		{
 			// have the Controller_Rest router deal with it
 			return parent::router($resource, $arguments);
@@ -106,12 +106,12 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	}
 	
 	/**
-	 * Decide whether to return REST or templated response
+	 * Decide whether to return RESTful or templated response
 	 * Override in subclass to introduce custom switching logic.
 	 *
 	 * @param  boolean
 	 */
-	public function shall_return_restful()
+	public function is_restful()
 	{
 		return \Input::is_ajax();
 	}

--- a/classes/controller/hybrid.php
+++ b/classes/controller/hybrid.php
@@ -34,7 +34,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 */
 	public function before()
 	{
-		if ( ! \Input::is_ajax())
+		if ( ! $this->shall_return_restful())
 		{
 			if ( ! empty($this->template) and is_string($this->template))
 			{
@@ -53,7 +53,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 */
 	public function after($response)
 	{
-		if ( ! \Input::is_ajax())
+		if ( ! $this->shall_return_restful())
 		{
 			// If nothing was returned default to the template
 			if (empty($response))
@@ -88,7 +88,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	public function router($resource, array $arguments)
 	{
 		// if this is an ajax call
-		if (\Input::is_ajax())
+		if ($this->shall_return_restful())
 		{
 			// have the Controller_Rest router deal with it
 			return parent::router($resource, $arguments);
@@ -103,5 +103,16 @@ abstract class Controller_Hybrid extends \Controller_Rest
 
 		// if not, we got ourselfs a genuine 404!
 		throw new \HttpNotFoundException();
+	}
+	
+	/**
+	 * Decide whether to return REST or templated response
+	 * Override in subclass to introduce custom switching logic.
+	 *
+	 * @param  boolean
+	 */
+	public function shall_return_restful()
+	{
+		return \Input::is_ajax();
 	}
 }


### PR DESCRIPTION
Take advantage of the Hollywood principle in order to easily provide custom switching logic for hybrid controllers.

Example:

If one wanted to enable RESTful responses for ajax calls as well as all requests ending with any of the known format extensions (`…/foo/bar.json`) one could simply override `shall_return_restful()` in the subclass:

```
public function shall_return_restful()
{
    if (array_key_exists(\Input::extension(), $this->_supported_formats))
    {
        return true;
    }
    return parent::shall_return_restful(); // or return false for full override
}
```
