### PR TITLE
Use '.' as directory separator in view file path

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -34,6 +34,17 @@ class Uri
 	{
 		if ($request = \Request::active())
 		{
+			switch ($segment)
+			{
+				case 'first':
+				$segment = 0;
+				break;
+				
+				case 'last':
+				$segment = count($request->uri->segments());
+				break;
+			}
+			
 			return $request->uri->get_segment($segment, $default);
 		}
 

--- a/classes/view.php
+++ b/classes/view.php
@@ -374,7 +374,13 @@ class View
 	{
 		// set find_file's one-time-only search paths
 		\Finder::instance()->flash($this->request_paths);
-
+		
+		// search / replace "." to "/" in view string
+		if (strpos($file, '.') !== false)
+		{
+			$file = str_replace('.', '/', $file);
+		}
+		
 		// locate the view file
 		if (($path = \Finder::search('views', $file, '.'.$this->extension, false, false)) === false)
 		{


### PR DESCRIPTION
Add Arr::get() like syntax support for view paths. Ie:

`View::forge('folder.subfolder.file')`
