### PR TITLE
Disable path cache on config file reload

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -94,7 +94,7 @@ class Config
 		{
 			try
 			{
-				$config = $file->load($overwrite);
+				$config = $file->load($overwrite, ! $reload);
 			}
 			catch (\ConfigException $e)
 			{

--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -36,9 +36,9 @@ abstract class Config_File implements Config_Interface
 	 * @param   bool  $overwrite  Whether to overwrite existing values
 	 * @return  array  the config array
 	 */
-	public function load($overwrite = false)
+	public function load($overwrite = false, $cache = true)
 	{
-		$paths = $this->find_file();
+		$paths = $this->find_file($cache);
 		$config = array();
 
 		foreach ($paths as $path)
@@ -115,7 +115,7 @@ abstract class Config_File implements Config_Interface
 	 * @param   bool  $multiple  Whether to load multiple files or not
 	 * @return  array
 	 */
-	protected function find_file()
+	protected function find_file($cache = true)
 	{
 		if (($this->file[0] === '/' or (isset($this->file[1]) and $this->file[1] === ':')) and is_file($this->file))
 		{
@@ -124,8 +124,8 @@ abstract class Config_File implements Config_Interface
 		else
 		{
 			$paths = array_merge(
-				\Finder::search('config/'.\Fuel::$env, $this->file, $this->ext, true),
-				\Finder::search('config', $this->file, $this->ext, true)
+				\Finder::search('config/'.\Fuel::$env, $this->file, $this->ext, true, $cache),
+				\Finder::search('config', $this->file, $this->ext, true, $cache)
 			);
 		}
 

--- a/classes/finder.php
+++ b/classes/finder.php
@@ -330,7 +330,7 @@ class Finder
 		$file = $this->prep_path($dir).$file.$ext;
 		$cache_id .= $file;
 
-		if ($cached_path = $this->from_cache($cache_id))
+		if ($cache and $cached_path = $this->from_cache($cache_id))
 		{
 			return $cached_path;
 		}


### PR DESCRIPTION
This fixes a problem whereby when you reload a config file (e.g. `\Config::load('db', true, true)`) it was still looking in a cached list of paths, whereas more paths had subsequently been added to Finder since that config file was initially loaded.
