### PR TITLE
Print string if translation of it did't found.

### DIFF
--- a/classes/lang.php
+++ b/classes/lang.php
@@ -193,6 +193,7 @@ class Lang
 			$language = reset($languages);
 		}
 
+		$default = ($default) ? $default : $line;
 		return isset(static::$lines[$language]) ? \Str::tr(\Fuel::value(\Arr::get(static::$lines[$language], $line, $default)), $params) : $default;
 	}
 


### PR DESCRIPTION
It allows don't duplicate translating if in views use one of site languages.
