### PR TITLE
Ensure PhpErrorException is loaded.

### DIFF
--- a/base.php
+++ b/base.php
@@ -363,8 +363,6 @@ if ( ! function_exists('load_error_classes'))
 	{
 		class_exists('Fuel\\Core\\Error') or import('error');
 		class_exists('Error') or class_alias('Fuel\\Core\\Error', 'Error');
-
-		class_exists('Fuel\\Core\\PhpErrorException') or import('phperrorexception');
 		class_exists('PhpErrorException') or class_alias('Fuel\\Core\\PhpErrorException', 'PhpErrorException');
 
 		class_exists('Fuel\\Core\\Debug') or import('debug');

--- a/base.php
+++ b/base.php
@@ -364,6 +364,9 @@ if ( ! function_exists('load_error_classes'))
 		class_exists('Fuel\\Core\\Error') or import('error');
 		class_exists('Error') or class_alias('Fuel\\Core\\Error', 'Error');
 
+		class_exists('Fuel\\Core\\PhpErrorException') or import('phperrorexception');
+		class_exists('PhpErrorException') or class_alias('Fuel\\Core\\PhpErrorException', 'PhpErrorException');
+
 		class_exists('Fuel\\Core\\Debug') or import('debug');
 		class_exists('Debug') or class_alias('Fuel\\Core\\Debug', 'Debug');
 


### PR DESCRIPTION
I was getting this error after updating a site's submodules from 1.3/develop to 1.4/develop

> ErrorException [ Error ]: Class 'PhpErrorException' not found

After fixing it, I can see what was originally happening.

> Runtime Notice!
> ErrorException [ Runtime Notice ]: Declaration of Media_Manager\Model_Video::to_array() should be compatible with Orm\Model::to_array($custom = false, $recurse = false)
