### PR TITLE
Fix misjudgment of Response object if users write \Fuel\Core\Response in...

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -41,7 +41,7 @@ abstract class Controller
 	public function after($response)
 	{
 		// Make sure the $response is a Response object
-		if ( ! $response instanceof \Response)
+		if ( ! $response instanceof Response)
 		{
 			$response = \Response::forge($response);
 		}

--- a/classes/request.php
+++ b/classes/request.php
@@ -447,7 +447,7 @@ class Request
 		}
 
 		// Get the controller's output
-		if ($response instanceof \Response)
+		if ($response instanceof Response)
 		{
 			$this->response = $response;
 		}


### PR DESCRIPTION
... controllers

I don't know this is a bug or not.

If you write like this in your controller

```
public function action_image($id = null, $name = null)
{
    …
    $body = file_get_contents($path);
    return \Fuel\Core\Response::forge($body, 200, array('Content-Type' => 
'image/png'));
}
```

`if ( ! $response instanceof \Response)` will return true, because there is no \Response class. And Status code and Content-Type will be gone, because of next line `$response = \Response::forge($response);`

This PR fixes it.
