### PR TITLE
Update classes/session/driver.php

### DIFF
--- a/classes/session/driver.php
+++ b/classes/session/driver.php
@@ -265,7 +265,7 @@ abstract class Session_Driver
 
 			if (isset($this->flash[$this->config['flash_id'].'::'.$name]))
 			{
-				$this->flash[$this->config['flash_id'].'::'.$name]['state'] = 'used';
+				$this->flash[$this->config['flash_id'].'::'.$name]['state'] = 'old';
 				if ($keys)
 				{
 					$default = \Arr::get($this->flash[$this->config['flash_id'].'::'.$name]['value'], $keys[0], $default);


### PR DESCRIPTION
The latest commit to the classes/session/driver.php introduced a bug that prevented flash data from being erased from the session once it was used. This small change fixes it.
