### PR TITLE
Add query string pagination functionality

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -216,9 +216,6 @@ class Pagination
 				$this->template[$name] = $value;
 			}
 		}
-
-		// update the page counters
-		$this->_recalculate();
 	}
 
 	/**
@@ -250,6 +247,8 @@ class Pagination
 	 */
 	public function pages_render()
 	{
+		$this->_recalculate();
+
 		// no links if we only have one page
 		if ($this->config['total_pages'] == 1)
 		{
@@ -276,7 +275,14 @@ class Pagination
 			}
 			else
 			{
-				$url = ($i == 1) ? '' : '/'.$i;
+				if (is_null($this->config['uri_segment']))
+				{
+					$url = $i;
+				}
+				else
+				{
+					$url = ($i == 1) ? '' : '/'.$i;
+				}
 
 				$html .= str_replace(
 				    '{link}',
@@ -300,6 +306,8 @@ class Pagination
 	{
 		$html = '';
 
+		$this->_recalculate();
+
 		if ($this->config['total_pages'] > 1)
 		{
 			if ($this->config['current_page'] == 1)
@@ -313,7 +321,10 @@ class Pagination
 			else
 			{
 				$previous_page = $this->config['current_page'] - 1;
-				$previous_page = ($previous_page == 1) ? '' : '/'.$previous_page;
+				if ( ! is_null($this->config['uri_segment']))
+				{
+					$previous_page = ($previous_page == 1) ? '' : '/'.$previous_page;
+				}
 
 				$html = str_replace(
 				    '{link}',
@@ -337,6 +348,8 @@ class Pagination
 	{
 		$html = '';
 
+		$this->_recalculate();
+
 		if ($this->config['total_pages'] > 1)
 		{
 			if ($this->config['current_page'] == $this->config['total_pages'])
@@ -349,7 +362,14 @@ class Pagination
 			}
 			else
 			{
-				$next_page = '/'.($this->config['current_page'] + 1);
+				if (is_null($this->config['uri_segment']))
+				{
+					$next_page = $this->config['current_page'] + 1;
+				}
+				else
+				{
+					$next_page = '/'.($this->config['current_page'] + 1);
+				}
 
 				$html = str_replace(
 				    '{link}',
@@ -371,7 +391,15 @@ class Pagination
 		$this->config['total_pages'] = ceil($this->config['total_items'] / $this->config['per_page']) ?: 1;
 
 		// calculate the current page number
-		$this->config['current_page'] = ($this->config['total_items'] > 0 and $this->config['current_page'] > 1) ? $this->config['current_page'] : (int) \Request::main()->uri->get_segment($this->config['uri_segment']);
+		if (is_null($this->config['uri_segment']))
+		{
+			$page = $this->config['current_page'];
+		}
+		else
+		{
+			$page = (int) \Request::main()->uri->get_segment($this->config['uri_segment']);
+		}
+		$this->config['current_page'] = ($this->config['total_items'] > 0 and $this->config['current_page'] > 1) ? (int) $this->config['current_page'] : $page;
 
 		// make sure the current page is within bounds
 		if ($this->config['current_page'] > $this->config['total_pages'])

--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -215,7 +215,7 @@ class Pagination
 			$param = $this->config['uri_segment'];
 			$get = \Input::get();
 			$get[$param] = '{page}';
-			$this->config['pagination_url'] .= '?' . http_build_query($get);
+			$this->config['pagination_url'] .= '?'.http_build_query($get);
 			$this->config['pagination_url'] = preg_replace('/%7Bpage%7D/', '{page}', $this->config['pagination_url']);
 			$this->__set('current_page', (int) \Input::get($param));
 		}

--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -178,6 +178,8 @@ class Pagination
 	 */
 	public function __get($name)
 	{
+		$this->_recalculate();
+
 		if (array_key_exists($name, $this->config))
 		{
 			return $this->config[$name];
@@ -210,6 +212,14 @@ class Pagination
 			if (array_key_exists($name, $this->config))
 			{
 				$this->config[$name] = $value;
+
+				if ($name === 'pagination_url')
+				{
+					if (strpos($this->config[$name], '{page}') === FALSE)
+					{
+						$this->config[$name] = rtrim($this->config['pagination_url'], '/').'/{page}';
+					}
+				}
 			}
 			elseif (array_key_exists($name, $this->template))
 			{
@@ -275,18 +285,10 @@ class Pagination
 			}
 			else
 			{
-				if (is_null($this->config['uri_segment']))
-				{
-					$url = $i;
-				}
-				else
-				{
-					$url = ($i == 1) ? '' : '/'.$i;
-				}
-
+				$url = str_replace('{page}', $i, $this->config['pagination_url']);
 				$html .= str_replace(
 				    '{link}',
-				    str_replace(array('{uri}', '{page}'), array(rtrim($this->config['pagination_url'], '/').$url, $i), $this->template['regular-link']),
+				    str_replace(array('{uri}', '{page}'), array($url, $i), $this->template['regular-link']),
 				    $this->template['regular']
 				);
 			}
@@ -321,14 +323,11 @@ class Pagination
 			else
 			{
 				$previous_page = $this->config['current_page'] - 1;
-				if ( ! is_null($this->config['uri_segment']))
-				{
-					$previous_page = ($previous_page == 1) ? '' : '/'.$previous_page;
-				}
 
+				$url = str_replace('{page}', $previous_page, $this->config['pagination_url']);
 				$html = str_replace(
 				    '{link}',
-				    str_replace(array('{uri}', '{page}'), array(rtrim($this->config['pagination_url'], '/').$previous_page, $marker), $this->template['previous-link']),
+				    str_replace(array('{uri}', '{page}'), array($url, $marker), $this->template['previous-link']),
 				    $this->template['previous']
 				);
 			}
@@ -362,18 +361,12 @@ class Pagination
 			}
 			else
 			{
-				if (is_null($this->config['uri_segment']))
-				{
-					$next_page = $this->config['current_page'] + 1;
-				}
-				else
-				{
-					$next_page = '/'.($this->config['current_page'] + 1);
-				}
+				$next_page = $this->config['current_page'] + 1;
 
+				$url = str_replace('{page}', $next_page, $this->config['pagination_url']);
 				$html = str_replace(
 				    '{link}',
-				    str_replace(array('{uri}', '{page}'), array(rtrim($this->config['pagination_url'], '/').$next_page, $marker), $this->template['next-link']),
+				    str_replace(array('{uri}', '{page}'), array($url, $marker), $this->template['next-link']),
 				    $this->template['next']
 				);
 			}

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -20,20 +20,73 @@ namespace Fuel\Core;
  */
 class Test_Pagination extends TestCase
 {
-	public function setup()
+	public static function tearDownAfterClass()
+	{
+		// reset Request::$main
+		$request = \Request::forge();
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, false);
+		// reset Request::$active
+		$rp = new \ReflectionProperty($request, 'active');
+		$rp->setAccessible(true);
+		$rp->setValue($request, false);
+	}
+
+/**********************************
+ * Tests for URI Segment Pagination
+ **********************************/
+
+	protected function set_uri_segment_config()
 	{
 		$this->config = array(
-			'uri_segment'    => null,
-			'pagination_url' => 'http://docs.fuelphp.com/?p={page}',
+			'uri_segment'    => 3,
+			'pagination_url' => 'http://docs.fuelphp.com/welcome/index/',
 			'total_items'    => 100,
 			'per_page'       => 10,
 		);
 	}
 
-	public function test_get_total_pages()
+	public function test_uri_segment_auto_detect_pagination_url()
 	{
-		$pagination = Pagination::forge('mypagination', $this->config);
-		$pagination->current_page = 1;
+		// set Request::$main
+		$request = \Request::forge('welcome/index/3');
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+		// set Request::$active
+		$rp = new \ReflectionProperty($request, 'active');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+		// set base_url
+		Config::set('base_url', 'http://docs.fuelphp.com/welcome/index/');
+		$uri = new \Uri('/welcome/index/3');
+
+		$this->set_uri_segment_config();
+		$this->config['pagination_url'] = null;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+		$test = $pagination->pagination_url;
+		$expected = 'http://docs.fuelphp.com/welcome/index/welcome/index/{page}';
+		$this->assertEquals($expected, $test);
+
+		// reset base_url
+		Config::set('base_url', null);
+		// reset Request::$active
+		$rp->setValue($request, false);
+	}
+
+	public function test_uri_segment_get_total_pages()
+	{
+		// set Request::$main
+		$request = \Request::forge('welcome/index/');
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+
+		$this->set_uri_segment_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
 		$test = $pagination->total_pages;
 		$expected = 10;
 		$this->assertEquals($expected, $test);
@@ -43,9 +96,153 @@ class Test_Pagination extends TestCase
 	 * first page
 	 *
 	 */
-	public function test_first_page()
+	public function test_uri_segment_first_page()
 	{
-		$pagination = Pagination::forge('mypagination', $this->config);
+		// set Request::$main
+		$request = \Request::forge('welcome/index/');
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+
+		$this->set_uri_segment_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		$output = $pagination->previous();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="previous-inactive"><a href="#">&laquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->pages_render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="active"><a href="#">1</a></span><span><a href="http://docs.fuelphp.com/welcome/index/2">2</a></span><span><a href="http://docs.fuelphp.com/welcome/index/3">3</a></span><span><a href="http://docs.fuelphp.com/welcome/index/4">4</a></span><span><a href="http://docs.fuelphp.com/welcome/index/5">5</a></span><span><a href="http://docs.fuelphp.com/welcome/index/6">6</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->next();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="next"><a href="http://docs.fuelphp.com/welcome/index/2">&raquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<div class="pagination"><span class="previous-inactive"><a href="#">&laquo;</a></span><span class="active"><a href="#">1</a></span><span><a href="http://docs.fuelphp.com/welcome/index/2">2</a></span><span><a href="http://docs.fuelphp.com/welcome/index/3">3</a></span><span><a href="http://docs.fuelphp.com/welcome/index/4">4</a></span><span><a href="http://docs.fuelphp.com/welcome/index/5">5</a></span><span><a href="http://docs.fuelphp.com/welcome/index/6">6</a></span><span class="next"><a href="http://docs.fuelphp.com/welcome/index/2">&raquo;</a></span></div>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	 * last page
+	 *
+	 */
+	public function test_uri_segment_nextlink_inactive()
+	{
+		// set Request::$main
+		$request = \Request::forge('welcome/index/10');
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+
+		$this->set_uri_segment_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		$output = $pagination->next();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="next-inactive"><a href="#">&raquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->pages_render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span><a href="http://docs.fuelphp.com/welcome/index/6">6</a></span><span><a href="http://docs.fuelphp.com/welcome/index/7">7</a></span><span><a href="http://docs.fuelphp.com/welcome/index/8">8</a></span><span><a href="http://docs.fuelphp.com/welcome/index/9">9</a></span><span class="active"><a href="#">10</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->previous();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="previous"><a href="http://docs.fuelphp.com/welcome/index/9">&laquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<div class="pagination"><span class="previous"><a href="http://docs.fuelphp.com/welcome/index/9">&laquo;</a></span><span><a href="http://docs.fuelphp.com/welcome/index/6">6</a></span><span><a href="http://docs.fuelphp.com/welcome/index/7">7</a></span><span><a href="http://docs.fuelphp.com/welcome/index/8">8</a></span><span><a href="http://docs.fuelphp.com/welcome/index/9">9</a></span><span class="active"><a href="#">10</a></span><span class="next-inactive"><a href="#">&raquo;</a></span></div>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	 * total page is 1
+	 *
+	 */
+	public function test_uri_segment_total_page_is_one()
+	{
+		$this->set_uri_segment_config();
+		$this->config['per_page'] = 1000;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		$output = $pagination->pages_render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '';
+		$this->assertEquals($expected, $output);
+	}
+
+/***********************************
+ * Tests for Query String Pagination
+ ***********************************/
+
+	protected function set_query_string_config()
+	{
+		$this->config = array(
+			'uri_segment'    => 'p',
+			'pagination_url' => 'http://docs.fuelphp.com/',
+			'total_items'    => 100,
+			'per_page'       => 10,
+		);
+	}
+
+	public function test_query_string_auto_detect_pagination_url()
+	{
+		// set base_url
+		Config::set('base_url', 'http://docs.fuelphp.com/');
+		// set Request::$main
+		$request = \Request::forge('/');
+		$rp = new \ReflectionProperty($request, 'main');
+		$rp->setAccessible(true);
+		$rp->setValue($request, $request);
+
+		$this->set_query_string_config();
+		$this->config['pagination_url'] = null;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+		$test = $pagination->pagination_url;
+		$expected = 'http://docs.fuelphp.com/?p={page}';
+		$this->assertEquals($expected, $test);
+
+		// reset base_url
+		Config::set('base_url', null);
+	}
+
+	public function test_query_string_get_total_pages()
+	{
+		$this->set_query_string_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+		$test = $pagination->total_pages;
+		$expected = 10;
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * first page
+	 *
+	 */
+	public function test_query_string_first_page()
+	{
+		$this->set_query_string_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
 		$pagination->current_page = 1;
 
 		$output = $pagination->previous();
@@ -68,9 +265,11 @@ class Test_Pagination extends TestCase
 	 * last page
 	 *
 	 */
-	public function test_nextlink_inactive()
+	public function test_query_string_nextlink_inactive()
 	{
-		$pagination = Pagination::forge('mypagination', $this->config);
+		$this->set_query_string_config();
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
 		$pagination->current_page = 10;
 
 		$output = $pagination->next();

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -13,12 +13,79 @@
 namespace Fuel\Core;
 
 /**
- * Request class tests
+ * Pagination class tests
  *
  * @group Core
- * @group Request
+ * @group Pagination
  */
 class Test_Pagination extends TestCase
 {
- 	public function test_foo() {}
+	public function setup()
+	{
+		$this->config = array(
+			'uri_segment'    => null,
+			'pagination_url' => 'http://docs.fuelphp.com/?p={page}',
+			'total_items'    => 100,
+			'per_page'       => 10,
+		);
+	}
+
+	public function test_get_total_pages()
+	{
+		$pagination = Pagination::forge('mypagination', $this->config);
+		$pagination->current_page = 1;
+		$test = $pagination->total_pages;
+		$expected = 10;
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * first page
+	 *
+	 */
+	public function test_first_page()
+	{
+		$pagination = Pagination::forge('mypagination', $this->config);
+		$pagination->current_page = 1;
+
+		$output = $pagination->previous();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="previous-inactive"><a href="#">&laquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->pages_render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="active"><a href="#">1</a></span><span><a href="http://docs.fuelphp.com/?p=2">2</a></span><span><a href="http://docs.fuelphp.com/?p=3">3</a></span><span><a href="http://docs.fuelphp.com/?p=4">4</a></span><span><a href="http://docs.fuelphp.com/?p=5">5</a></span><span><a href="http://docs.fuelphp.com/?p=6">6</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->next();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="next"><a href="http://docs.fuelphp.com/?p=2">&raquo;</a></span>';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	 * last page
+	 *
+	 */
+	public function test_nextlink_inactive()
+	{
+		$pagination = Pagination::forge('mypagination', $this->config);
+		$pagination->current_page = 10;
+
+		$output = $pagination->next();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="next-inactive"><a href="#">&raquo;</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->pages_render();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span><a href="http://docs.fuelphp.com/?p=6">6</a></span><span><a href="http://docs.fuelphp.com/?p=7">7</a></span><span><a href="http://docs.fuelphp.com/?p=8">8</a></span><span><a href="http://docs.fuelphp.com/?p=9">9</a></span><span class="active"><a href="#">10</a></span>';
+		$this->assertEquals($expected, $output);
+
+		$output = $pagination->previous();
+		$output = str_replace(array("\n", "\t"), "", $output);
+		$expected = '<span class="previous"><a href="http://docs.fuelphp.com/?p=9">&laquo;</a></span>';
+		$this->assertEquals($expected, $output);
+	}
 }


### PR DESCRIPTION
Supporting pagination with query string.

Eg:

```
    $config = array(
        'url_segment'  => 'page',
        'total_items'    => 100,
        'per_page'       => 10,
    );

    $pagination = Pagination::forge('mypagination', $config);
    echo $pagination->render();
```

If url_segment is int, URI segment pagination same as before, else Query string pagination.
