### PR TITLE
Update classes/image/gd.php

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -36,6 +36,14 @@ class Image_Gd extends \Image_Driver
 		// Check if the function exists
 		if (function_exists('imagecreatefrom'.$image_extension))
 		{
+			// Check for the image channels before doing any processing
+			$data = getimagesize($image_fullpath);
+
+			if ( ! isset($data['channels']))
+			{
+				throw new \RuntimeException("Could not get the image channels for: ".$image_fullpath);
+			}
+			
 			// Create a new transparent image.
 			$sizes = $this->sizes($image_fullpath);
 			$tmpImage = call_user_func('imagecreatefrom'.$image_extension, $image_fullpath);


### PR DESCRIPTION
Error: imagecreatefromjpeg(): gd-jpeg: JPEG library reports unrecoverable error:  in /mnt/data/www/fuel/core/classes/image/gd.php on 41

From the tests I've done, this only happens when the Image class tries to process an image without channel information (RGB/CMYK).

To avoid this, we should first check for the info, and throw an Exception if we cannot get it.
