### PR TITLE
Update classes/image/gd.php

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -36,17 +36,15 @@ class Image_Gd extends \Image_Driver
 		// Check if the function exists
 		if (function_exists('imagecreatefrom'.$image_extension))
 		{
-			// Check for the image channels before doing any processing
-			$data = getimagesize($image_fullpath);
-
-			if ( ! isset($data['channels']))
-			{
-				throw new \RuntimeException("Could not get the image channels for: ".$image_fullpath);
-			}
-			
 			// Create a new transparent image.
 			$sizes = $this->sizes($image_fullpath);
-			$tmpImage = call_user_func('imagecreatefrom'.$image_extension, $image_fullpath);
+			$tmpImage = @call_user_func('imagecreatefrom'.$image_extension, $image_fullpath);
+			
+			if ($tmpImage === false)
+			{
+				throw new \RuntimeException("An error occurred in imagecreatefrom".$image_extension."() while loading: ".$image_fullpath);
+			}
+
 			$image = $this->create_transparent_image($sizes->width, $sizes->height, $tmpImage);
 			if ( ! $return_data)
 			{

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -38,13 +38,7 @@ class Image_Gd extends \Image_Driver
 		{
 			// Create a new transparent image.
 			$sizes = $this->sizes($image_fullpath);
-			$tmpImage = @call_user_func('imagecreatefrom'.$image_extension, $image_fullpath);
-			
-			if ($tmpImage === false)
-			{
-				throw new \RuntimeException("An error occurred in imagecreatefrom".$image_extension."() while loading: ".$image_fullpath);
-			}
-
+			$tmpImage = call_user_func('imagecreatefrom'.$image_extension, $image_fullpath);
 			$image = $this->create_transparent_image($sizes->width, $sizes->height, $tmpImage);
 			if ( ! $return_data)
 			{


### PR DESCRIPTION
So I dug a bit further and found out that the unrecoverable error in GB/JPEG library isn't caused by a missing image channel info, although that was the only pattern I was getting at first.

If we set persistence to false (default) in the Image class config, it will call reload() after save/output.

The problem occurs when we save/output a different image format from the one we loaded first (i.e. load a PNG and save/output a JPG).

When loading a PNG and saving a JPG, we have:

On the first load() call:

file: test.png
called method: imagecreatefrompng()
$this->image_extension = 'png'
$image_extension = 'png'

On the second load() call (during save() / called by reload()):

file: test.png
called method: imagecreatefromjpeg()
$this->image_extension = 'jpg'
$image_extension = 'jpeg'

The unrecoverable error happens because on the second load() the class tries to open a PNG with imagecreatefromjpeg().

Since I don't know if this is intended behaviour or not, my proposal is to supress the error to avoid the script from failing, and throw a Runtime Exception so we can gracefuly handle the problem.
