### PR TITLE
Messages of Validation tests independent from application langs files

### DIFF
--- a/tests/validation.php
+++ b/tests/validation.php
@@ -619,6 +619,7 @@ class Test_Validation extends TestCase
 
 		$val = Validation::forge(__FUNCTION__);
 		$val->add('f1', 'F1')->add_rule('valid_string', array('alpha', 'numeric'));
+		$val->set_message('valid_string', 'The valid string rule :rule(:param:1) failed for field :label');
 		$val->run($post);
 
 		$test = $val->error('f1')->get_message();
@@ -638,6 +639,7 @@ class Test_Validation extends TestCase
 
 		$val = Validation::forge(__FUNCTION__);
 		$val->add_field('f1', 'F1', 'valid_string[alpha,numeric]');
+		$val->set_message('valid_string', 'The valid string rule :rule(:param:1) failed for field :label');
 		$val->run($post);
 
 		$test = $val->error('f1')->get_message();


### PR DESCRIPTION
If I've translated the validation lang file ... validation test failed :

<pre>
Tests Running...This may take a few moments.
PHPUnit 3.6.11 by Sebastian Bergmann.

...............................................................  63 / 362 ( 17%)
............................................................... 126 / 362 ( 34%)
............................................................... 189 / 362 ( 52%)
............................................................... 252 / 362 ( 69%)
....................................................FF......... 315 / 362 ( 87%)
...............................................

Time: 3 seconds, Memory: 20.50Mb

There were 2 failures:

1) Fuel\Core\Test_Validation::test_validation_valid_string_multiple_flags_error_message_add_rule
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'The valid string rule valid_string(alpha, numeric) failed for field F1'
+'La regola di validazione "valid_string" è fallita per il campo "<b>F1</b>"'

2) Fuel\Core\Test_Validation::test_validation_valid_string_multiple_flags_error_message_add_field
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'The valid string rule valid_string(alpha, numeric) failed for field F1'
+'La regola di validazione "valid_string" è fallita per il campo "<b>F1</b>"'

FAILURES!
Tests: 362, Assertions: 376, Failures: 2.
</pre>
