### PR TITLE
Cast debug_lines as an array to stop some Twig errors from causing 'Invalid argumen...

### DIFF
--- a/views/errors/php_fatal_error.php
+++ b/views/errors/php_fatal_error.php
@@ -54,7 +54,7 @@
 			<li>
 				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>');return false;"><?php echo \Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
 				<div id="backtrace_<?php echo $id; ?>" class="backtrace_block">
-<pre class="fuel_debug_source"><?php foreach ((array)$debug_lines as $line_num => $line_content): ?>
+<pre class="fuel_debug_source"><?php foreach ((array) $debug_lines as $line_num => $line_content): ?>
 <span<?php echo ($line_num == $trace['line']) ? ' class="fuel_line fuel_current_line"' : ' class="fuel_line"'; ?>><span class="fuel_line_number"><?php echo str_pad($line_num, (strlen(count($debug_lines))), ' ', STR_PAD_LEFT); ?></span><span class="fuel_line_content"><?php echo $line_content . PHP_EOL; ?>
 </span></span><?php endforeach; ?></pre>
 				</div>

--- a/views/errors/php_fatal_error.php
+++ b/views/errors/php_fatal_error.php
@@ -54,7 +54,7 @@
 			<li>
 				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>');return false;"><?php echo \Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
 				<div id="backtrace_<?php echo $id; ?>" class="backtrace_block">
-<pre class="fuel_debug_source"><?php foreach ($debug_lines as $line_num => $line_content): ?>
+<pre class="fuel_debug_source"><?php foreach ((array)$debug_lines as $line_num => $line_content): ?>
 <span<?php echo ($line_num == $trace['line']) ? ' class="fuel_line fuel_current_line"' : ' class="fuel_line"'; ?>><span class="fuel_line_number"><?php echo str_pad($line_num, (strlen(count($debug_lines))), ' ', STR_PAD_LEFT); ?></span><span class="fuel_line_content"><?php echo $line_content . PHP_EOL; ?>
 </span></span><?php endforeach; ?></pre>
 				</div>


### PR DESCRIPTION
...t supplied for foreach()' errors as this was stopping the real error showing through.
