### PR TITLE
Added count to Inflector::pluralize

### DIFF
--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -132,7 +132,7 @@ class Inflector
 
 		// If a counter is provided, and that equals 1
 		// return as singular.
-		if ($count == 1)
+		if ($count === 1)
 		{
 			return $result;
 		}

--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -123,11 +123,19 @@ class Inflector
 	 * Gets the plural version of the given word
 	 *
 	 * @param   string  the word to pluralize
+	 * @param	int		number of instances	
 	 * @return  string  the plural version of $word
 	 */
-	public static function pluralize($word)
+	public static function pluralize($word, $count = 0)
 	{
 		$result = strval($word);
+
+		// If a counter is provided, and that equals 1
+		// return as singular.
+		if ($count == 1)
+		{
+			return $result;
+		}
 
 		if ( ! static::is_countable($result))
 		{

--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -123,7 +123,7 @@ class Inflector
 	 * Gets the plural version of the given word
 	 *
 	 * @param   string  the word to pluralize
-	 * @param	int		number of instances	
+	 * @param   int     number of instances	
 	 * @return  string  the plural version of $word
 	 */
 	public static function pluralize($word, $count = 0)


### PR DESCRIPTION
I thought of this today and I seemed to write a lot of unnecessary code just to get this to work.

Current situation:

```
echo $count.' ';
echo ($count > 1) ? 'people' : 'person';
```

or if you use Inflector::pluralize

```
echo $count.' ';
$entity = 'person';
echo ($count > 1) ? Inflector::pluralize($entity) : $entity;
```

However, this is what I’m proposing:

```
echo $count.' '.Inflector::pluralize('person', $count);
```

And it’ll simply return it if the second parameter is 1.
