### PR TITLE
Add flip() method to the image class

### DIFF
--- a/classes/image.php
+++ b/classes/image.php
@@ -158,7 +158,19 @@ class Image
 	{
 		return static::instance()->rotate($degrees);
 	}
-
+	
+	/**
+	 * Creates a vertical / horizontal or both mirror image.
+	 * 
+	 * @access public
+	 * @param string $direction 'vertical', 'horizontal', 'both'
+	 * @return Image_Driver
+	 */
+	public static function flip($direction)
+	{
+		return static::instance()->flip($direction);
+	}
+	
 	/**
 	 * Adds a watermark to the image.
 	 *

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -214,6 +214,20 @@ abstract class Image_Driver
 		$this->queue('resize', $width, $height, $keepar, $pad);
 		return $this;
 	}
+	
+	
+	/**
+	 * Creates a vertical / horizontal or both mirror image.
+	 * 
+	 * @access public
+	 * @param mixed $direction 'vertical', 'horizontal', 'both'
+	 * @return Image_Driver
+	 */
+	public function flip($direction)
+	{
+		$this->queue('flip', $direction);
+		return $this;
+	}
 
 	/**
 	 * Executes the resize event when the queue is ran.

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -145,6 +145,51 @@ class Image_Gd extends \Image_Driver
 		}
 	}
 
+	protected function _flip($mode)
+	{
+		$sizes	= (array)$this->sizes();
+		$source = array_merge($sizes, array('x' => 0, 'y' => 0));
+		
+		switch ($mode)
+		{
+			case 'vertical':
+			$source['y'] = $sizes['height'] - 1;
+			$source['height'] = -$sizes['height'];
+			break;
+			
+			case 'horizontal':
+			$source['x'] = $sizes['width'] - 1;
+			$source['width']	= -$sizes['width'];
+			break;
+			
+			case 'both':
+			$source['y'] = $sizes['height'] - 1;
+			$source['x'] = $sizes['width'] - 1;
+			$source['height'] = -$sizes['height'];
+			$source['width']	= -$sizes['width'];
+			break;
+			
+			default: return false;
+		}
+		
+		$image = imagecreatetruecolor($sizes['width'], $sizes['height']);
+		
+		imagecopyresampled(
+			$image,
+			$this->image_data,
+			0,
+			0,
+			$source['x'],
+			$source['y'],
+			$sizes['width'],
+			$sizes['height'],
+			$source['width'],
+			$source['height']
+		);
+		
+		$this->image_data = $image;
+	}
+
 	protected function _border($size, $color = null)
 	{
 		extract(parent::_border($size, $color));

--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -84,6 +84,28 @@ class Image_Imagemagick extends \Image_Driver
 
 		$this->clear_sizes();
 	}
+	
+	protected function _flip($direction)
+	{
+		switch ($direction)
+		{
+			case 'vertical':
+			$arg = '-flip';
+			break;
+
+			case 'horizontal':
+			$arg = '-flop';
+			break;
+			
+			case 'both':
+			$arg = '-flip -flop';
+			break;
+			
+			default: return false;
+		}
+		$image = '"'.$this->image_temp.'"';
+		$this->exec('convert', $image.' '.$arg.' '.$image);
+	}
 
 	protected function _watermark($filename, $position, $padding = 5)
 	{

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -18,7 +18,7 @@ class Image_Imagick extends \Image_Driver
 {
 
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
-	private $imagick = null;
+	protected $imagick = null;
 
 	public function load($filename, $return_data = false, $force_extension = false)
 	{
@@ -77,7 +77,28 @@ class Image_Imagick extends \Image_Driver
 		$wmimage->evaluateImage(\Imagick::EVALUATE_MULTIPLY, $this->config['watermark_alpha'] / 100, \Imagick::CHANNEL_ALPHA);
 		$this->imagick->compositeImage($wmimage, \Imagick::COMPOSITE_DEFAULT, $x, $y);
 	}
-
+	
+	protected function _flip($direction)
+	{
+		switch ($direction)
+		{
+			case 'vertical':
+			$this->imagick->flipImage();
+			break;
+			
+			case 'horizontal':
+			$this->imagick->flopImage();
+			break;
+			
+			case 'both':
+			$this->imagick->flipImage();
+			$this->imagick->flopImage();
+			break;
+			
+			default: return false;
+		}
+	}
+	
 	protected function _border($size, $color = null)
 	{
 		extract(parent::_border($size, $color));


### PR DESCRIPTION
Allow vertical and / or horizontal image flipping.

The method requires one of the following parameters: `vertical`, `horizontal`, `both`

```
$image::load('some/image.jpg')->flip('vertical');
```
