### PR TITLE
Image Class: load(), save(), reload(), load() bug.

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -845,7 +845,7 @@ abstract class Image_Driver
 	public function reload()
 	{
 		$this->debug("Reloading was called!");
-		$this->load($this->image_fullpath, false, $this->image_extension);
+		$this->load($this->image_fullpath);
 		return $this;
 	}
 


### PR DESCRIPTION
Fixes #1225

I'm not sure if this is the best way of going about this,
or if the default image config "persistence" should be set to true
to prevent the second load, but here's one way of skinning the cat.
