### PR TITLE
File move & copy methods require very loose areas

### DIFF
--- a/classes/file.php
+++ b/classes/file.php
@@ -438,16 +438,8 @@ class File
 	 */
 	public static function rename($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path_inst      = static::instance($source_area);
-		$new_path_inst  = static::instance($target_area ?: $source_area);
-
-		if ( ! $path_inst || ! $new_path_inst)
-		{
-			return false;
-		}
-
-		$path     = $path_inst->get_path($path);
-		$new_path = $new_path_inst->get_path($new_path);
+		$path = static::instance($source_area)->get_path($path);
+		$new_path = static::instance($target_area ?: $source_area)->get_path($new_path);
 
 		return rename($path, $new_path);
 	}
@@ -471,16 +463,8 @@ class File
 	 */
 	public static function copy($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path_inst      = static::instance($source_area);
-		$new_path_inst  = static::instance($target_area ?: $source_area);
-
-		if ( ! $path_inst || ! $new_path_inst)
-		{
-			return false;
-		}
-
-		$path     = $path_inst->get_path($path);
-		$new_path = $new_path_inst->get_path($new_path);
+		$path      = static::instance($source_area)->get_path($path);
+		$new_path  = static::instance($target_area ?: $source_area)->get_path($new_path);
 
 		if ( ! is_file($path))
 		{
@@ -507,16 +491,8 @@ class File
 	{
 		$target_area = $target_area ?: $source_area;
 
-		$path_inst      = static::instance($source_area);
-		$new_path_inst  = static::instance($target_area);
-
-		if ( ! $path_inst || ! $new_path_inst)
-		{
-			return false;
-		}
-
-		$path     = rtrim($path_inst->get_path($path), '\\/').DS;
-		$new_path = rtrim($new_path_inst->get_path($new_path), '\\/').DS;
+		$path      = rtrim(static::instance($source_area)->get_path($path), '\\/').DS;
+		$new_path  = rtrim(static::instance($target_area)->get_path($new_path), '\\/').DS;
 
 		if ( ! is_dir($path))
 		{

--- a/classes/file.php
+++ b/classes/file.php
@@ -438,8 +438,16 @@ class File
 	 */
 	public static function rename($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path = static::instance($source_area)->get_path($path);
-		$new_path = static::instance($target_area ?: $source_area)->get_path($new_path);
+		$path_inst      = static::instance($source_area);
+		$new_path_inst  = static::instance($target_area ?: $source_area);
+
+		if ( ! $path_inst || ! $new_path_inst)
+		{
+			return false;
+		}
+
+		$path     = $path_inst->get_path($path);
+		$new_path = $new_path_inst->get_path($new_path);
 
 		return rename($path, $new_path);
 	}
@@ -461,10 +469,18 @@ class File
 	 * @param   string|File_Area|null  target path file area name, object or null for non-specific. Defaults to source_area if not set.
 	 * @return  bool
 	 */
-	public static function copy($path, $new_path, $source_area = null, $target_area)
+	public static function copy($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path      = static::instance($source_area)->get_path($path);
-		$new_path  = static::instance($target_area ?: $source_area)->get_path($new_path);
+		$path_inst      = static::instance($source_area);
+		$new_path_inst  = static::instance($target_area ?: $source_area);
+
+		if ( ! $path_inst || ! $new_path_inst)
+		{
+			return false;
+		}
+
+		$path     = $path_inst->get_path($path);
+		$new_path = $new_path_inst->get_path($new_path);
 
 		if ( ! is_file($path))
 		{
@@ -491,8 +507,16 @@ class File
 	{
 		$target_area = $target_area ?: $source_area;
 
-		$path      = rtrim(static::instance($source_area)->get_path($path), '\\/').DS;
-		$new_path  = rtrim(static::instance($target_area)->get_path($new_path), '\\/').DS;
+		$path_inst      = static::instance($source_area);
+		$new_path_inst  = static::instance($target_area);
+
+		if ( ! $path_inst || ! $new_path_inst)
+		{
+			return false;
+		}
+
+		$path     = rtrim($path_inst->get_path($path), '\\/').DS;
+		$new_path = rtrim($new_path_inst->get_path($new_path), '\\/').DS;
 
 		if ( ! is_dir($path))
 		{

--- a/classes/file.php
+++ b/classes/file.php
@@ -307,7 +307,7 @@ class File
 		$basepath  = rtrim(static::instance($area)->get_path($basepath), '\\/').DS;
 		$new_file  = static::instance($area)->get_path($basepath.$name);
 
-		if ( ! $file = static::open_file(@fopen($new_file, 'w'), true, $area) )
+		if ( ! $file = static::open_file(@fopen($new_file, 'w'), true, $area))
 		{
 			if ( ! is_dir($basepath) or ! is_writable($basepath))
 			{
@@ -432,13 +432,14 @@ class File
 	 *
 	 * @param   string  path to file or directory to rename
 	 * @param   string  new path (full path, can also cause move)
-	 * @param   string|File_Area|null  file area name, object or null for non-specific
+	 * @param   string|File_Area|null  source path file area name, object or null for non-specific
+	 * @param   string|File_Area|null  target path file area name, object or null for non-specific. Defaults to source_area if not set.
 	 * @return  bool
 	 */
-	public static function rename($path, $new_path, $area = null)
+	public static function rename($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path = static::instance($area)->get_path($path);
-		$new_path = static::instance($area)->get_path($new_path);
+		$path = static::instance($source_area)->get_path($path);
+		$new_path = static::instance($target_area ?: $source_area)->get_path($new_path);
 
 		return rename($path, $new_path);
 	}
@@ -446,9 +447,9 @@ class File
 	/**
 	 * Alias for rename(), not needed but consistent with other methods
 	 */
-	public static function rename_dir($path, $new_path, $area = null)
+	public static function rename_dir($path, $new_path, $source_area = null, $target_area = null)
 	{
-		return static::rename($path, $new_path, $area);
+		return static::rename($path, $new_path, $source_area, $target_area);
 	}
 
 	/**
@@ -456,13 +457,14 @@ class File
 	 *
 	 * @param   string  path to file to copy
 	 * @param   string  new base directory (full path)
-	 * @param   string|File_Area|null  file area name, object or null for non-specific
+	 * @param   string|File_Area|null  source path file area name, object or null for non-specific
+	 * @param   string|File_Area|null  target path file area name, object or null for non-specific. Defaults to source_area if not set.
 	 * @return  bool
 	 */
-	public static function copy($path, $new_path, $area = null)
+	public static function copy($path, $new_path, $source_area = null, $target_area)
 	{
-		$path      = static::instance($area)->get_path($path);
-		$new_path  = static::instance($area)->get_path($new_path);
+		$path      = static::instance($source_area)->get_path($path);
+		$new_path  = static::instance($target_area ?: $source_area)->get_path($new_path);
 
 		if ( ! is_file($path))
 		{
@@ -480,14 +482,17 @@ class File
 	 *
 	 * @param   string  path to directory which contents will be copied
 	 * @param   string  new base directory (full path)
-	 * @param   string|File_Area|null  file area name, object or null for non-specific
+	 * @param   string|File_Area|null  source path file area name, object or null for non-specific
+	 * @param   string|File_Area|null  target path file area name, object or null for non-specific. Defaults to source_area if not set.
 	 * @return  bool
 	 * @throws  FileAccessException  when something went wrong
 	 */
-	public static function copy_dir($path, $new_path, $area = null)
+	public static function copy_dir($path, $new_path, $source_area = null, $target_area = null)
 	{
-		$path      = rtrim(static::instance($area)->get_path($path), '\\/').DS;
-		$new_path  = rtrim(static::instance($area)->get_path($new_path), '\\/').DS;
+		$target_area = $target_area ?: $source_area;
+
+		$path      = rtrim(static::instance($source_area)->get_path($path), '\\/').DS;
+		$new_path  = rtrim(static::instance($target_area)->get_path($new_path), '\\/').DS;
 
 		if ( ! is_dir($path))
 		{
@@ -496,20 +501,20 @@ class File
 		elseif ( ! file_exists($new_path))
 		{
 			$newpath_dirname = pathinfo($new_path, PATHINFO_DIRNAME);
-			static::create_dir($newpath_dirname, pathinfo($new_path, PATHINFO_BASENAME), fileperms($newpath_dirname) ?: 0777, $area);
+			static::create_dir($newpath_dirname, pathinfo($new_path, PATHINFO_BASENAME), fileperms($newpath_dirname) ?: 0777, $target_area);
 		}
 
-		$files = static::read_dir($path, -1, array(), $area);
+		$files = static::read_dir($path, -1, array(), $source_area);
 		foreach ($files as $dir => $file)
 		{
 			if (is_array($file))
 			{
-				$check = static::create_dir($new_path.DS, substr($dir, 0, -1), fileperms($path.$dir) ?: 0777, $area);
-				$check and static::copy_dir($path.$dir.DS, $new_path.$dir, $area);
+				$check = static::create_dir($new_path.DS, substr($dir, 0, -1), fileperms($path.$dir) ?: 0777, $target_area);
+				$check and static::copy_dir($path.$dir.DS, $new_path.$dir, $source_area, $target_area);
 			}
 			else
 			{
-				$check = static::copy($path.$file, $new_path.$file, $area);
+				$check = static::copy($path.$file, $new_path.$file, $source_area, $target_area);
 			}
 
 			// abort if something went wrong


### PR DESCRIPTION
I tend to make my file areas pretty strict.  This becomes a problem with the methods in File that can copy/move/rename between two endpoints.

If I need to copy a file from /fuel/app/uploads to /public/assets/img I need to make an area that is too lenient to enforce any real restriction.

For instance:

`public static function rename($path, $new_path, $area = null)`

The area sent would need to contain $path and $new_path.  This may require that the area be the root of the entire project.

So my proposal is to add a second area argument to these methods that will allow the methods to operate in two strict areas.

This implementation should still support setting a single area making it backward compatible. The new area argument defaults to the first area.

I haven't tested this yet, just getting some feedback before I go off to bed.

Thoughts?

Signed-off-by: Ian Turgeon iturgeon@gmail.com
