### PR TITLE
isset() instead of array_key_exists(): performance

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -231,7 +231,7 @@ class Autoloader
 			static::$auto_initialize = $class;
 		}
 
-		if (array_key_exists($class, static::$classes))
+		if (isset(static::$classes[$class]))
 		{
 			include str_replace('/', DS, static::$classes[$class]);
 			static::init_class($class);


### PR DESCRIPTION
Using isset() to check if classes have already been already added to static::$classes, instead of array_key_exists(), improves performance.
