### PR TITLE
fixed Query_Builder::reset() - reset all fields used to compile the query

### DIFF
--- a/classes/database/query/builder/delete.php
+++ b/classes/database/query/builder/delete.php
@@ -61,7 +61,7 @@ class Database_Query_Builder_Delete extends \Database_Query_Builder_Where
 			// Get the database instance
 			$db = \Database_Connection::instance($db);
 		}
-		
+
 		// Start a deletion query
 		$query = 'DELETE FROM '.$db->quote_table($this->_table);
 
@@ -88,8 +88,11 @@ class Database_Query_Builder_Delete extends \Database_Query_Builder_Where
 
 	public function reset()
 	{
-		$this->_table = NULL;
-		$this->_where = array();
+		$this->_table =
+		$this->_limit = NULL;
+
+		$this->_where    =
+		$this->_order_by = array();
 
 		$this->_parameters = array();
 

--- a/classes/database/query/builder/update.php
+++ b/classes/database/query/builder/update.php
@@ -135,10 +135,13 @@ class Database_Query_Builder_Update extends \Database_Query_Builder_Where
 	{
 		$this->_table = NULL;
 
-		$this->_set   =
-		$this->_where = array();
+		$this->_join     =
+		$this->_set      =
+		$this->_where    =
+		$this->_order_by = array();
 
-		$this->_limit = NULL;
+		$this->_limit     =
+		$this->_last_join = NULL;
 
 		$this->_parameters = array();
 


### PR DESCRIPTION
%subj%
The 'update' and 'delete' query builders weren't resetting some of their fields, e.g. $_join in the first one (it's how I noticed the bug). The bug is simple, so is the fix :)

PS. I see that it's been here from the v.1.0, strange that no one noticed
