### PR TITLE
(Re-request PR#1252) fixed Query_Builder::reset()

### DIFF
--- a/classes/database/query/builder/delete.php
+++ b/classes/database/query/builder/delete.php
@@ -61,7 +61,7 @@ class Database_Query_Builder_Delete extends \Database_Query_Builder_Where
 			// Get the database instance
 			$db = \Database_Connection::instance($db);
 		}
-		
+
 		// Start a deletion query
 		$query = 'DELETE FROM '.$db->quote_table($this->_table);
 
@@ -89,9 +89,13 @@ class Database_Query_Builder_Delete extends \Database_Query_Builder_Where
 	public function reset()
 	{
 		$this->_table = NULL;
-		$this->_where = array();
+
+		$this->_where    = array();
+		$this->_order_by = array();
 
 		$this->_parameters = array();
+
+		$this->_limit = NULL;
 
 		return $this;
 	}

--- a/classes/database/query/builder/insert.php
+++ b/classes/database/query/builder/insert.php
@@ -184,7 +184,7 @@ class Database_Query_Builder_Insert extends \Database_Query_Builder
 	{
 		$this->_table = NULL;
 
-		$this->_columns =
+		$this->_columns = array();
 		$this->_values  = array();
 
 		$this->_parameters = array();

--- a/classes/database/query/builder/select.php
+++ b/classes/database/query/builder/select.php
@@ -448,18 +448,18 @@ class Database_Query_Builder_Select extends \Database_Query_Builder_Where
 
 	public function reset()
 	{
-		$this->_select   =
-		$this->_from     =
-		$this->_join     =
-		$this->_where    =
-		$this->_group_by =
-		$this->_having   =
+		$this->_select   = array();
+		$this->_from     = array();
+		$this->_join     = array();
+		$this->_where    = array();
+		$this->_group_by = array();
+		$this->_having   = array();
 		$this->_order_by = array();
 
 		$this->_distinct = FALSE;
 
-		$this->_limit     =
-		$this->_offset    =
+		$this->_limit     = NULL;
+		$this->_offset    = NULL;
 		$this->_last_join = NULL;
 
 		$this->_parameters = array();

--- a/classes/database/query/builder/update.php
+++ b/classes/database/query/builder/update.php
@@ -23,6 +23,9 @@ class Database_Query_Builder_Update extends \Database_Query_Builder_Where
 	// JOIN ...
 	protected $_join = array();
 
+	// The last JOIN statement created
+	protected $_last_join;
+
 	/**
 	 * Set the table for a update.
 	 *
@@ -135,10 +138,13 @@ class Database_Query_Builder_Update extends \Database_Query_Builder_Where
 	{
 		$this->_table = NULL;
 
-		$this->_set   =
-		$this->_where = array();
+		$this->_join     = array();
+		$this->_set      = array();
+		$this->_where    = array();
+		$this->_order_by = array();
 
-		$this->_limit = NULL;
+		$this->_limit     = NULL;
+		$this->_last_join = NULL;
 
 		$this->_parameters = array();
 


### PR DESCRIPTION
1. fixed the reset() functionality
2. defined $_last_join field in the 'update' builder
3. corrected other builder's reset() code style (https://github.com/fuel/core/pull/1252#commitcomment-2360680)
