### PR TITLE
Added Content-Length to the Response

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -289,7 +289,7 @@ class Response
 
 		if($send_headers)
 		{
-			$this->set_header('Content-Length', strlen($body));
+			$this->set_header('Content-Length', mb_strlen($body));
 			$this->send_headers();
 		}
 

--- a/classes/response.php
+++ b/classes/response.php
@@ -287,9 +287,9 @@ class Response
 	{
 		$body = $this->__toString();
 
-		if($send_headers)
+		if ($send_headers)
 		{
-			$this->set_header('Content-Length', mb_strlen($body));
+			$this->set_header('Content-Length', (function_exists('mb_strlen') ? mb_strlen($body) : strlen($body)));
 			$this->send_headers();
 		}
 

--- a/classes/response.php
+++ b/classes/response.php
@@ -285,11 +285,17 @@ class Response
 	 */
 	public function send($send_headers = false)
 	{
-		$send_headers and $this->send_headers();
+		$body = $this->__toString();
+
+		if($send_headers)
+		{
+			$this->set_header('Content-Length', strlen($body));
+			$this->send_headers();
+		}
 
 		if ($this->body != null)
 		{
-			echo $this->__toString();
+			echo $body;
 		}
 	}
 

--- a/classes/response.php
+++ b/classes/response.php
@@ -289,7 +289,7 @@ class Response
 
 		if ($send_headers)
 		{
-			$this->set_header('Content-Length', (function_exists('mb_strlen') ? mb_strlen($body) : strlen($body)));
+			$this->set_header('Content-Length', (MBSTRING ? mb_strlen($body) : strlen($body)));
 			$this->send_headers();
 		}
 


### PR DESCRIPTION
This now counts the string length of the response body and outputs
the Content-Length header accordingly.

Signed-off-by: Tom Schlick tom@tomschlick.com
