### PR TITLE
Does not strip extension when uri ends with a slash

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -179,18 +179,22 @@ class Input
 		// Deal with any trailing dots
 		$uri = rtrim($uri, '.');
 
-		// Strip the defined url suffix from the uri if needed
-		$uri_info = pathinfo($uri);
-
-		if ( ! empty($uri_info['extension']))
+		// If uri does not end with a slash
+		if ( ! preg_match('#/$#', $uri))
 		{
-			if (strpos($uri_info['extension'],'/') === false)
-			{
-				static::$detected_ext = $uri_info['extension'];
+			// Strip the defined url suffix from the uri if needed
+			$uri_info = pathinfo($uri);
 
-				if (\Config::get('routing.strip_extension', true))
+			if ( ! empty($uri_info['extension']))
+			{
+				if (strpos($uri_info['extension'],'/') === false)
 				{
-					$uri = $uri_info['dirname'].'/'.$uri_info['filename'];
+					static::$detected_ext = $uri_info['extension'];
+
+					if (\Config::get('routing.strip_extension', true))
+					{
+						$uri = $uri_info['dirname'].'/'.$uri_info['filename'];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
``` php
// URL: http://localhost/example/index.html
echo Input::uri(); // return /example/index (correct)

// URL: http://localhost/example/1.2.3/
echo Input::uri(); // return /example/1.2 (incorrect)
```

Is this a bug ?
I implemented a branching process when the URI ends with a slash.
