### PR TITLE
Add solution for delivery query strings when uri_segment is numeric

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -130,6 +130,7 @@ class Pagination
 		'show_first'              => false,
 		'show_last'               => false,
 		'pagination_url'          => null,
+		'query'                   => array(),
 	);
 
 	/**
@@ -511,11 +512,17 @@ class Pagination
 				$this->config['pagination_url'] = rtrim($this->config['pagination_url'], '/').'/{page}';
 			}
 
+			if (strpos($this->config['pagination_url'], '{query_string}') === false and is_array($this->config['query']) and count($this->config['query']))
+			{
+				// if no query_string placeholder is present, add one to the end of the URL
+				$this->config['pagination_url'] .= '?{query_string}';
+			}
+
 		}
 
 		// return the page link
 		empty($page) and $page = 1;
-		return str_replace('{page}', $page, $this->config['pagination_url']);
+		return str_replace(array('{page}', '{query_string}'), array($page, http_build_query($this->config['query'])), $this->config['pagination_url']);
 	}
 
 }


### PR DESCRIPTION
If want delivery query strings and want set uri_segment is numeric in slash path,
Then I should set config below.

``` php
// URL: http://localhost/test/2?keyword=pagination
        $config = array(
            'pagination_url' => '/test/{page}?'.http_build_query(Input::get()),
            'total_items' => 100,
            'per_page' => 10,
            'uri_segment' => 2,
        );

```

But I think better setting is below.

``` php
        $config = array(
            'pagination_url' => '/test/',
            'total_items' => 100,
            'per_page' => 10,
            'uri_segment' => 2,
            'query' => Input::get(),
        );
```

Some argue that there is a problem with the design URI, But, for example, I think when doing renovations add GET parameters to the existing management systems, this feature that is needed.
