### PR TITLE
Added _write_connection property to Model_Crud to support replicated database setups

### DIFF
--- a/tests/model/crud.php
+++ b/tests/model/crud.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Fuel framework
+ *
+ * @package   Fuel
+ * @version   1.0
+ * @author    Fuel Development Team
+ * @license   MIT License
+ * @copyright 2010 - 2012 Fuel Development Team
+ * @link      http://fuelphp.com
+ */
+
+namespace Fuel\Core;
+
+/**
+ * Model_Crud class tests
+ *
+ * @group Core
+ * @group Model
+ */
+class Test_Model_Crud extends TestCase
+{
+	public function test_foo() {}
+
+	public function test_get_connection()
+	{
+		$refl = new \ReflectionClass('\Fuel\Core\Model_Crud_Tester');
+		$method = $refl->getMethod('get_connection');
+		$method->setAccessible(true);
+
+		$tester = new Model_Crud_Tester();
+		$write = $method->invokeArgs($tester, array(true));
+		$read = $method->invokeArgs($tester, array(false));
+
+		$this->assertEquals('read', $read);
+		$this->assertEquals('write', $write);
+	}
+}
+
+class Model_Crud_Tester extends \Fuel\Core\Model_Crud
+{
+	static protected $_connection = "read";
+
+	static protected $_write_connection = "write";
+}


### PR DESCRIPTION
Another change to support replications. This adds a property to Model_Crud as well as replaces all instances of 'isset(static::$_connection) ? static::$_connection : null' with a call to a new method Model_Crud::get_connection(). Also added a basic unit test to confirm that get_connection() works correctly. 
