### PR TITLE
_make_link bug fix

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -466,6 +466,16 @@ class Pagination
 			// break the url in bits so we can insert it
 			$url = parse_url($this->config['pagination_url']);
 
+			// parse the query string
+			if (isset($url['query']))
+			{
+				parse_str($url['query'], $url['query']);
+			}
+			else
+			{
+				$url['query'] = array();
+			}
+
 			// is the page number a URI segment?
 			if (is_numeric($this->config['uri_segment']))
 			{
@@ -484,9 +494,6 @@ class Pagination
 			}
 			else
 			{
-				// parse the query string, we need to insert page number in there
-				$url['query'] = isset($url['query']) ? parse_str($url['query'], $url['query']) : array();
-
 				// add our placeholder
 				$url['query'][$this->config['uri_segment']] = '{page}';
 			}
@@ -495,6 +502,7 @@ class Pagination
 			$query = empty($url['query']) ? '' : '?'.preg_replace('/%7Bpage%7D/', '{page}', http_build_query($url['query']));
 			unset($url['query']);
 			empty($url['scheme']) or $url['scheme'] .= '://';
+			empty($url['port']) or $url['host'] .= ':';
 			$this->config['pagination_url'] = implode($url).$query;
 		}
 

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -225,6 +225,98 @@ class Test_Pagination extends TestCase
 		$this->assertEquals($expected, $output);
 	}
 
+	public function test_uri_segment_make_link_with_no_query_string_ending_page_number()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/10');
+		$this->set_uri_segment_config();
+		$this->config['pagination_url'] = 'http://docs.fuelphp.com/welcome/index/55';
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = 'http://docs.fuelphp.com/welcome/index/1';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = 'http://docs.fuelphp.com/welcome/index/99';
+		$this->assertEquals($expected, $test);
+	}
+
+	public function test_uri_segment_make_link_with_no_query_string_ending_slash()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/');
+		$this->set_uri_segment_config();
+		$this->config['pagination_url'] = 'http://docs.fuelphp.com/welcome/index/';
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = 'http://docs.fuelphp.com/welcome/index/1';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = 'http://docs.fuelphp.com/welcome/index/99';
+		$this->assertEquals($expected, $test);
+	}
+
+	public function test_uri_segment_make_link_with_query_string_ending_page_number()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/55?foo=bar&fuel[]=php1&fuel[]=php2&');
+		$this->set_uri_segment_config();
+
+		// no define pagination_url
+		$this->config['pagination_url'] = null;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = '/welcome/index/1?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = '/welcome/index/99?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
+	}
+
+	public function test_uri_segment_make_link_with_query_string_ending_slash()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/?foo=bar&fuel[]=php1&fuel[]=php2&');
+		$this->set_uri_segment_config();
+
+		// no define pagination_url
+		$this->config['pagination_url'] = null;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = '/welcome/index/1?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = '/welcome/index/99?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
+	}
+
 /***********************************
  * Tests for Query String Pagination
  ***********************************/
@@ -330,5 +422,74 @@ class Test_Pagination extends TestCase
 		$output = str_replace(array("\n", "\t"), "", $output);
 		$expected = '<span class="previous"><a href="http://docs.fuelphp.com/?p=9">&laquo;</a></span>';
 		$this->assertEquals($expected, $output);
+	}
+
+	public function test_query_string_make_link_by_request()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/?foo=bar&fuel[]=php1&fuel[]=php2&p=40');
+
+		$this->set_query_string_config();
+		$this->config['pagination_url'] = null;
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = 'welcome/index/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=1';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = 'welcome/index/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=99';
+		$this->assertEquals($expected, $test);
+	}
+
+	public function test_query_string_make_link_by_pagination_url()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/?foo=bar&fuel[]=php1&fuel[]=php2&p=40');
+		
+		$this->set_query_string_config();
+		$this->config['pagination_url'] = 'http://docs.fuelphp.com/?foo=bar&fuel[]=php1&fuel[]=php2';
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=1';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=99';
+		$this->assertEquals($expected, $test);
+	}
+
+	public function test_query_string_make_link_by_pagination_url_include_page_number()
+	{
+		// set Request::$main & $active
+		$this->set_request('welcome/index/?foo=bar&fuel[]=php1&fuel[]=php2&p=40');
+		
+		$this->set_query_string_config();
+		$this->config['pagination_url'] = 'http://docs.fuelphp.com/?foo=bar&p=123&fuel[]=php1&fuel[]=php2';
+
+		$pagination = Pagination::forge(__METHOD__, $this->config);
+
+		// set _make_link() accessible
+		$_make_link = new \ReflectionMethod($pagination, '_make_link');
+		$_make_link->setAccessible(true);
+
+		$test = $_make_link->invoke($pagination, 1);
+		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;p=1&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
+
+		$test = $_make_link->invoke($pagination, 99);
+		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;p=99&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$this->assertEquals($expected, $test);
 	}
 }

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -285,11 +285,11 @@ class Test_Pagination extends TestCase
 		$_make_link->setAccessible(true);
 
 		$test = $_make_link->invoke($pagination, 1);
-		$expected = '/welcome/index/1?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = '/welcome/index/1?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 
 		$test = $_make_link->invoke($pagination, 99);
-		$expected = '/welcome/index/99?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = '/welcome/index/99?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 	}
 
@@ -309,11 +309,11 @@ class Test_Pagination extends TestCase
 		$_make_link->setAccessible(true);
 
 		$test = $_make_link->invoke($pagination, 1);
-		$expected = '/welcome/index/1?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = '/welcome/index/1?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 
 		$test = $_make_link->invoke($pagination, 99);
-		$expected = '/welcome/index/99?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = '/welcome/index/99?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 	}
 
@@ -439,11 +439,11 @@ class Test_Pagination extends TestCase
 		$_make_link->setAccessible(true);
 
 		$test = $_make_link->invoke($pagination, 1);
-		$expected = 'welcome/index/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=1';
+		$expected = 'welcome/index/?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2&p=1';
 		$this->assertEquals($expected, $test);
 
 		$test = $_make_link->invoke($pagination, 99);
-		$expected = 'welcome/index/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=99';
+		$expected = 'welcome/index/?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2&p=99';
 		$this->assertEquals($expected, $test);
 	}
 
@@ -462,11 +462,11 @@ class Test_Pagination extends TestCase
 		$_make_link->setAccessible(true);
 
 		$test = $_make_link->invoke($pagination, 1);
-		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=1';
+		$expected = 'http://docs.fuelphp.com/?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2&p=1';
 		$this->assertEquals($expected, $test);
 
 		$test = $_make_link->invoke($pagination, 99);
-		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2&amp;p=99';
+		$expected = 'http://docs.fuelphp.com/?foo=bar&fuel%5B0%5D=php1&fuel%5B1%5D=php2&p=99';
 		$this->assertEquals($expected, $test);
 	}
 
@@ -485,11 +485,11 @@ class Test_Pagination extends TestCase
 		$_make_link->setAccessible(true);
 
 		$test = $_make_link->invoke($pagination, 1);
-		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;p=1&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = 'http://docs.fuelphp.com/?foo=bar&p=1&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 
 		$test = $_make_link->invoke($pagination, 99);
-		$expected = 'http://docs.fuelphp.com/?foo=bar&amp;p=99&amp;fuel%5B0%5D=php1&amp;fuel%5B1%5D=php2';
+		$expected = 'http://docs.fuelphp.com/?foo=bar&p=99&fuel%5B0%5D=php1&fuel%5B1%5D=php2';
 		$this->assertEquals($expected, $test);
 	}
 }


### PR DESCRIPTION
1. parse_str is destructive. So can't use in ternary operator.
2. $url['port'] is not empty, then add ':' after $url['host'].
   (for example: http://localhost:8080)
