### PR TITLE
Updated to allow to set full path to APPPATH, COREPATH and PKGPATH on testing

### DIFF
--- a/bootstrap_phpunit.php
+++ b/bootstrap_phpunit.php
@@ -9,9 +9,9 @@ include_once('PHPUnit/Autoload.php');
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$app_path		= trim($_SERVER['app_path'], '/').'/';
-$package_path	= trim($_SERVER['package_path'], '/').'/';
-$core_path		= trim($_SERVER['core_path'], '/').'/';
+$app_path		= rtrim($_SERVER['app_path'], '/').'/';
+$package_path	= rtrim($_SERVER['package_path'], '/').'/';
+$core_path		= rtrim($_SERVER['core_path'], '/').'/';
 
 /**
  * Website docroot


### PR DESCRIPTION
In case to set full path to `<server name="core_path">` on `phpunit.xml`, test fails because `trim` function trims the first `/` of the path.

Signed-off-by: Hiroyuki Anai pirosikick@gmail.com
