### PR TITLE
Updated to follow redirects

### DIFF
--- a/classes/agent.php
+++ b/classes/agent.php
@@ -432,6 +432,7 @@ class Agent
 				$curl = curl_init();
 				curl_setopt($curl, CURLOPT_BINARYTRANSFER, 1);
 				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 				curl_setopt($curl, CURLOPT_MAXREDIRS, 5);
 				curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 				curl_setopt($curl, CURLOPT_HEADER, 0);


### PR DESCRIPTION
When `browscap.url` in `config/agent.php` returns `301` or `302`, `agent.php` fails in downloading browscap file.

Signed-off-by: Hiroyuki Anai pirosikick@gmail.com
