### PR TITLE
Removed the unnecessary code that set Fuel::$env in bootstrap_phpunit.ph...

### DIFF
--- a/bootstrap_phpunit.php
+++ b/bootstrap_phpunit.php
@@ -35,8 +35,7 @@ defined('FUEL_START_MEM') or define('FUEL_START_MEM', memory_get_usage());
 // Boot the app
 require_once APPPATH.'bootstrap.php';
 
-// Set the environment to TEST
-Fuel::$env = Fuel::TEST;
+// Set test mode
 Fuel::$is_test = true;
 
 // Import the TestCase class


### PR DESCRIPTION
...p

Signed-off-by: mamor mamor.dev@gmail.com
## 

PR for https://github.com/fuel/core/issues/1287

I have to confirm the two.

one:
Before and after remove the code, unit tests have been similar results.

```
$ php oil test group=Core
Tests Running...This may take a few moments.
PHPUnit 3.7.10 by Sebastian Bergmann.

Configuration read from /foo/fuel/core/phpunit.xml

...............................................................  63 / 328 ( 19%)
............................................................... 126 / 328 ( 38%)
............................................................... 189 / 328 ( 57%)
............................................................... 252 / 328 ( 76%)
............................................................... 315 / 328 ( 96%)
.............

Time: 1 second, Memory: 19.25Mb

OK (328 tests, 348 assertions)
```

two:
After delete development/db.php and create test/db.php, I have confirmed the following.

Create TestCase

```
<?php

/**
 * @group App
 */
class Test_Env extends TestCase
{
    public function test_env() {
        $output = Fuel::$env;
        $expected = Fuel::TEST;
        $this->assertEquals($expected, $output);
    }

    public function test_db_connection() {
        $output = DBUtil::table_exists('exists');
        $this->assertTrue($output);

        $output = DBUtil::table_exists('not exists');
        $this->assertFalse($output);
    }

}
```

Run command

```
$ php oil test group=App
Tests Running...This may take a few moments.
PHPUnit 3.7.10 by Sebastian Bergmann.

Configuration read from /foo/fuel/core/phpunit.xml

..

Time: 0 seconds, Memory: 14.75Mb

OK (2 tests, 3 assertions)
```
