### PR TITLE
set data before checking for primary key in crud model's constructor

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -385,17 +385,17 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess, \Serializabl
 	 */
 	public function __construct(array $data = array())
 	{
-		if (isset($this->{static::primary_key()}))
-		{
-			$this->is_new(false);
-		}
-
 		if ( ! empty($data))
 		{
 			foreach ($data as $key => $value)
 			{
 				$this->{$key} = $value;
 			}
+		}
+
+		if (isset($this->{static::primary_key()}))
+		{
+			$this->is_new(false);
 		}
 	}
 


### PR DESCRIPTION
I don't understand why primary key is checked before data are even set. How can existing record ever be detected?
