### PR TITLE
Support localized language URLs

### DIFF
--- a/classes/lang.php
+++ b/classes/lang.php
@@ -58,6 +58,10 @@ class Lang
 				}
 			}
 		}
+		if (empty($language))
+		{
+			$language = self::$fallback[0];
+		}
 		return $language;
 	}
 
@@ -76,10 +80,6 @@ class Lang
 		// get the active language and all fallback languages
 		$language or $language = self::lang();
 		$languages = static::$fallback;
-		if (empty($language))
-		{
-			$language = $languages[0];
-		}
 
 		// make sure we don't have the active language in the fallback array
 		if (in_array($language, $languages))
@@ -175,10 +175,6 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
-			if (empty($language))
-			{
-				$language = self::$fallback[0];
-			}
 		}
 
 		// prefix the file with the language
@@ -231,10 +227,6 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
-			if (empty($language))
-			{
-				$language = self::$fallback[0];
-			}
 		}
 
 		return isset(static::$lines[$language]) ? \Str::tr(\Fuel::value(\Arr::get(static::$lines[$language], $line, $default)), $params) : $default;
@@ -256,10 +248,6 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
-			if (empty($language))
-			{
-				$language = self::$fallback[0];
-			}
 		}
 
 		isset(static::$lines[$language]) or static::$lines[$language] = array();
@@ -282,10 +270,6 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
-			if (empty($language))
-			{
-				$language = self::$fallback[0];
-			}
 		}
 
 		return isset(static::$lines[$language]) ? \Arr::delete(static::$lines[$language], $item) : false;
@@ -301,10 +285,6 @@ class Lang
 	public static function localized($uri, $language = null) {
 		if (empty($language)) {
 			$language = self::lang();
-			if (empty($language))
-			{
-				$language = self::$fallback[0];
-			}
 		}
 		if (!empty($language) and $language != self::$default_language) {
 			$uri = '/' . $language . $uri;

--- a/classes/lang.php
+++ b/classes/lang.php
@@ -76,6 +76,10 @@ class Lang
 		// get the active language and all fallback languages
 		$language or $language = self::lang();
 		$languages = static::$fallback;
+		if (empty($language))
+		{
+			$language = $languages[0];
+		}
 
 		// make sure we don't have the active language in the fallback array
 		if (in_array($language, $languages))
@@ -171,6 +175,10 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
+			if (empty($language))
+			{
+				$language = self::$fallback[0];
+			}
 		}
 
 		// prefix the file with the language
@@ -223,6 +231,10 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
+			if (empty($language))
+			{
+				$language = self::$fallback[0];
+			}
 		}
 
 		return isset(static::$lines[$language]) ? \Str::tr(\Fuel::value(\Arr::get(static::$lines[$language], $line, $default)), $params) : $default;
@@ -244,6 +256,10 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
+			if (empty($language))
+			{
+				$language = self::$fallback[0];
+			}
 		}
 
 		isset(static::$lines[$language]) or static::$lines[$language] = array();
@@ -266,6 +282,10 @@ class Lang
 		if ($language === null)
 		{
 			$language = self::lang();
+			if (empty($language))
+			{
+				$language = self::$fallback[0];
+			}
 		}
 
 		return isset(static::$lines[$language]) ? \Arr::delete(static::$lines[$language], $item) : false;
@@ -281,6 +301,10 @@ class Lang
 	public static function localized($uri, $language = null) {
 		if (empty($language)) {
 			$language = self::lang();
+			if (empty($language))
+			{
+				$language = self::$fallback[0];
+			}
 		}
 		if (!empty($language) and $language != self::$default_language) {
 			$uri = '/' . $language . $uri;

--- a/config/config.php
+++ b/config/config.php
@@ -88,7 +88,7 @@ return array(
 	'language'           => 'en', // Default language
 	'language_fallback'  => 'en', // Fallback language when file isn't available for default language
 	'locale'             => 'en_US', // PHP set_locale() setting, null to not set
-
+    'languages'          => Array(), // array with supported languages for URI, empty if not using
 	/**
 	 * Internal string encoding charset
 	 */


### PR DESCRIPTION
### About

This feature allows to make localized URLs. ie.
`http://domain/lang1/controller/method`
`http://domain/lang2/controller/method`

While I've seen other implementations which change Uri class this DOES NOT because it have several issues.
### Implementation

Uri class isn't changed and Lang class is improved properly -> all code is fully backward compatible and everything will work same as before for everyone who don't need such feature. No need to change existing code.
### Usefulness

I'm pretty sure there's people who would love such feature (including me).

And this implementation have several advantages.
- Easy to make same page links for different languages.
- Switching between languages user gets same page (in other language) without redirects.
- Backward compatible
- Lang class supports this feature making it in right place where it should be. And allows routing handle some specific language needs.
- Can be easily customizable if language need to be in other component than first (eg. last). While currently this can't be achieved with config, it's really easy to either directly edit lang class or just overload in app.
- SEO friendly
- Language in URL can be overridden with `Config::set('language',$lang)`
### Usage

To use this feature there are required few code changes, but nothing much.
1. all links which are supposed to be for same language must be replaced with
   `Lang::localized($uri)`, eg. `<a href="<?php echo Lang::localized('/blog/article/')?>"/>Article</a>`
   (Note: currently `localized` doesn't support schema or relative urls, and it expects that uri starts with `/` but it can be implemented if needed, now can do just `'https://domain'.Lang::localized('/blog/article/')`)
2. make links which change language. either use `Lang::localized('/blog/article/','ru')` or directly write `<a href="/ru">RU</a>`
3. in app `config.php` add available languages `'languages' => Array('en', 'ru')`
4. change `routes.php` config to also include localized routing.
#### `routes.php` config changes explained

Will need routes for both cases when language is included in URI and when isn't.
So will need to add another `_root_` ie. `$routes[$langs]` and all other routes prefixed with `$routes[(({$langs})/)?route]`

There's 4 possible configurations.
##### 1.

SEO friendly. Default language without any prefix. ie. `http://domain/controller` and all other languages `http://domain/lang/controller`. BUT `http://domain/default_lang/controller` returns 404

`config.php`: `'language' => 'en'` // specify which language will be served as default. without included in URL

`routes.php`

```
<?php

$languages = Config::get('languages');
unset($languages[0]);
$langs = implode('|', $languages);

return array(
'_root_' => 'welcome/index', // The default route
"({$langs})" => 'welcome/index', // The default route in other language
"(({$langs})/)?hello(/:name)?" => array('welcome/hello', 'name' => 'hello'),
);
```
##### 2.

Default language without any prefix. ie. `http://domain/controller`, BUT `http://domain/default_lang/controller` will still work.

everything same as previous, just without `unset($languages[0]);`
##### 3.

All languages `http://domain/lang/controller`. BUT `http://domain/controller` will return 404. There's exception to `_root_`, it will give default language (language_fallback).

`config.php`: `'language' => ''` // no default language, MUST be in URL
`'language_fallback' => 'en'` // Fallback language if language isn't in URL

`routes.php`

```
<?php

$langs = implode('|', Config::get('languages'));

return array(
'_root_' => 'welcome/index', // The default route
"({$langs})" => 'welcome/index', // The default route in other language
"(({$langs})/)?hello(/:name)?" => array('welcome/hello', 'name' => 'hello'),
);
```
##### 4.

Make your own routes, unlimited possibilities. Maybe you don't have some article in that language? No problem, just give in default language or give page informing that it's not available.
### PS

I've been using this feature already some while and it works great :)

Also btw I replaced some code which didn't make any sense...

```
   if ($language === null) {
      $languages = static::$fallback;
      array_unshift($languages, $language ?: \Config::get('language'));
      $language = reset($languages);
   }
```

firstly it was in several places exactly same and `$languages` wasn't used anywhere only these few lines. And that code part is used only when `$language` is `null`, but `null` is always `false`, so `$languages` always will be with prepended with `Config::get('language')` and so always `$language=Config::get('language')` when `$language` is `null`
