### PR TITLE
Improved display.php in phpquickprofiler so it supports any EOL not only LF

### DIFF
--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -17,7 +17,7 @@
 
 function displayPqp($output) {
 
-	$css = str_replace("\n", "", <<<CSS
+	$css = preg_replace('/[\n\r]/', '', <<<CSS
 .pQp{width:100%;z-index:9999;text-align:center;position:fixed;bottom:0;}
 * html .pQp{position:absolute;}
 .pQp *{margin:0 ;padding:0;border:none;background:#222;}

--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -662,5 +662,3 @@ FOOTER;
 
 	return $return_output;
 }
-
-?>


### PR DESCRIPTION
Currently phpquickprofiler wont work if line endings are other than LF, this fixes it so it won't matter anymore.

Otherwise if cloning repository from Windows when git is installed with default options it will replace LF with CRLF
