### PR TITLE
Remove PHP end tags

### DIFF
--- a/vendor/phpquickprofiler/console.php
+++ b/vendor/phpquickprofiler/console.php
@@ -94,5 +94,3 @@ class Console {
 	}
 
 }
-
-?>

--- a/vendor/phpquickprofiler/phpquickprofiler.php
+++ b/vendor/phpquickprofiler/phpquickprofiler.php
@@ -227,5 +227,3 @@ class PhpQuickProfiler {
 	}
 
 }
-
-?>

--- a/vendor/phpseclib/Crypt/Random.php
+++ b/vendor/phpseclib/Crypt/Random.php
@@ -131,4 +131,3 @@ function crypt_random($min = 0, $max = 0x7FFFFFFF)
     extract(unpack('Nrandom', $crypto->encrypt("\0\0\0\0")));
     return abs($random) % ($max - $min) + $min;
 }
-?>

--- a/vendor/phpseclib/Net/SSH1.php
+++ b/vendor/phpseclib/Net/SSH1.php
@@ -1378,4 +1378,3 @@ class Net_SSH1 {
         return rtrim($this->server_identification);
     }
 }
-?>


### PR DESCRIPTION
This is not really issue, but I think it should be good practice and also consistency with rest of framework.

While it's unlikely but possible that somehow accidentally space is after `?>` that would make it sent to browser and thus all next header changes would fail because headers already sent. And this kind of mistakes are very hard to track down, which file is causing it.
