### PR TITLE
function __  should also support language parameter like \Lang::get

### DIFF
--- a/base.php
+++ b/base.php
@@ -202,9 +202,9 @@ if ( ! function_exists('render'))
  */
 if ( ! function_exists('__'))
 {
-	function __($string, $params = array(), $default = null)
+	function __($string, $params = array(), $default = null, $language = null)
 	{
-		return \Lang::get($string, $params, $default);
+		return \Lang::get($string, $params, $default, $language);
 	}
 }
 


### PR DESCRIPTION
Currently `__` doesn't support language parameter so instead have to use \Lang::get but I think it should support same parameters. So it can be used as simplification.
