### PR TITLE
Improve Lang class for easier extendability

### DIFF
--- a/classes/lang.php
+++ b/classes/lang.php
@@ -43,10 +43,7 @@ class Lang
 	 */
 	public static function get_lang() {
 		$language = \Config::get('language');
-		if (empty($language))
-		{
-			$language = self::$fallback[0];
-		}
+		empty($language) and $language = static::$fallback[0];
 		return $language;
 	}
 
@@ -63,7 +60,7 @@ class Lang
 	public static function load($file, $group = null, $language = null, $overwrite = false, $reload = false)
 	{
 		// get the active language and all fallback languages
-		$language or $language = self::get_lang();
+		$language or $language = static::get_lang();
 		$languages = static::$fallback;
 
 		// make sure we don't have the active language in the fallback array
@@ -157,10 +154,7 @@ class Lang
 	 */
 	public static function save($file, $lang, $language = null)
 	{
-		if ($language === null)
-		{
-			$language = self::get_lang();
-		}
+		($language === null) and $language = static::get_lang();
 
 		// prefix the file with the language
 		if ( ! is_null($language))
@@ -209,10 +203,7 @@ class Lang
 	 */
 	public static function get($line, array $params = array(), $default = null, $language = null)
 	{
-		if ($language === null)
-		{
-			$language = self::get_lang();
-		}
+		($language === null) and $language = static::get_lang();
 
 		return isset(static::$lines[$language]) ? \Str::tr(\Fuel::value(\Arr::get(static::$lines[$language], $line, $default)), $params) : $default;
 	}
@@ -230,10 +221,7 @@ class Lang
 	{
 		$group === null or $line = $group.'.'.$line;
 
-		if ($language === null)
-		{
-			$language = self::get_lang();
-		}
+		($language === null) and $language = static::get_lang();
 
 		isset(static::$lines[$language]) or static::$lines[$language] = array();
 
@@ -252,10 +240,7 @@ class Lang
 	{
 		$group === null or $line = $group.'.'.$line;
 
-		if ($language === null)
-		{
-			$language = self::get_lang();
-		}
+		($language === null) and $language = static::get_lang();
 
 		return isset(static::$lines[$language]) ? \Arr::delete(static::$lines[$language], $item) : false;
 	}

--- a/classes/lang.php
+++ b/classes/lang.php
@@ -41,7 +41,8 @@ class Lang
 	 *
 	 * @return   string    currently active language
 	 */
-	public static function get_lang() {
+	public static function get_lang()
+	{
 		$language = \Config::get('language');
 		empty($language) and $language = static::$fallback[0];
 		return $language;

--- a/classes/lang.php
+++ b/classes/lang.php
@@ -37,6 +37,20 @@ class Lang
 	}
 
 	/**
+	 * Returns currently active language.
+	 *
+	 * @return   string    currently active language
+	 */
+	public static function get_lang() {
+		$language = \Config::get('language');
+		if (empty($language))
+		{
+			$language = self::$fallback[0];
+		}
+		return $language;
+	}
+
+	/**
 	 * Loads a language file.
 	 *
 	 * @param    mixed        $file        string file | language array | Lang_Interface instance
@@ -49,7 +63,7 @@ class Lang
 	public static function load($file, $group = null, $language = null, $overwrite = false, $reload = false)
 	{
 		// get the active language and all fallback languages
-		$language or $language = \Config::get('language');
+		$language or $language = self::get_lang();
 		$languages = static::$fallback;
 
 		// make sure we don't have the active language in the fallback array
@@ -145,9 +159,7 @@ class Lang
 	{
 		if ($language === null)
 		{
-			$languages = static::$fallback;
-			array_unshift($languages, $language ?: \Config::get('language'));
-			$language = reset($languages);
+			$language = self::get_lang();
 		}
 
 		// prefix the file with the language
@@ -199,9 +211,7 @@ class Lang
 	{
 		if ($language === null)
 		{
-			$languages = static::$fallback;
-			array_unshift($languages, $language ?: \Config::get('language'));
-			$language = reset($languages);
+			$language = self::get_lang();
 		}
 
 		return isset(static::$lines[$language]) ? \Str::tr(\Fuel::value(\Arr::get(static::$lines[$language], $line, $default)), $params) : $default;
@@ -222,9 +232,7 @@ class Lang
 
 		if ($language === null)
 		{
-			$languages = static::$fallback;
-			array_unshift($languages, $language ?: \Config::get('language'));
-			$language = reset($languages);
+			$language = self::get_lang();
 		}
 
 		isset(static::$lines[$language]) or static::$lines[$language] = array();
@@ -246,9 +254,7 @@ class Lang
 
 		if ($language === null)
 		{
-			$languages = static::$fallback;
-			array_unshift($languages, $language ?: \Config::get('language'));
-			$language = reset($languages);
+			$language = self::get_lang();
 		}
 
 		return isset(static::$lines[$language]) ? \Arr::delete(static::$lines[$language], $item) : false;


### PR DESCRIPTION
Currently if anyone wants to extend Lang class and provide his own way how to determine which is currently active language, he's forced to overload most of Lang functions (load, save, get, set, delete)

This improvement adds function `Lang::get_lang()` which determines currently active language and will be used by all those previously mentioned functions. Thus if you need to change the way how active language is determined you can just overload this one function without need to change anything else.

It doesn't change functionality so it's fully compatible with current applications. Also it improves Lang class existing code.

``` php
if ($language === null)
{
     $languages = static::$fallback;
     array_unshift($languages, $language ?: \Config::get('language'));
     $language = reset($languages);
}
```

I mentioned this code part already in #1291 which does nothing more than `$language = \Config::get('language')` and also is used in several places.
