### PR TITLE
Fixed a weird is_scalar conflict

### DIFF
--- a/classes/form/instance.php
+++ b/classes/form/instance.php
@@ -300,9 +300,12 @@ class Form_Instance
 			if ( ! is_array($checked))
 			{
 				// If it's true, then go for it
-				if (is_bool($checked) and $checked === true)
+				if (is_bool($checked))
 				{
-					$attributes['checked'] = 'checked';
+					if($checked === true)
+					{
+						$attributes['checked'] = 'checked';	
+					}
 				}
 
 				// Otherwise, if the string/number/whatever matches then do it
@@ -342,9 +345,12 @@ class Form_Instance
 			if ( ! is_array($checked))
 			{
 				// If it's true, then go for it
-				if (is_bool($checked) and $checked === true)
+				if (is_bool($checked))
 				{
-					$attributes['checked'] = 'checked';
+					if($checked === true)
+					{
+						$attributes['checked'] = 'checked';	
+					}
 				}
 
 				// Otherwise, if the string/number/whatever matches then do it


### PR DESCRIPTION
In some cases if $checked = false but is boolean and the value of the
field is '0' the is_scalar would evaluate to true which obviously shouldn't happen.
making the statement two if clauses fixes this because it wont drop down into the
is_scalar block
