### PR TITLE
New FuelPHP Upload class compatibility problems

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -89,7 +89,7 @@ class Upload
 
 		// add the callbacks
 		$config['langCallback'] = '\\Upload::langCallback';
-		$config['moveCallback'] = '\\Upload::moveCallback';
+		$config['moveCallback'] = null;
 
 		// get an upload instance
 		static::$upload = new \FuelPHP\Upload\Upload($config);

--- a/classes/upload.php
+++ b/classes/upload.php
@@ -168,15 +168,26 @@ class Upload
 		foreach ($files as $file)
 		{
 			$data = array();
+
 			foreach ($file as $item => $value)
 			{
 				$item == 'element' and $item = 'field';
 				$item == 'tmp_name' and $item = 'file';
 				$data[$item] = $value;
 			}
+			
+			if (isset($data['path'])) {
+				$data['saved_to'] = $data['path'];
+			}
+			
+			if (isset($data['filename'])) {
+				$data['saved_as'] = $data['filename'];
+			}
+
 			$data['field'] = str_replace('.', ':', $data['field']);
 			$data['error'] = ! $file->isValid();
 			$data['errors'] = array();
+
 			$result[] = $data;
 		}
 


### PR DESCRIPTION
I am currently working on a site that is due to go live in March so I am updating Fuel regularly.

Here is my original code that worked with Fuel 1.5/develop.

``` php
<?php

$config = array(
    'ext_whitelist'  => array('csv'),
    'path'           => APPPATH.'data/',
    'prefix'         => date('Y-m-d_H-i-s_')
);

\Upload::process($config);

if (\Upload::is_valid()) {
    \Upload::save();
} else {
    throw new \Exception("Invalid file uploaded, please try uploading a .csv file.");
}

$files = \Upload::get_files();
$data = file_get_contents($files[0]['saved_to'].$files[0]['saved_as']);
```

Updating to 1.6/develop causes this error when uploading a file.

```
call_user_func() expects parameter 1 to be a valid callback, function '/tmp/phpvJjKU0' not found or invalid function name
fuel/vendor/fuelphp/upload/src/FuelPHP/Upload/File.php:447
```

Straight away I noticed that line was using `call_user_func()` incorrectly, but also, it shouldn't have been getting there. Please bear with me whilst I submit the pull request to fix that issue.

I imagine there will be further issues with the `fuelphp\upload` class, as it doesn't appear to be complete. But this pull request, and my other pull request, at least make it work with my existing code.

I know that my pull requests are going to break uploading via FTP, if that worked to begin with.
