### PR TITLE
Fixed Debug::dump() when called from call_user_func_array()

### DIFF
--- a/classes/debug.php
+++ b/classes/debug.php
@@ -53,15 +53,21 @@ class Debug
 		{
 			$backtrace = debug_backtrace();
 
-			// If being called from within, show the file above in the backtrack
-			if (strpos($backtrace[0]['file'], 'core/classes/debug.php') !== FALSE)
+			$position = 0;
+			while ( ! isset($backtrace[$position]['file']))
 			{
-				$callee = $backtrace[1];
-				$label = \Inflector::humanize($backtrace[1]['function']);
+				$position++;
+			}
+
+			// If being called from within, show the file above in the backtrack
+			if (strpos($backtrace[$position]['file'], 'core/classes/debug.php') !== FALSE)
+			{
+				$callee = $backtrace[$position + 1];
+				$label = \Inflector::humanize($backtrace[$position + 1]['function']);
 			}
 			else
 			{
-				$callee = $backtrace[0];
+				$callee = $backtrace[$position];
 				$label = 'Debug';
 			}
 

--- a/classes/debug.php
+++ b/classes/debug.php
@@ -54,7 +54,7 @@ class Debug
 			$backtrace = debug_backtrace();
 
 			$position = 0;
-			while ( ! isset($backtrace[$position]['file']))
+			while ( ! isset($backtrace[$position]['file']) and isset($backtrace[$position]))
 			{
 				$position++;
 			}

--- a/tests/debug.php
+++ b/tests/debug.php
@@ -20,5 +20,19 @@ namespace Fuel\Core;
  */
 class Test_Debug extends TestCase
 {
- 	public function test_foo() {}
+ 	public function test_debug_dump_normally()
+ 	{
+ 		// Set to browser mode.
+ 		\Fuel::$is_cli = false;
+
+ 		\Debug::dump(1, 2, 3);
+ 	}
+
+  	public function test_debug_dump_by_call_user_func_array()
+ 	{
+ 		// Set to browser mode.
+ 		\Fuel::$is_cli = false;
+
+ 		call_user_func_array('\\Debug::dump', array(1, 2, 3));
+ 	}
 }


### PR DESCRIPTION
I made shortcut function like below.

``` php
function d()
{
    $args = func_get_args();
    call_user_func_array('\\Debug::dump', $args);
}
```

But then, I got error.

``` html
ErrorException [ Notice ]: Undefined index: file

COREPATH/classes/debug.php @ line 57
```

``` php
// If being called from within, show the file above in the backtrack
 if (strpos($backtrace[0]['file'], 'core/classes/debug.php') !== FALSE)
```

Is this a bug or not?
If this is a bug, I attach a little draft fix.
Can you check it?
