### PR TITLE
Remove including PHPUnit/Autoload.php

### DIFF
--- a/bootstrap_phpunit.php
+++ b/bootstrap_phpunit.php
@@ -1,8 +1,5 @@
 <?php
 
-// Load the PUPUnit Autoloader
-include_once('PHPUnit/Autoload.php');
-
 /**
  * Set error reporting and display errors settings.  You will want to change these when in production.
  */


### PR DESCRIPTION
This including causes error when PHPUnit 3.7.13-11-g0b50d0a is installed via Composer.

`Compile Error - require_once(): Failed opening required 'SebastianBergmann/Version/autoload.php'` 

When PHPUnit is installed through Composer it seems to be unnecessary.
See https://github.com/sebastianbergmann/phpunit/issues/795

It is also unnecessary if PHPUnit is not installed through Composer, because `Oil\Command` class `@include_once($phpunit_autoload_path);`
