### PR TITLE
Made configurable first/last, next/previous markers

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -48,13 +48,13 @@ class Pagination
 	{
 		// old pre-1.4 mapping to new instance methods
 		static $mapping = array(
-			'get' => '__get',
-			'set' => '__set',
-			'set_config' => '__set',
+			'get'          => '__get',
+			'set'          => '__set',
+			'set_config'   => '__set',
 			'create_links' => 'render',
-			'page_links' => 'pages_render',
-			'prev_link' => 'previous',
-			'next_link' => 'next',
+			'page_links'   => 'pages_render',
+			'prev_link'    => 'previous',
+			'next_link'    => 'next',
 		);
 
 		array_key_exists($name, $mapping) and $name = $mapping[$name];
@@ -140,8 +140,10 @@ class Pagination
 	protected $template = array(
 		'wrapper'                 => "<div class=\"pagination\">\n\t{pagination}\n</div>\n",
 		'first'                   => "<span class=\"first\">\n\t{link}\n</span>\n",
+		'first-marker'            => "««",
 		'first-link'              => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'previous'                => "<span class=\"previous\">\n\t{link}\n</span>\n",
+		'previous-marker'         => "«",
 		'previous-link'           => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'previous-inactive'       => "<span class=\"previous-inactive\">\n\t{link}\n</span>\n",
 		'previous-inactive-link'  => "\t\t<a href=\"{uri}\">{page}</a>\n",
@@ -150,10 +152,12 @@ class Pagination
 		'active'                  => "<span class=\"active\">\n\t{link}\n</span>\n",
 		'active-link'             => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'next'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
+		'next-marker'             => "»",
 		'next-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'next-inactive'           => "<span class=\"next-inactive\">\n\t{link}\n</span>\n",
 		'next-inactive-link'      => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'last'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
+		'last-marker'             => "»»",
 		'last-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
 	);
 
@@ -244,7 +248,8 @@ class Pagination
 
 		$html = str_replace(
 			'{pagination}',
-			$this->first().$this->previous().$this->pages_render().$this->next().$this->last(),
+			$this->first($this->template['first-marker']).$this->previous($this->template['previous-marker'])
+				.$this->pages_render().$this->next($this->template['next-marker']).$this->last($this->template['last-marker']),
 			$this->template['wrapper']
 		);
 

--- a/config/pagination.php
+++ b/config/pagination.php
@@ -58,9 +58,11 @@ return array(
 	'bootstrap'                   => array(
 		'wrapper'                 => "<div class=\"pagination\">\n\t<ul>{pagination}\n\t</ul>\n</div>\n",
 
+		'first-marker'            => "««",
 		'first'                   => "\n\t\t<li>{link}</li>",
 		'first-link'              => "<a href=\"{uri}\">{page}</a>",
 
+		'previous-marker'         => "«",
 		'previous'                => "\n\t\t<li>{link}</li>",
 		'previous-link'           => "<a href=\"{uri}\" rel=\"prev\">{page}</a>",
 
@@ -73,12 +75,14 @@ return array(
 		'active'                  => "\n\t\t<li class=\"active\">{link}</li>",
 		'active-link'             => "<a href=\"{uri}\">{page}</a>",
 
+		'next-marker'             => "»",
 		'next'                    => "\n\t\t<li>{link}</li>",
 		'next-link'               => "<a href=\"{uri}\" rel=\"next\">{page}</a>",
 
 		'next-inactive'           => "\n\t\t<li class=\"disabled\">{link}</li>",
 		'next-inactive-link'      => "<a href=\"{uri}\" rel=\"next\">{page}</a>",
 
+		'last-marker'             => "»»",
 		'last'                    => "\n\t\t<li>{link}</li>",
 		'last-link'               => "<a href=\"{uri}\">{page}</a>",
 	),


### PR DESCRIPTION
Pagination class didn't can to configure text of first/last and next/previous links. Fixed it.
Added new template values: first-marker, previous-marker, next-marker, last-marker.
