### PR TITLE
Made compatability fixes to upload class

### DIFF
--- a/classes/upload.php
+++ b/classes/upload.php
@@ -216,7 +216,7 @@ class Upload
 			$data['errors'] = array();
 			foreach ($file->getErrors() as $error)
 			{
-				$data['errors'][] = array($error->getError(), $error->getMessage());
+				$data['errors'][] = array('error' => $error->getError(), 'message' => $error->getMessage());
 			}
 			$result[] = $data;
 		}
@@ -301,8 +301,14 @@ class Upload
 	 */
 	public static function save()
 	{
+		$args = func_get_args();
+
 		foreach (static::$upload->getValidFiles() as $file)
 		{
+			if(isset($args[1])) {
+				$file->setConfig('path', $args[1]);
+			}
+
 			$file->save();
 		}
 	}


### PR DESCRIPTION
2 changes. Errors used to have keys for their number,message array. I've re-added these to try to maintain backwards compatibility.

save() takes parameters as noted in its comments. I've used the 2nd param to set the path of the file else it saves to '//'. This maintains compatibility with old code that calls \Upload::save(id, path)
