### PR TITLE
Faster memcached section index update

### DIFF
--- a/classes/cache/storage/memcached.php
+++ b/classes/cache/storage/memcached.php
@@ -371,7 +371,8 @@ class Cache_Storage_Memcached extends \Cache_Storage_Driver
 
 				// create a new index and store the key
 				is_array($index) || $index = array();
-				$this->memcached->set($this->config['cache_id'].$sections, array_merge($index, array($identifier => array($key,$this->created))), 0);
+				$index[$identifier] = array($key, $this->created);
+				$this->memcached->set($this->config['cache_id'].$sections, $index, 0);
 
 				// get the directory index
 				$index = $this->memcached->get($this->config['cache_id'].'__DIR__');


### PR DESCRIPTION
`array_merge` has a huge impact on performance when sections are about 1k entries and more. I know, they shouldn't be so large, but even with smaller sections - it's better to use simple `$index[$identifier] = ...;` syntax instead of merge
