### PR TITLE
Fix csrf_autoload bug. It be check only 'POST', 'PUT' and 'DELETE' http methods.

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -54,7 +54,8 @@ class Security
 		static::$csrf_old_token = \Input::cookie(static::$csrf_token_key, false);
 
 		// if csrf automatic checking is enabled, and it fails validation, bail out!
-		if (\Config::get('security.csrf_autoload', true) and ! static::check_token())
+		$is_check_token_request = in_array(strtolower(\Input::method()), array('post', 'put', 'delete'));
+		if (\Config::get('security.csrf_autoload', true) and $is_check_token_request and ! static::check_token())
 		{
 			throw new \SecurityException('CSRF validation failed, Possible hacking attempt detected!');
 		}

--- a/classes/security.php
+++ b/classes/security.php
@@ -54,10 +54,13 @@ class Security
 		static::$csrf_old_token = \Input::cookie(static::$csrf_token_key, false);
 
 		// if csrf automatic checking is enabled, and it fails validation, bail out!
-		$is_check_token_request = in_array(strtolower(\Input::method()), array('post', 'put', 'delete'));
-		if (\Config::get('security.csrf_autoload', true) and $is_check_token_request and ! static::check_token())
+		if (\Config::get('security.csrf_autoload', true))
 		{
-			throw new \SecurityException('CSRF validation failed, Possible hacking attempt detected!');
+			$check_token_methods = \Config::get('security.csrf_autoload_methods', array('post', 'put', 'delete'));
+			if (in_array(strtolower(\Input::method()), $check_token_methods) and ! static::check_token())
+			{
+				throw new \SecurityException('CSRF validation failed, Possible hacking attempt detected!');
+			}
 		}
 
 		// throw an exception if no the output filter setting is missing from the app config

--- a/config/config.php
+++ b/config/config.php
@@ -124,6 +124,7 @@ return array(
 		'csrf_autoload'    => false,
 		'csrf_token_key'   => 'fuel_csrf_token',
 		'csrf_expiration'  => 0,
+		'csrf_autoload_methods' => array('post', 'put', 'delete'),
 
 		/**
 		 * This input filter can be any normal PHP function as well as 'xss_clean'


### PR DESCRIPTION
Currently check allmethod on csrf_autoload is true.  
It will be catch \SecurityException when I access to some pages by http GET method.

this pull request check http methods and run check_token() only post, put and delete method.
