### PR TITLE
Change logic on CSRF token generate.

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -292,7 +292,12 @@ class Security
 		// set new token for next session when necessary
 		else
 		{
-			static::$csrf_token = md5(uniqid().time());
+			static::$csrf_token = md5(
+				uniqid()
+				.time()
+				.\Config::get('security.csrf_token_salt', '')
+				.mt_rand(1,1000000)
+			);
 
 			$expiration = \Config::get('security.csrf_expiration', 0);
 			\Cookie::set(static::$csrf_token_key, static::$csrf_token, $expiration);

--- a/config/config.php
+++ b/config/config.php
@@ -124,7 +124,7 @@ return array(
 		'csrf_autoload'    => false,
 		'csrf_token_key'   => 'fuel_csrf_token',
 		'csrf_expiration'  => 0,
-		'csrf_token_salt'  => 'put your salt for generate csrf token',
+		'csrf_token_salt'  => 'put your salt value here to make the token more secure',
 
 		/**
 		 * This input filter can be any normal PHP function as well as 'xss_clean'

--- a/config/config.php
+++ b/config/config.php
@@ -124,6 +124,7 @@ return array(
 		'csrf_autoload'    => false,
 		'csrf_token_key'   => 'fuel_csrf_token',
 		'csrf_expiration'  => 0,
+		'csrf_token_salt'  => 'put your salt for generate csrf token',
 
 		/**
 		 * This input filter can be any normal PHP function as well as 'xss_clean'


### PR DESCRIPTION
Currently logic of generate token can be inferred.
because, uniqid() uses microtime.

I tried use more secure logic that used salt.
