### PR TITLE
Added first/last inactive generation

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -142,23 +142,27 @@ class Pagination
 		'first'                   => "<span class=\"first\">\n\t{link}\n</span>\n",
 		'first-marker'            => "&laquo;&laquo;",
 		'first-link'              => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'first-inactive'          => "",
+		'first-inactive-link'     => "",
 		'previous'                => "<span class=\"previous\">\n\t{link}\n</span>\n",
 		'previous-marker'         => "&laquo;",
 		'previous-link'           => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'previous-inactive'       => "<span class=\"previous-inactive\">\n\t{link}\n</span>\n",
-		'previous-inactive-link'  => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'previous-inactive-link'  => "\t\t<a href=\"#\">{page}</a>\n",
 		'regular'                 => "<span>\n\t{link}\n</span>\n",
 		'regular-link'            => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'active'                  => "<span class=\"active\">\n\t{link}\n</span>\n",
-		'active-link'             => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'active-link'             => "\t\t<a href=\"#\">{page}</a>\n",
 		'next'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
 		'next-marker'             => "&raquo;",
 		'next-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'next-inactive'           => "<span class=\"next-inactive\">\n\t{link}\n</span>\n",
-		'next-inactive-link'      => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'next-inactive-link'      => "\t\t<a href=\"#\">{page}</a>\n",
 		'last'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
 		'last-marker'             => "&raquo;&raquo;",
-		'last-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'last-link'               => "\t\t<a href=\"#\">{page}</a>\n",
+		'last-inactive'           => "",
+		'last-inactive-link'      => "",
 	);
 
 	/**
@@ -317,13 +321,24 @@ class Pagination
 	{
 		$html = '';
 
-		if ($this->config['show_first'] and $this->config['total_pages'] > 1 and $this->config['calculated_page'] > 1)
+		if ($this->config['show_first'])
 		{
-			$html = str_replace(
-				'{link}',
-				str_replace(array('{uri}', '{page}'), array($this->_make_link(1), $marker), $this->template['first-link']),
-				$this->template['first']
-			);
+			if ($this->config['total_pages'] > 1 and $this->config['calculated_page'] > 1)
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array($this->_make_link(1), $marker), $this->template['first-link']),
+					$this->template['first']
+				);
+			}
+			else
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array('#', $marker), $this->template['first-inactive-link']),
+					$this->template['first-inactive']
+				);
+			}
 		}
 
 		return $html;
@@ -413,13 +428,24 @@ class Pagination
 	{
 		$html = '';
 
-		if ($this->config['show_last'] and $this->config['total_pages'] > 1 and $this->config['calculated_page'] != $this->config['total_pages'])
+		if ($this->config['show_last'])
 		{
-			$html = str_replace(
-				'{link}',
-				str_replace(array('{uri}', '{page}'), array($this->_make_link($this->config['total_pages']), $marker), $this->template['last-link']),
-				$this->template['last']
-			);
+			if ($this->config['total_pages'] > 1 and $this->config['calculated_page'] != $this->config['total_pages'])
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array($this->_make_link($this->config['total_pages']), $marker), $this->template['last-link']),
+					$this->template['last']
+				);
+			}
+			else
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array('#', $marker), $this->template['last-inactive-link']),
+					$this->template['last-inactive']
+				);
+			}
 		}
 
 		return $html;


### PR DESCRIPTION
Made first/last links configurable. It allows not to dissapear links if we are already at first/last page, if needed. By default templates are empty – for backward compability.

Also i replace {uri} with # in inactive url templates. That allows to configure link of inactive pages, not hardcoded # as before. It brakes bc a little. I think that really small number of people will get broken urls of inactive pages, if apply my changes. I can add sanitizing of inactive template to remove {uri} from inactive template but think that it's very weird and clumsy.
