### PR TITLE
Inactive patterns now have not {uri}. Added first/last inactive generation

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -142,23 +142,27 @@ class Pagination
 		'first'                   => "<span class=\"first\">\n\t{link}\n</span>\n",
 		'first-marker'            => "&laquo;&laquo;",
 		'first-link'              => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'first-inactive'          => "",
+		'first-inactive-link'     => "",
 		'previous'                => "<span class=\"previous\">\n\t{link}\n</span>\n",
 		'previous-marker'         => "&laquo;",
 		'previous-link'           => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'previous-inactive'       => "<span class=\"previous-inactive\">\n\t{link}\n</span>\n",
-		'previous-inactive-link'  => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'previous-inactive-link'  => "\t\t<a href=\"#\">{page}</a>\n",
 		'regular'                 => "<span>\n\t{link}\n</span>\n",
 		'regular-link'            => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'active'                  => "<span class=\"active\">\n\t{link}\n</span>\n",
-		'active-link'             => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'active-link'             => "\t\t<a href=\"#\">{page}</a>\n",
 		'next'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
 		'next-marker'             => "&raquo;",
 		'next-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
 		'next-inactive'           => "<span class=\"next-inactive\">\n\t{link}\n</span>\n",
-		'next-inactive-link'      => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'next-inactive-link'      => "\t\t<a href=\"#\">{page}</a>\n",
 		'last'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
 		'last-marker'             => "&raquo;&raquo;",
 		'last-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'last-inactive'           => "",
+		'last-inactive-link'      => "",
 	);
 
 	/**
@@ -317,13 +321,24 @@ class Pagination
 	{
 		$html = '';
 
-		if ($this->config['show_first'] and $this->config['total_pages'] > 1 and $this->config['calculated_page'] > 1)
+		if ($this->config['show_first'])
 		{
-			$html = str_replace(
-				'{link}',
-				str_replace(array('{uri}', '{page}'), array($this->_make_link(1), $marker), $this->template['first-link']),
-				$this->template['first']
-			);
+			if ($this->config['total_pages'] > 1 and $this->config['calculated_page'] > 1)
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array($this->_make_link(1), $marker), $this->template['first-link']),
+					$this->template['first']
+				);
+			}
+			else
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array('#', $marker), $this->template['first-inactive-link']),
+					$this->template['first-inactive']
+				);
+			}
 		}
 
 		return $html;
@@ -413,13 +428,24 @@ class Pagination
 	{
 		$html = '';
 
-		if ($this->config['show_last'] and $this->config['total_pages'] > 1 and $this->config['calculated_page'] != $this->config['total_pages'])
+		if ($this->config['show_last'])
 		{
-			$html = str_replace(
-				'{link}',
-				str_replace(array('{uri}', '{page}'), array($this->_make_link($this->config['total_pages']), $marker), $this->template['last-link']),
-				$this->template['last']
-			);
+			if ($this->config['total_pages'] > 1 and $this->config['calculated_page'] != $this->config['total_pages'])
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array($this->_make_link($this->config['total_pages']), $marker), $this->template['last-link']),
+					$this->template['last']
+				);
+			}
+			else
+			{
+				$html = str_replace(
+					'{link}',
+					str_replace(array('{uri}', '{page}'), array('#', $marker), $this->template['last-inactive-link']),
+					$this->template['last-inactive']
+				);
+			}
 		}
 
 		return $html;

--- a/config/pagination.php
+++ b/config/pagination.php
@@ -33,29 +33,35 @@ return array(
 		'first-marker'            => "&laquo;&laquo;",
 		'first-link'              => "\t\t<a href=\"{uri}\">{page}</a>\n",
 
+		'first-inactive'          => "",
+		'first-inactive-link'     => "",
+
 		'previous'                => "<span class=\"previous\">\n\t{link}\n</span>\n",
 		'previous-marker'         => "&laquo;",
 		'previous-link'           => "\t\t<a href=\"{uri}\" rel=\"prev\">{page}</a>\n",
 
 		'previous-inactive'       => "<span class=\"previous-inactive\">\n\t{link}\n</span>\n",
-		'previous-inactive-link'  => "\t\t<a href=\"{uri}\" rel=\"prev\">{page}</a>\n",
+		'previous-inactive-link'  => "\t\t<a href=\"#\" rel=\"prev\">{page}</a>\n",
 
 		'regular'                 => "<span>\n\t{link}\n</span>\n",
 		'regular-link'            => "\t\t<a href=\"{uri}\">{page}</a>\n",
 
 		'active'                  => "<span class=\"active\">\n\t{link}\n</span>\n",
-		'active-link'             => "\t\t<a href=\"{uri}\">{page}</a>\n",
+		'active-link'             => "\t\t<a href=\"#\">{page}</a>\n",
 
 		'next'                    => "<span class=\"next\">\n\t{link}\n</span>\n",
 		'next-marker'            => "&raquo;",
 		'next-link'               => "\t\t<a href=\"{uri}\" rel=\"next\">{page}</a>\n",
 
 		'next-inactive'           => "<span class=\"next-inactive\">\n\t{link}\n</span>\n",
-		'next-inactive-link'      => "\t\t<a href=\"{uri}\" rel=\"next\">{page}</a>\n",
+		'next-inactive-link'      => "\t\t<a href=\"#\" rel=\"next\">{page}</a>\n",
 
 		'last'                    => "<span class=\"last\">\n\t{link}\n</span>\n",
 		'last-marker'             => "&raquo;&raquo;",
 		'last-link'               => "\t\t<a href=\"{uri}\">{page}</a>\n",
+
+		'last-inactive'           => "",
+		'last-inactive-link'      => "",
 	),
 
 	// Twitter bootstrap 2.x template
@@ -66,29 +72,35 @@ return array(
 		'first-marker'            => "&laquo;&laquo;",
 		'first-link'              => "<a href=\"{uri}\">{page}</a>",
 
+		'first-inactive'          => "",
+		'first-inactive-link'     => "",
+
 		'previous'                => "\n\t\t<li>{link}</li>",
 		'previous-marker'         => "&laquo;",
 		'previous-link'           => "<a href=\"{uri}\" rel=\"prev\">{page}</a>",
 
 		'previous-inactive'       => "\n\t\t<li class=\"disabled\">{link}</li>",
-		'previous-inactive-link'  => "<a href=\"{uri}\" rel=\"prev\">{page}</a>",
+		'previous-inactive-link'  => "<a href=\"#\" rel=\"prev\">{page}</a>",
 
 		'regular'                 => "\n\t\t<li>{link}</li>",
 		'regular-link'            => "<a href=\"{uri}\">{page}</a>",
 
 		'active'                  => "\n\t\t<li class=\"active\">{link}</li>",
-		'active-link'             => "<a href=\"{uri}\">{page}</a>",
+		'active-link'             => "<a href=\"#\">{page}</a>",
 
 		'next'                    => "\n\t\t<li>{link}</li>",
 		'next-marker'             => "&raquo;",
 		'next-link'               => "<a href=\"{uri}\" rel=\"next\">{page}</a>",
 
 		'next-inactive'           => "\n\t\t<li class=\"disabled\">{link}</li>",
-		'next-inactive-link'      => "<a href=\"{uri}\" rel=\"next\">{page}</a>",
+		'next-inactive-link'      => "<a href=\"#\" rel=\"next\">{page}</a>",
 
 		'last'                    => "\n\t\t<li>{link}</li>",
 		'last-marker'             => "&raquo;&raquo;",
 		'last-link'               => "<a href=\"{uri}\">{page}</a>",
+
+		'last-inactive'           => "",
+		'last-inactive-link'      => "",
 	),
 
 );


### PR DESCRIPTION
Backward fully compatible. Changed template for using "#" instead of "{uri}", that is more clear. Now behavior of pagination is fully configurable.

Suggest to declare deprecation of using "{uri}" in inactive links and remove support of them in 1.7. (But it's just suggestion).
