### PR TITLE
Easy way to switch default connection.

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -49,7 +49,7 @@ abstract class Database_Connection
 		if ($name === null)
 		{
 			// Use the default instance name
-			$name = \Config::get('db.active');
+			$name = static::$default;
 		}
 
 		if ( ! isset(static::$instances[$name]))

--- a/config/db.php
+++ b/config/db.php
@@ -20,13 +20,6 @@
  */
 
 return array(
-
-	/*
-	 * If you don't specify a DB configuration name when you create a connection
-	 * the configuration to be used will be determined by the 'active' value
-	 */
-	'active' => 'default',
-
 	/**
 	 * Base PDO config
 	 */


### PR DESCRIPTION
Hi.
## supply a Easy way to switch default connection.

As we know all the DB kind obeject use \Database_Connection::instance() to connection.
for example:
  A,B modules Use master,slave connection.
A switch connection to master just:

``` php
\Database_Connection::$default = "master"
```

And B switch connection to slave just:

``` php
\Database_Connection::$default = "slave"
```

end than modules work out must give back it.

``` php
\Database_Connection::$default = "default"
```
## Bad thing is.

User ma be very sure hie use which one  connection.
