### PR TITLE
Fixed Event_Instance::unregister() bug

### DIFF
--- a/classes/event/instance.php
+++ b/classes/event/instance.php
@@ -102,7 +102,7 @@ class Event_Instance
 		{
 			if ($callback === null)
 			{
-				$this->_events = array();
+				unset($this->_events[$event]);
 				return true;
 			}
 


### PR DESCRIPTION
in https://github.com/fuel/core/pull/1344 I just followed the annotation. 
But the target to unregister is incorrect. 
**This will unset all events.** It's my fault.
