### PR TITLE
Propose _validation_date

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -953,7 +953,7 @@ class Validation
 	 * @param   bool    Whether validation checks strict
 	 * @return  bool
 	 */
-	public function _validation_date($val, $format = null, $strict = true)
+	public function _validation_valid_date($val, $format = null, $strict = true)
 	{
 		if ($this->_empty($val))
 		{

--- a/classes/validation.php
+++ b/classes/validation.php
@@ -944,4 +944,29 @@ class Validation
 
 		return true;
 	}
+
+	/**
+	 * Checks whether string input is valid date format
+	 *
+	 * @param   string
+	 * @param   string  The format used at the time of a validation
+	 * @param   bool    Whether validation checks strict
+	 * @return  bool
+	 */
+	public function _validation_date($val, $format = null, $strict = true)
+	{
+		if ($this->_empty($val))
+		{
+			return true;
+		}
+		if ($format)
+		{
+			$parsed = date_parse_from_format($format, $val);
+		}
+		else
+		{
+			$parsed = date_parse($val);
+		}
+		return \Arr::get($parsed, 'error_count', 1) + ($strict ? \Arr::get($parsed, 'warning_count', 1) : 0) === 0;
+	}
 }

--- a/tests/validation.php
+++ b/tests/validation.php
@@ -682,4 +682,129 @@ class Test_Validation extends TestCase
 
 		$this->assertEquals($expected, $test);
 	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   success
+	 */
+	public function test_validation_date_none_arguments() {
+		$post = array(
+			'f1' => '2013/02/26',
+			'f2' => '2013-02-26',
+			'f3' => '2013/2/26 12:0:33',
+			'f4' => '19 Jan 2038 03:14:07',
+			'f5' => 'Sat Mar 10 17:16:18 MST 2001',
+			'f6' => '',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date');
+		$val->add_field('f2', 'F2', 'date');
+		$val->add_field('f3', 'F3', 'date');
+		$val->add_field('f4', 'F4', 'date');
+		$val->add_field('f5', 'F5', 'date');
+		$val->add_field('f6', 'F6', 'date');
+		$test = $val->run($post);
+		$expected = true;
+
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   failure
+	 */
+	public function test_validation_date_none_arguments_error() {
+		$post = array(
+			'f1' => 'test',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date');
+		$test = $val->run($post);
+		$expected = false;
+
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   failure
+	 */
+	public function test_validation_date_none_arguments_strict_error() {
+		$post = array(
+			'f1' => '2013/02/29',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date');
+		$test = $val->run($post);
+		$expected = false;
+
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   success
+	 */
+	public function test_validation_date_format() {
+		$post = array(
+			'f1' => '2013/02/26',
+			'f2' => '2013-02-26',
+			'f3' => '2013/2/26 12:0:33',
+			'f4' => '19 Jan 2038 03:14:07',
+			'f5' => 'Sat Mar 10 17:16:18 MST 2001',
+			'f6' => '',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date[Y/m/d]');
+		$val->add_field('f2', 'F2', 'date[Y-m-d]');
+		$val->add_field('f3', 'F3', 'date[Y/m/d H:i:s]');
+		$val->add_field('f4', 'F4', 'date[d M Y H:i:s]');
+		$val->add_field('f5', 'F5', 'date[D M d H:i:s T Y]');
+		$val->add_field('f6', 'F6', 'date[Y/m/d]');
+
+		$test = $val->run($post);
+		$expected = true;
+
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   failure
+	 */
+	public function test_validation_date_format_error() {
+		$post = array(
+			'f1' => '2013/02/26',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date[Y/m/d H:i:s]');
+
+		$test = $val->run($post);
+		$expected = false;
+
+		$this->assertEquals($expected, $test);
+	}
+
+	/**
+	 * Validation:  date
+	 * Expecting:   success
+	 */
+	public function test_validation_date_not_strict() {
+		$post = array(
+			'f1' => '2013/02/29',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('f1', 'F1', 'date[Y/m/d,0]');
+
+		$test = $val->run($post);
+		$expected = true;
+
+		$this->assertEquals($expected, $test);
+	}
 }

--- a/tests/validation.php
+++ b/tests/validation.php
@@ -684,10 +684,10 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   success
 	 */
-	public function test_validation_date_none_arguments() {
+	public function test_validation_valid_date_none_arguments() {
 		$post = array(
 			'f1' => '2013/02/26',
 			'f2' => '2013-02-26',
@@ -699,11 +699,11 @@ class Test_Validation extends TestCase
 
 		$val = Validation::forge(__FUNCTION__);
 		$val->add_field('f1', 'F1', 'valid_date');
-		$val->add_field('f2', 'F2', 'date');
-		$val->add_field('f3', 'F3', 'date');
-		$val->add_field('f4', 'F4', 'date');
-		$val->add_field('f5', 'F5', 'date');
-		$val->add_field('f6', 'F6', 'date');
+		$val->add_field('f2', 'F2', 'valid_date');
+		$val->add_field('f3', 'F3', 'valid_date');
+		$val->add_field('f4', 'F4', 'valid_date');
+		$val->add_field('f5', 'F5', 'valid_date');
+		$val->add_field('f6', 'F6', 'valid_date');
 		$test = $val->run($post);
 		$expected = true;
 

--- a/tests/validation.php
+++ b/tests/validation.php
@@ -698,7 +698,7 @@ class Test_Validation extends TestCase
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date');
+		$val->add_field('f1', 'F1', 'valid_date');
 		$val->add_field('f2', 'F2', 'date');
 		$val->add_field('f3', 'F3', 'date');
 		$val->add_field('f4', 'F4', 'date');
@@ -711,16 +711,16 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   failure
 	 */
-	public function test_validation_date_none_arguments_error() {
+	public function test_validation_valid_date_none_arguments_error() {
 		$post = array(
 			'f1' => 'test',
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date');
+		$val->add_field('f1', 'F1', 'valid_date');
 		$test = $val->run($post);
 		$expected = false;
 
@@ -728,16 +728,16 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   failure
 	 */
-	public function test_validation_date_none_arguments_strict_error() {
+	public function test_validation_valid_date_none_arguments_strict_error() {
 		$post = array(
 			'f1' => '2013/02/29',
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date');
+		$val->add_field('f1', 'F1', 'valid_date');
 		$test = $val->run($post);
 		$expected = false;
 
@@ -745,10 +745,10 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   success
 	 */
-	public function test_validation_date_format() {
+	public function test_validation_valid_date_format() {
 		$post = array(
 			'f1' => '2013/02/26',
 			'f2' => '2013-02-26',
@@ -759,12 +759,12 @@ class Test_Validation extends TestCase
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date[Y/m/d]');
-		$val->add_field('f2', 'F2', 'date[Y-m-d]');
-		$val->add_field('f3', 'F3', 'date[Y/m/d H:i:s]');
-		$val->add_field('f4', 'F4', 'date[d M Y H:i:s]');
-		$val->add_field('f5', 'F5', 'date[D M d H:i:s T Y]');
-		$val->add_field('f6', 'F6', 'date[Y/m/d]');
+		$val->add_field('f1', 'F1', 'valid_date[Y/m/d]');
+		$val->add_field('f2', 'F2', 'valid_date[Y-m-d]');
+		$val->add_field('f3', 'F3', 'valid_date[Y/m/d H:i:s]');
+		$val->add_field('f4', 'F4', 'valid_date[d M Y H:i:s]');
+		$val->add_field('f5', 'F5', 'valid_date[D M d H:i:s T Y]');
+		$val->add_field('f6', 'F6', 'valid_date[Y/m/d]');
 
 		$test = $val->run($post);
 		$expected = true;
@@ -773,16 +773,16 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   failure
 	 */
-	public function test_validation_date_format_error() {
+	public function test_validation_valid_date_format_error() {
 		$post = array(
 			'f1' => '2013/02/26',
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date[Y/m/d H:i:s]');
+		$val->add_field('f1', 'F1', 'valid_date[Y/m/d H:i:s]');
 
 		$test = $val->run($post);
 		$expected = false;
@@ -791,16 +791,16 @@ class Test_Validation extends TestCase
 	}
 
 	/**
-	 * Validation:  date
+	 * Validation:  valid_date
 	 * Expecting:   success
 	 */
-	public function test_validation_date_not_strict() {
+	public function test_validation_valid_date_not_strict() {
 		$post = array(
 			'f1' => '2013/02/29',
 		);
 
 		$val = Validation::forge(__FUNCTION__);
-		$val->add_field('f1', 'F1', 'date[Y/m/d,0]');
+		$val->add_field('f1', 'F1', 'valid_date[Y/m/d,0]');
 
 		$test = $val->run($post);
 		$expected = true;


### PR DESCRIPTION
I often implement the validation of date for 'datepicker' forms. 
So I propose that extension.
Can you check?

Example:

``` php
        $post = array(
            'f1' => '2013/02/26',
            'f2' => '2013-02-26',
            'f3' => '2013/2/26 12:0:33',
            'f4' => '19 Jan 2038 03:14:07',
            'f5' => 'Sat Mar 10 17:16:18 MST 2001',
            'f6' => '',
            'f7' => 'foobar',
            'f8' => '2013/02/26',
            'f9' => '2013/02/29',
        );

        $val = Validation::forge('test');
        $val->add_field('f1', 'F1', 'valid-date'); // OK
        $val->add_field('f2', 'F2', 'valid_date[Y-m-d]'); // OK
        $val->add_field('f3', 'F3', 'valid_date[Y/m/d H:i:s]'); // OK
        $val->add_field('f4', 'F4', 'valid_date[d M Y H:i:s]'); // OK
        $val->add_field('f5', 'F5', 'valid_date[D M d H:i:s T Y]'); // OK
        $val->add_field('f6', 'F6', 'valid_date[Y/m/d]'); // OK
        $val->add_field('f7', 'F7', 'valid_date'); // NG
        $val->add_field('f8', 'F8', 'valid_date[Y-m-d]'); // NG
        $val->add_field('f9', 'F9', 'valid_date'); // NG
        $val->add_field('f9', 'F9', 'valid_date[,0]'); // OK
```
