### PR TITLE
Added $_mass_whitelist/blacklist to Model_Crud

### DIFF
--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -46,6 +46,16 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess, \Serializabl
 	// protected static $_properties = array();
 
 	/**
+	 * @var  array  $_mass_whitelist  The table column names which will be set while using mass assignment like ->set($data)
+	 */
+	// protected static $_mass_whitelist = array();
+
+	/**
+	 * @var  array  $_mass_blacklist  The table column names which will not be set while using mass assignment like ->set($data)
+	 */
+	// protected static $_mass_blacklist = array();
+
+	/**
 	 * @var array  $_labels  Field labels (must set this in your Model to use)
 	 */
 	// protected static $_labels = array();
@@ -421,7 +431,19 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess, \Serializabl
 	{
 		foreach ($data as $key => $value)
 		{
-			$this->{$key} = $value;
+			if (isset(static::$_mass_whitelist))
+			{
+				in_array($key, static::$_mass_whitelist) and $this->{$key} = $value;
+			}
+			elseif (isset(static::$_mass_blacklist))
+			{
+				( ! in_array($key, static::$_mass_blacklist)) and $this->{$key} = $value;
+			}
+			else
+			{
+				// no static::$_mass_whitelist or static::$_mass_whitelist set, proceed with default behavior
+				$this->{$key} = $value;
+			}
 		}
 		return $this;
 	}

--- a/classes/model/crud.php
+++ b/classes/model/crud.php
@@ -441,7 +441,7 @@ class Model_Crud extends \Model implements \Iterator, \ArrayAccess, \Serializabl
 			}
 			else
 			{
-				// no static::$_mass_whitelist or static::$_mass_whitelist set, proceed with default behavior
+				// no static::$_mass_whitelist or static::$_mass_blacklist set, proceed with default behavior
 				$this->{$key} = $value;
 			}
 		}


### PR DESCRIPTION
For example I have Model_Customer to work with and it's ok.

Now I need Model_Customer_Api which would extend the Model_CUstomer, but I want only fields like:

``` php
    protected static $_mass_whitelist = array(
        'first_name',
        'last_name',
    );
```

to be changed from Api model, but not others. so I pass only those fields.
It will work only for ->set($input);

For example: 
$input = array('first_name' => 'test', 'password' => 'wont_be_save');

So like $customer = Model_Customer_Api::find_by_pk(1);
$customer->set($input):
$customer->save();

will save only the 'fist_name'.
But if we will use the:
$customer->password = 'will_be_save';
it'll still work.

I think you understand the use case.

Also made the mass_blacklist, so we can blacklist for example 'username' field, where api won't be able to change the username.

Thanks,
huglester
