### PR TITLE
Fix for a Fieldset issue, where zero or false values are not populated.

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -520,7 +520,7 @@ class Fieldset
 				// convert form field array's to Fuel dotted notation
 				$name = str_replace(array('[',']'), array('.', ''), $f->name);
 
-				if ($value = \Arr::get($input, $name) or $value = \Arr::get($input, $f->basename))
+				if (null !==($value = \Arr::get($input, $name) or $value = \Arr::get($input, $f->basename)))
 				{
 					$f->set_value($value, true);
 				}


### PR DESCRIPTION
## Issue

When creating forms with the `Fieldset` class after attempting to populate the fieldset with a model, any fields with values inequivalent to false are not parsed.  This is mainly a problem with drop-down fields.

For example:

1 => 'Active',
0 => 'Inactive',

When the value of the field inside the model is ZERO (as stored in the database); I expect `<option value="0" selected="selected">Inactive</option>`  ACTUALLY what I get is `<option value="0">Inactive</option>`.
