### PR TITLE
Change Config::load() process

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -107,17 +107,17 @@ class Config
 		// Serialize no assoc arrays.
 		$serialize = function (&$array) use (&$serialize)
 		{
-			foreach ($array as $k => $v)
+			foreach ($array as $k => &$v)
 			{
 				if (is_array($v))
 				{
 					if (\Arr::is_assoc($v))
 					{
-						$serialize($array[$k]);
+						$serialize($v);
 					}
 					else
 					{
-						$array[$k] = array(md5('_serialized_'.$k) => true, 'content' => serialize($v));
+						$v = array(md5('_serialized_'.$k) => true, 'content' => serialize($v));
 					}
 				}
 			}
@@ -126,17 +126,17 @@ class Config
 		// Unserialize no assoc arrays.
 		$unserialize = function (&$array) use (&$unserialize)
 		{
-			foreach ($array as $k => $v)
+			foreach ($array as $k => &$v)
 			{
 				if (is_array($v))
 				{
 					if (\Arr::get($v, md5('_serialized_'.$k)))
 					{
-						$array[$k] = unserialize(\Arr::get($v, 'content'));
+						$v = unserialize(\Arr::get($v, 'content'));
 					}
 					else
 					{
-						$unserialize($array[$k]);
+						$unserialize($v);
 					}
 				}
 			}

--- a/classes/config.php
+++ b/classes/config.php
@@ -104,10 +104,54 @@ class Config
 			$group = $group === true ? $file->group() : $group;
 		}
 
+		// Serialize no assoc arrays.
+		$serialize = function (&$array) use (&$serialize)
+		{
+			foreach ($array as $k => $v)
+			{
+				if (is_array($v))
+				{
+					if (\Arr::is_assoc($v))
+					{
+						$serialize($array[$k]);
+					}
+					else
+					{
+						$array[$k] = array(md5('_serialized_'.$k) => true, 'content' => serialize($v));
+					}
+				}
+			}
+		};
+
+		// Unserialize no assoc arrays.
+		$unserialize = function (&$array) use (&$unserialize)
+		{
+			foreach ($array as $k => $v)
+			{
+				if (is_array($v))
+				{
+					if (\Arr::get($v, md5('_serialized_'.$k)))
+					{
+						$array[$k] = unserialize(\Arr::get($v, 'content'));
+					}
+					else
+					{
+						$unserialize($array[$k]);
+					}
+				}
+			}
+		};
+		
 		if ($group === null)
 		{
+			// Before merging, serialize no assoc arrays.
+			$serialize(static::$items);
+			$serialize($config);
+
 			static::$items = $reload ? $config : ($overwrite ? array_merge(static::$items, $config) : \Arr::merge(static::$items, $config));
 			static::$itemcache = array();
+
+			$unserialize(static::$items);
 		}
 		else
 		{
@@ -116,7 +160,15 @@ class Config
 			{
 				static::$items[$group] = array();
 			}
-			static::$items[$group] = $overwrite ? array_merge(static::$items[$group],$config) : \Arr::merge(static::$items[$group],$config);
+
+			// Before merging, serialize no assoc arrays.
+			$serialize(static::$items[$group]);
+			$serialize($config);
+
+			static::$items[$group] = $overwrite ? array_merge(static::$items[$group], $config) : \Arr::merge(static::$items[$group], $config);
+
+			$unserialize(static::$items[$group]);
+
 			$group .= '.';
 			foreach (static::$itemcache as $key => $value)
 			{

--- a/tests/config.php
+++ b/tests/config.php
@@ -20,5 +20,141 @@ namespace Fuel\Core;
  */
 class Test_Config extends TestCase
 {
- 	public function test_foo() {}
+
+	public function provider_config()
+	{
+		return array(
+			array(
+				array(
+					'foo' => 'bar',
+					'fuel' => 'php',
+					'multi' => array(
+						'key' => 'value',
+						'numbers' => array(1, 2),
+					),
+					'array' => array(1, 2, 3),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests Config::load()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_load($config)
+	{
+		\Config::load(array('test' => $config));
+
+		$expected = $config;
+		$this->assertEquals($expected, \Config::get('test'));
+	}
+
+	/**
+	 * Tests Config::load()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_load_group($config)
+	{
+		\Config::load(array('test' => $config), 'group');
+
+		$expected = $config;
+		$this->assertEquals($expected, \Config::get('group.test'));
+	}
+
+	/**
+	 * Tests Config::load()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_load_merge($config)
+	{
+		\Config::load(array('test' => $config));
+		\Config::load(array(
+			'test' => array(
+				'foo' => 'boo',
+				'multi' => array(
+					'numbers' => array(),
+				),
+				'array' => array(1, 9),
+			)
+		));
+
+		$expected = array(
+			'foo' => 'boo',
+			'fuel' => 'php',
+			'multi' => array(
+				'key' => 'value',
+				'numbers' => array(),
+			),
+			'array' => array(1, 9),
+		);
+		$this->assertEquals($expected, \Config::get('test'));
+	}
+
+	/**
+	 * Tests Config::load()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_load_group_merge($config)
+	{
+		\Config::load(array('test' => $config), 'group');
+		\Config::load(array(
+			'test' => array(
+				'foo' => 'boo',
+				'multi' => array(
+					'numbers' => array(),
+				),
+				'array' => array(1, 9),
+			)
+		), 'group');
+
+		$expected = array(
+			'foo' => 'boo',
+			'fuel' => 'php',
+			'multi' => array(
+				'key' => 'value',
+				'numbers' => array(),
+			),
+			'array' => array(1, 9),
+		);
+		$this->assertEquals($expected, \Config::get('group.test'));
+	}
+
+	/**
+	 * Tests Config::set()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_set($config)
+	{
+		\Config::load(array('test' => $config));
+		\Config::set('test.multi.numbers', array());
+
+		$expected = array();
+		$this->assertEquals($expected, \Config::get('test.multi.numbers'));
+	}
+
+	/**
+	 * Tests Config::delete()
+	 * 
+	 * @test
+	 * @dataProvider provider_config
+	 */
+	public function test_delete($config)
+	{
+		\Config::load(array('test' => $config));
+		\Config::delete('test.multi.key');
+
+		$expected = null;
+		$this->assertEquals($expected, \Config::get('test.multi.key'));
+	}
 }


### PR DESCRIPTION
Change to check whether each array are assoc or not.
As a result of this change, the following settings can be.

``` php
\Config::load(array(
    'test' => array(
        'foo' => 'bar',
        'fuel' => 'php',
        'multi' => array(
            'key' => 'value',
            'numbers' => array(1, 2),
        ),
        'array' => array(1, 2, 3),
    )
));

\Config::load(array(
    'test' => array(
        'foo' => 'boo',
        'multi' => array(
            'numbers' => array(),
        ),
        'array' => array(1, 9),
    )
));

print_r(\Config::get('test'));

// Array
// (
//     [foo] => boo
//     [fuel] => php
//     [multi] => Array
//         (
//             [key] => value
//             [numbers] => Array
//                 (
//                 )
//         )
//     [array] => Array
//         (
//             [0] => 1
//             [1] => 9
//         )
// )
```
