### PR TITLE
View class keep the data used at the latest rendering

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -38,6 +38,11 @@ class View
 	protected static $global_filter = array();
 
 	/**
+	 * @var  array  Keep the data used at the latest rendering
+	 */
+	protected static $last_data = array();
+
+	/**
 	 * @var  array  Current active search paths
 	 */
 	protected $request_paths = array();
@@ -108,9 +113,9 @@ class View
 		{
 			$data = get_object_vars($data);
 		}
-		elseif ($data and ! is_array($data))
+		elseif ($data !== true and $data and ! is_array($data))
 		{
-			throw new \InvalidArgumentException('The data parameter only accepts objects and arrays.');
+			throw new \InvalidArgumentException('The data parameter only accepts objects and arrays and true.');
 		}
 
 		$this->auto_filter = is_null($filter) ? \Config::get('security.auto_filter_output', true) : $filter;
@@ -122,6 +127,9 @@ class View
 
 		if ($data !== null)
 		{
+			// If the second parameter is true, restore the last data.
+			$data === true and $data = static::$last_data ?: array();
+
 			// Add the values to the current data
 			$this->data = $data;
 		}
@@ -560,6 +568,9 @@ class View
 		{
 			throw new \FuelException('You must set the file to use within your view before rendering');
 		}
+
+		// Store the last data
+		static::$last_data = $this->data;
 
 		// combine local and global data and capture the output
 		$return = $this->process_file();


### PR DESCRIPTION
When rendering a View of the multilayer, the value set in the controller does not reach the end of the rendering process.
If you pass the value of the lower layer to the View, We have to verbose description as the second argument of View::forge.
Or, there is also a hack like the following.

``` php
<body>
   <div id="container">
       <?php echo View::forge('next/view', $__data) ?>
   </div>
</body>
```

But I do not think that the way is correct.
It is because malfunction will be caused if `'__data'` is set to View. ..and more reasons.

This change enables the following.

``` php
<body>
   <div id="container">
       <?php echo View::forge('next/view', true) ?>
   </div>
</body>
```
