### PR TITLE
Changed filename to be optional when saving image

### DIFF
--- a/classes/image.php
+++ b/classes/image.php
@@ -235,7 +235,7 @@ class Image
 	 * @param   string  $permissions  Allows unix style permissions
 	 * @return  Image_Driver
 	 */
-	public static function save($filename, $permissions = null)
+	public static function save($filename = null, $permissions = null)
 	{
 		return static::instance()->save($filename, $permissions);
 	}

--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -614,8 +614,13 @@ abstract class Image_Driver
 	 * @param   string  $permissions  Allows unix style permissions
 	 * @return  array
 	 */
-	public function save($filename, $permissions = null)
+	public function save($filename = null, $permissions = null)
 	{
+		if (empty($filename))
+		{
+			$filename = $this->image_filename;
+		}
+		
 		$directory = dirname($filename);
 		if ( ! is_dir($directory))
 		{


### PR DESCRIPTION
Before if you wanted to use the same image you would have to pass the file path twice.

Before:

``` php
$image = Image::load('fuel.png')
$image->resize('10', '10');
$image->save('fuel.png');
```

After:

``` php
$image = Image::load('fuel.png')
$image->resize('10', '10');
$image->save();
```
