### PR TITLE
Fixed image drivers to be compatible with change to save() that extend it

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -326,7 +326,7 @@ class Image_Gd extends \Image_Driver
 		return (object) array('width' => $width, 'height' => $height);
 	}
 
-	public function save($filename, $permissions = null)
+	public function save($filename = null, $permissions = null)
 	{
 		extract(parent::save($filename, $permissions));
 

--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -209,7 +209,7 @@ class Image_Imagemagick extends \Image_Driver
 		return $return;
 	}
 
-	public function save($filename, $permissions = null)
+	public function save($filename = null, $permissions = null)
 	{
 		extract(parent::save($filename, $permissions));
 

--- a/classes/image/imagick.php
+++ b/classes/image/imagick.php
@@ -191,7 +191,7 @@ class Image_Imagick extends \Image_Driver
 		);
 	}
 
-	public function save($filename, $permissions = null)
+	public function save($filename = null, $permissions = null)
 	{
 		extract(parent::save($filename, $permissions));
 


### PR DESCRIPTION
Goes with 0b68408bde47132e300b7942b83ab1bbee0ce05d
