### PR TITLE
fix documnet root access for uri with extension

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -193,7 +193,7 @@ class Input
 
 					if (\Config::get('routing.strip_extension', true))
 					{
-						$uri = $uri_info['dirname'].'/'.$uri_info['filename'];
+						$uri = ($uri_info['dirname'] === '\\' ? '' : $uri_info['dirname']).'/'.$uri_info['filename'];
 					}
 				}
 			}


### PR DESCRIPTION
This is Windows issue for documnet root access.
If uri access has extension.
For example 'http://test.com/index.html'.

```
$uri_info['dirname'] === '\';
```

This commit is fix of document root access for uri with extension.
