### PR TITLE
fix group parameter being ignored in Lang::delete

### DIFF
--- a/classes/lang.php
+++ b/classes/lang.php
@@ -239,7 +239,7 @@ class Lang
 	 */
 	public static function delete($item, $group = null, $language = null)
 	{
-		$group === null or $line = $group.'.'.$line;
+		$group === null or $item = $group.'.'.$item;
 
 		($language === null) and $language = static::get_lang();
 


### PR DESCRIPTION
The `$group` parameter was ignored in `Lang::delete`. This commit provides a fix for it.
