### PR TITLE
trim the trailing slash on https:// anchor links

### DIFF
--- a/classes/html.php
+++ b/classes/html.php
@@ -46,9 +46,12 @@ class Html
 			$urlparts = explode('?', $href, 2);
 			$href = \Uri::create($urlparts[0], array(), isset($urlparts[1])?$urlparts[1]:array(), $secure);
 		}
-		elseif ( ! preg_match('#^(javascript:|\#)# i', $href) and  is_bool($secure))
+		elseif ( ! preg_match('#^(javascript:|\#)# i', $href) and is_bool($secure))
 		{
 			$href = http_build_url($href, array('scheme' => $secure ? 'https' : 'http'));
+
+			// Trim the trailing slash
+			$href = rtrim($href, '/');
 		}
 
 		// Create and display a URL hyperlink


### PR DESCRIPTION
If you pass true (4th param) to Html::anchor() it returns a trailing slash as it uses http_build_url() function instead of Uri::create(). 

Uri::create() returns a URI without a trailing slash. 

I've mimicked the behaviour of Uri::create() to remove the trailing slash.

Failed test results shown here https://gist.github.com/steadweb/5403721
