### PR TITLE
Added Validation option us_phone_number to validation class

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -969,4 +969,18 @@ class Validation
 		}
 		return \Arr::get($parsed, 'error_count', 1) + ($strict ? \Arr::get($parsed, 'warning_count', 1) : 0) === 0;
 	}
+
+	/**
+	 * Checks if input can be formated as a US phone number.
+	 * 
+	 * @param	string|int
+	 * @param	int 	The number of expected numeric digits.
+	 * @return	bool
+	 */
+	public function _validation_us_phone_number($val, $length=10)
+	{
+		//Remove all non numeric characters
+		$number = preg_replace("[\D]",'', (string) $val);
+		return (int) strlen($number) === (int) $length;
+	}
 }


### PR DESCRIPTION
This will remove all non numeric characters, count the total digits and compare it to the passed length argument (default is 10).

This allows US phone numbers such as:
(000) 000-0000
000-000-0000
0000000000
000 000 0000
or any other format that includes the number of digits required.

Note: Its up to the programmer to format the number after the info has been submitted and before it is saved.
