### PR TITLE
prevent invalid XML node names

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -145,15 +145,15 @@ class Format
 
 		foreach ($data as $key => $value)
 		{
-			// no numeric keys in our xml please!
-			if (is_numeric($key))
+			// replace anything not alpha numeric
+			$key = preg_replace('/[^a-z_\-0-9]/i', '', $key);
+
+			// no invalid keys in our xml please!
+			if ( ! static::_valid_xml_key($key))
 			{
 				// make string key...
 				$key = (\Inflector::singularize($basenode) != $basenode) ? \Inflector::singularize($basenode) : 'item';
 			}
-
-			// replace anything not alpha numeric
-			$key = preg_replace('/[^a-z_\-0-9]/i', '', $key);
 
 			// if there is another array found recrusively call this function
 			if (is_array($value) or is_object($value))
@@ -516,5 +516,21 @@ class Format
 	public static function _init()
 	{
 		\Config::load('format', true);
+	}
+	
+	/*
+	 * Valid XML Key
+	 *
+	 * Is the key a valid XML node name?
+	 * @return bool true|false
+	 */
+	protected static function _valid_xml_key($key)
+	{
+	    try {
+	        new \DOMElement($key);
+	        return true;
+	    } catch (\DOMException $e) {
+	        return false;
+	    }
 	}
 }


### PR DESCRIPTION
Format::to_xml() method can return invalid XML if the node name starts with a number or if it contains only numeric and other non-alpha characters. To fix, we remove any non-alphanumeric characters before checking to see if the key can be used to instantiate a new DOMElement.

Example of invalid results before this patch:
oil c
$array('30:0' => 'thing');
print_r(\Format::forge($array)->to_xml());
