### PR TITLE
add before_view() method to ViewModel

### DIFF
--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -111,9 +111,14 @@ abstract class ViewModel
 	}
 
 	/**
-	 * Executed before the view method
+	 * Executed before the view method on forge
 	 */
 	public function before() {}
+
+	/**
+	 * Execute before the view method
+	 */
+	public function before_view() {}
 
 	/**
 	 * The default view method
@@ -237,6 +242,7 @@ abstract class ViewModel
 			Request::active($this->_active_request);
 		}
 
+		$this->before_view();
 		$this->{$this->_method}();
 		$this->after();
 


### PR DESCRIPTION
The `ViewModel::before()` method excuted on `ViewModel::forge()`.  
`before()` can't get params of set after forge.

``` php
example: <?php
//on controller
$this->template->content = ViewModel::forge('foo/bar');
$this->template->content->set('param_a', $param_a);

//on class View_Foo_Bar
public function before()
{
    Debug::dump($this->param_a); // OutOfBoundsException [ Error ]: View variable is not set:param_a
}
```

The `before_view()` method can do it.
