### PR TITLE
Put example image preset in a comment

### DIFF
--- a/config/image.php
+++ b/config/image.php
@@ -92,7 +92,7 @@ return array(
 		 * Note that config values here override the current configuration.
 		 *
 		 * Driver cannot be changed in here.
-		 */
+		 
 		'example' => array(
 			'quality' => 100,
 			'bgcolor' => null,
@@ -103,6 +103,7 @@ return array(
 				array('output', 'png')
 			)
 		)
+		*/
 	)
 );
 


### PR DESCRIPTION
The presets functionality is very useful but by making the example preset also a real one means you have to explicitly test for it or overwrite it in your own config if you want to automatically produce all of your presets in a loop.
