### PR TITLE
Use %w not %[fx:w]

### DIFF
--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -188,7 +188,7 @@ class Image_Imagemagick extends \Image_Driver
 				$filename = $this->image_temp;
 			}
 
-			$output = $this->exec('identify', '-format "%[fx:w] %[fx:h]" "'.$filename.'"[0]');
+			$output = $this->exec('identify', '-format "%w %h" "'.$filename.'"[0]');
 			list($width, $height) = explode(" ", $output[0]);
 			$return = (object) array(
 				'width' => $width,


### PR DESCRIPTION
According to the imagemagick docs, %[fx:w] is exactly equal to %w, except it doesn't appear to work on whatever version of imagemagick I'm running.
