### PR TITLE
set fallback of lang::get() for tabular fieldset label

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -600,7 +600,7 @@ class Fieldset
 				{
 					continue;
 				}
-				$fields_output .= "\t".'<th class="'.$this->tabular_form_relation.'_col_'.$field.'">'.(isset($settings['label'])?\Lang::get($settings['label']):'').'</th>'.PHP_EOL;
+				$fields_output .= "\t".'<th class="'.$this->tabular_form_relation.'_col_'.$field.'">'.(isset($settings['label'])?\Lang::get($settings['label'], array(), $settings['label']):'').'</th>'.PHP_EOL;
 			}
 			$fields_output .= "\t".'<th>'.\Config::get('form.tabular_delete_label', 'Delete?').'</th>'.PHP_EOL;
 


### PR DESCRIPTION
Currently if there is no Lang set for the label the tabular fieldset returns false and no label is displayed.
I've amended this behaviour and provided the label from the tabular fieldset model as the third lang::get parameter so it always falls back to what you are passing it if no Lang alternative is found.
