### PR TITLE
Fixed behavior for timestamp 0

### DIFF
--- a/classes/date.php
+++ b/classes/date.php
@@ -286,7 +286,7 @@ class Date
 
 	public function __construct($timestamp = null, $timezone = null)
 	{
-		! $timestamp and $timestamp = time() + static::$server_gmt_offset;
+		is_null( $timestamp ) and $timestamp = time() + static::$server_gmt_offset;
 		! $timezone and $timezone   = \Fuel::$timezone;
 
 		$this->timestamp = $timestamp;


### PR DESCRIPTION
echo Date::forge(0); returns "Wed May  1 22:32:10 2013" but should be "Thu Jan  1 01:00:00 1970".
