### PR TITLE
App ViewModels not found when routing to a Module

### DIFF
--- a/classes/viewmodel.php
+++ b/classes/viewmodel.php
@@ -41,9 +41,10 @@ abstract class ViewModel
 
 		if ( ! class_exists($class))
 		{
-			if ( ! class_exists($class = $viewmodel))
+			$class = 'View_'.ucfirst(str_replace(array('/', DS), '_', $viewmodel));
+			if ( ! class_exists($class))
 			{
-				throw new \OutOfBoundsException('ViewModel "View_'.ucfirst(str_replace(array('/', DS), '_', $viewmodel)).'" could not be found.');
+				throw new \OutOfBoundsException('ViewModel "'.$class.'" could not be found.');
 			}
 		}
 


### PR DESCRIPTION
I had a ViewModel `class View_Newsletter extends \ViewModel` at `fuel/app/classes/view/newsletter.php` which worked fine when accessing a page served by a Controller in app.

When I then accessed a page within a Module the ViewModel could no longer be found, reporting the error `OutOfBoundsException [ Error ]: ViewModel "View_Newsletter" could not be found`
