### PR TITLE
Add support for HEAD method in cURL driver (rfc2616)

### DIFF
--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -220,6 +220,21 @@ class Request_Curl extends \Request_Driver
 	}
 
 	/**
+	 * HEAD request
+	 *
+	 * @param   array  $params
+	 * @return  void
+	 */
+	protected function method_head()
+	{
+		$this->method_get();
+
+		$this->set_option(CURLOPT_NOBODY, true);
+		$this->set_option(CURLOPT_HEADER, true);
+
+	}
+
+	/**
 	 * POST request
 	 *
 	 * @param   array  $params


### PR DESCRIPTION
Adding the missing HEAD method in cURL driver.
This is a GET method which doesn't return a message body.

From the RFC : 
_The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response. The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information sent in response to a GET request. This method can be used for obtaining metainformation about the entity implied by the request without transferring the entity-body itself. This method is often used for testing hypertext links for validity, accessibility, and recent modification._
