### PR TITLE
Added build_query_string() to URI class

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -235,7 +235,7 @@ class Uri
 	 * @param   array    ...
 	 * @return  string
 	 */
-	public static function build_query_string(array $params)
+	public static function build_query_string($params)
 	{
 		$params = array();
 

--- a/classes/uri.php
+++ b/classes/uri.php
@@ -228,6 +228,26 @@ class Uri
 		return $url;
 	}
 
+	/**
+	 * Builds a query string based on a number of merged arrays
+	 *
+	 * @param   array    Array to merge
+	 * @param   array    ...
+	 * @return  string
+	 */
+	public static function build_query_string()
+	{
+		$params = array();
+
+		foreach (func_get_args() as $arg)
+		{
+			$arg = (array)$arg;
+
+			$params = \Arr::merge($params, $arg);
+		}
+
+		return http_build_query($params);
+	}
 
 	/**
 	 * @var  string  The URI string

--- a/classes/uri.php
+++ b/classes/uri.php
@@ -235,7 +235,7 @@ class Uri
 	 * @param   array    ...
 	 * @return  string
 	 */
-	public static function build_query_string()
+	public static function build_query_string(array $params)
 	{
 		$params = array();
 


### PR DESCRIPTION
As discussed in #fuelphp. Designed for use like this...

``` html
<a href="<?= \Uri::build_query_string(\Input::get(), ['foo'=>'bar']) ?>">Foo</a>
```
