### PR TITLE
add migrate old number migrations option

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -411,6 +411,15 @@ class Migrate
 			// add the file to the migrations list if it's in between version bounds
 			if ((is_null($start) or $migration > $start) and (is_null($end) or $migration <= $end))
 			{
+				// add suffix to $migrations key number if exists key yet
+				if(array_key_exists($migration, $migrations)){
+					if(($pos = strpos($migration, '_')) === false){
+						$migration .= '_1';
+					}else{
+						$migration .= '_' . ((int)substr($migration, $pos + 1, strlen($migration)) + 1);
+					}
+				}
+
 				// see if it is already installed
 				if ( in_array(basename($file, '.php'), $current))
 				{

--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -409,7 +409,7 @@ class Migrate
 			is_numeric($migration) and $migration = (int) $migration;
 
 			// add the file to the migrations list if it's in between version bounds
-			if ((is_null($start) or $migration > $start) and (is_null($end) or $migration <= $end))
+			if ((is_null($start) or \Config::get('migrate.find_old_numbers', false) or $migration > $start) and (is_null($end) or $migration <= $end))
 			{
 				// add suffix to $migrations key number if exists key yet
 				if(array_key_exists($migration, $migrations)){

--- a/config/config.php
+++ b/config/config.php
@@ -339,4 +339,16 @@ return array(
 		'language'  => array(),
 	),
 
+	/**
+	 * Configs to migration
+	 */
+	'migrate' => array(
+
+		/**
+		 * Migration find files only after current migrated number default.
+		 * If you set true, check include before current migrated number.
+		 */
+		'find_old_numbers' => false,
+	),
+
 );


### PR DESCRIPTION
When team develop on git
- Developer A add migration 010_a to branch A
- Developer B add migration 010_b and 011_b to branch B
- Developer C add migration 009_c to branch C
- Branch A merge to master and `oil r migrate`.
  - master migrations: 001..008 and 010_a
- Branch B merge to master and `oil r migrate`.
  - master migrations: 001..008, 010_a 010_b and 011_b
  - 010_b is skipped migration
  - because 010 is migrated yet.
- Branch C merge to master and `oil r migrate`
  - master migrations: 001..008, 010_a, 010_b, 011_b and 009_c
  - 009_c is skipped migration
  - because 009 is less than current number

I fix these
- migrate same number
- add migrate old numbers option
