### PR TITLE
Fix bug with expired session

### DIFF
--- a/classes/session/redis.php
+++ b/classes/session/redis.php
@@ -126,15 +126,9 @@ class Session_Redis extends \Session_Driver
 					// cookie present, but session record missing. force creation of a new session
 					return $this->read(true);
 				}
-				else
-				{
-					// update the session
-					$this->keys['previous_id'] = $this->keys['session_id'];
-					$this->keys['session_id']  = $payload['rotated_session_id'];
 
-					// unpack the payload
-					$payload = $this->_unserialize($payload);
-				}
+				// unpack the payload
+				$payload = $this->_unserialize($payload);
 			}
 
 			if ( ! isset($payload[0]) or ! is_array($payload[0]))


### PR DESCRIPTION
If the session is expired the Redis driver try to set $this->keys['previous_id'] with $this->keys['session_id'] which do not exist also it try to set $this->keys['session_id']  with $payload['rotated_session_id'] but we have just set the payload variable with the retated_session from Redis.
We just need to unserialize the data like in Memcached and File driver.
