### PR TITLE
add default extension if there is not one set

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -150,6 +150,7 @@ class Config
 
 		$info = pathinfo($file);
 		$type = 'php';
+
 		if (isset($info['extension']))
 		{
 			$type = $info['extension'];
@@ -158,7 +159,12 @@ class Config
 			{
 				$file = substr($file, 0, -(strlen($type) + 1));
 			}
+		} 
+		else 
+		{
+			$file .= '.' . $type;
 		}
+
 		$class = '\\Config_'.ucfirst($type);
 
 		if ( ! class_exists($class))


### PR DESCRIPTION
The docs say 'The path to the config file, relative to the config directory. Do not include the file extension (".php" is assumed).'
which currently is not correct. If you do not specify a file extension none gets set so this sets the default if one is not provided.
