### PR TITLE
Fixup hardcoded *nix paths, some spaces around concatenation

### DIFF
--- a/classes/migrate.php
+++ b/classes/migrate.php
@@ -496,7 +496,7 @@ class Migrate
 			// find a module
 			foreach (\Config::get('module_paths') as $m)
 			{
-				$files = glob($m .$name.'/'.\Config::get('migrations.folder').'*_*.php');
+				$files = glob($m.$name.DS.\Config::get('migrations.folder').'*_*.php');
 				if (count($files))
 				{
 					break;
@@ -508,7 +508,7 @@ class Migrate
 			// find all modules
 			foreach (\Config::get('module_paths') as $m)
 			{
-				$files = array_merge($files, glob($m.'*/'.\Config::get('migrations.folder').'*_*.php'));
+				$files = array_merge($files, glob($m.'*'.DS.\Config::get('migrations.folder').'*_*.php'));
 			}
 		}
 
@@ -531,7 +531,7 @@ class Migrate
 			// find a package
 			foreach (\Config::get('package_paths', array(PKGPATH)) as $p)
 			{
-				$files = glob($p .$name.'/'.\Config::get('migrations.folder').'*_*.php');
+				$files = glob($p.$name.DS.\Config::get('migrations.folder').'*_*.php');
 				if (count($files))
 				{
 					break;
@@ -543,7 +543,7 @@ class Migrate
 			// find all packages
 			foreach (\Config::get('package_paths', array(PKGPATH)) as $p)
 			{
-				$files = array_merge($files, glob($p.'*/'.\Config::get('migrations.folder').'*_*.php'));
+				$files = array_merge($files, glob($p.'*'.DS.\Config::get('migrations.folder').'*_*.php'));
 			}
 		}
 

--- a/tasks/migrate.php
+++ b/tasks/migrate.php
@@ -75,9 +75,9 @@ class Migrate
 				foreach (\Config::get('module_paths') as $path)
 				{
 					// get all modules that have files in the migration folder
-					foreach (glob($path . '*/') as $m)
+					foreach (glob($path.'*'.DS) as $m)
 					{
-						if (count(glob($m.\Config::get('migrations.folder').'/*.php')))
+						if (count(glob($m.\Config::get('migrations.folder').DS.'*.php')))
 						{
 							static::$modules[] = basename($m);
 						}
@@ -100,9 +100,9 @@ class Migrate
 				// get all packages that have files in the migration folder
 				foreach (\Config::get('package_paths', array(PKGPATH)) as $p)
 				{
-					foreach (glob($p . '*/') as $pp)
+					foreach (glob($p.'*'.DS) as $pp)
 					{
-						if (count(glob($pp.\Config::get('migrations.folder').'/*.php')))
+						if (count(glob($pp.\Config::get('migrations.folder').DS.'*.php')))
 						{
 							static::$packages[] = basename($pp);
 						}


### PR DESCRIPTION
Fixed a few hardcoded *nix directory separators that would stop `oil` from finding any migrations with glob patterns in Windows.
