### PR TITLE
Fixed 'Undefined index: session_id' on line 132 or session redis class

### DIFF
--- a/classes/session/redis.php
+++ b/classes/session/redis.php
@@ -3,7 +3,7 @@
  * Part of the Fuel framework.
  *
  * @package    Fuel
- * @version    1.7
+ * @version    1.6
  * @author     Fuel Development Team
  * @license    MIT License
  * @copyright  2010 - 2013 Fuel Development Team
@@ -116,7 +116,7 @@ class Session_Redis extends \Session_Driver
 
 			// unpack the payload
 			$payload = $this->_unserialize($payload);
-
+			
 			// session referral?
 			if (isset($payload['rotated_session_id']))
 			{
@@ -128,10 +128,6 @@ class Session_Redis extends \Session_Driver
 				}
 				else
 				{
-					// update the session
-					$this->keys['previous_id'] = $this->keys['session_id'];
-					$this->keys['session_id']  = $payload['rotated_session_id'];
-
 					// unpack the payload
 					$payload = $this->_unserialize($payload);
 				}


### PR DESCRIPTION
So this is my first ever pull request with github (slash git) and I have no idea what I'm doing, so here goes:

I was receiving an 'undefined index session_id on line 132 of session/redis.php class' error. Traced to to the fact that we can see on line 99:

$this->keys = array();

and then on line 132:

$this->keys['previous_id'] = $this->keys['session_id'];

So therefore we try and access the 'session_id' key of the keys array, despite not setting anything in the keys at all.

Compare this to the session/memcached.php class, where these two lines of code at 132 and 133 aren't there.

I suggest removing them, making the method definition very similar to the memcahced equivalent.
