### PR TITLE
Bugfix Format::forge()->to_(json|serialized|php)

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -252,7 +252,7 @@ class Format
 	 */
 	public function to_json($data = null, $pretty = false)
 	{
-		if ($data == null)
+		if ($data === null)
 		{
 			$data = $this->_data;
 		}
@@ -287,7 +287,7 @@ class Format
 	 */
 	public function to_serialized($data = null)
 	{
-		if ($data == null)
+		if ($data === null)
 		{
 			$data = $this->_data;
 		}
@@ -303,7 +303,7 @@ class Format
 	 */
 	public function to_php($data = null)
 	{
-		if ($data == null)
+		if ($data === null)
 		{
 			$data = $this->_data;
 		}


### PR DESCRIPTION
Loose typing provokes nullish values to be converted to null. Hence encoding empty array() doesn't work.

Strangely enough to_yaml() behaviour doesn't seem to be affected. But both `Format::forge(array())->to_json()` and `Format::forge()->to_yaml(array())` returns `---\n` (triple dash followed by a line break)

Before the patch :

```
Format::forge(array())->to_json() === '[]';
Format::forge()->to_json(array()) === 'null';

Format::forge(array())->to_serialized() === 'a:0:{}';
Format::forge()->to_serialized(array()) === 'N;';*

Format::forge(array())->to_php() === "array (\n)";
Format::forge()->to_serialized(array()) === 'NULL';
```

After the patch `Format::forge()->to_anything(array())` returns the same as `Format::forge(array())->to_anything()`
