### PR TITLE
Fixed copy/paste error on comment s/Memcached/redis/

### DIFF
--- a/classes/session/redis.php
+++ b/classes/session/redis.php
@@ -244,7 +244,7 @@ class Session_Redis extends \Session_Driver
 	 */
 	protected function _read_redis($session_id)
 	{
-		// fetch the session data from the Memcached server
+		// fetch the session data from the redis server
 		return $this->redis->get($session_id);
 	}
 


### PR DESCRIPTION
It seemed like a copy/paste error on a comment, talking about Memcached server on the redis session class
