### PR TITLE
replace non-alphanum characters before checking for numeric keys

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -145,15 +145,15 @@ class Format
 
 		foreach ($data as $key => $value)
 		{
+			// replace anything not alpha numeric
+			$key = preg_replace('/[^a-z_\-0-9]/i', '', $key);
+
 			// no numeric keys in our xml please!
 			if (is_numeric($key))
 			{
 				// make string key...
 				$key = (\Inflector::singularize($basenode) != $basenode) ? \Inflector::singularize($basenode) : 'item';
 			}
-
-			// replace anything not alpha numeric
-			$key = preg_replace('/[^a-z_\-0-9]/i', '', $key);
 
 			// if there is another array found recrusively call this function
 			if (is_array($value) or is_object($value))


### PR DESCRIPTION
As discussed in a previous pull request: https://github.com/fuel/core/pull/1405 as well as forum post: http://fuelphp.com/forums/discussion/12119/best-way-to-avoid-invalid-xml-formatting-in-api-output
