### PR TITLE
Add more ways of getting the CSRF token depending on the Request Method

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -265,17 +265,7 @@ class Security
 	 */
 	public static function check_token($value = null)
 	{
-		$value = $value ?: \Input::post(static::$csrf_token_key, \Input::json(static::$csrf_token_key, 'fail'));
-		
-		// If the request method is PUT or DELETE we should try and get data from those...
-		if(\Input::method() === 'PUT' && $value == 'fail')
-		{
-			$value = \Input::put(static::$csrf_token_key, 'fail');
-		} 
-		if(\Input::method() === 'DELETE' && $value == 'fail')
-		{
-			$value = \Input::delete(static::$csrf_token_key, 'fail');
-		}
+		$value = $value ?: \Input::param(static::$csrf_token_key, \Input::json(static::$csrf_token_key, 'fail'));
 		
 		// always reset token once it's been checked and still the same
 		if (static::fetch_token() == static::$csrf_old_token and ! empty($value))

--- a/classes/security.php
+++ b/classes/security.php
@@ -266,7 +266,17 @@ class Security
 	public static function check_token($value = null)
 	{
 		$value = $value ?: \Input::post(static::$csrf_token_key, \Input::json(static::$csrf_token_key, 'fail'));
-
+		
+		// If the request method is PUT or DELETE we should try and get data from those...
+		if(\Input::method() === 'PUT' && $value == 'fail')
+		{
+			$value = \Input::put(static::$csrf_token_key, 'fail');
+		} 
+		if(\Input::method() === 'DELETE' && $value == 'fail')
+		{
+			$value = \Input::delete(static::$csrf_token_key, 'fail');
+		}
+		
 		// always reset token once it's been checked and still the same
 		if (static::fetch_token() == static::$csrf_old_token and ! empty($value))
 		{


### PR DESCRIPTION
I'm developing a RESTful API and to use the methods PUT and DELETE with CSRF Autoload feature I needed this little "hack".
If Security::check_token() fails to get a token from Input::post(), Input::json() and the optional parameter it will try again with Input::put() if "PUT" is the request method, it will try again with Input::delete() if the request method is "DELETE" as well.

Just sharing this to stop others from over thinking the "CSRF verification failed" error when they just need something like this.
