### PR TITLE
Fixed Controller_Hybrid runtime notice

### DIFF
--- a/classes/controller/hybrid.php
+++ b/classes/controller/hybrid.php
@@ -56,7 +56,7 @@ abstract class Controller_Hybrid extends \Controller_Rest
 	 * @param  string
 	 * @param  array
 	 */
-	public function router($resource, array $arguments)
+	public function router($resource, $arguments)
 	{
 		// if this is an ajax call
 		if ($this->is_restful())


### PR DESCRIPTION
``` php
Runtime Notice!
Fuel\Core\PhpErrorException [ Runtime Notice ]: Declaration of Fuel\Core\Controller_Hybrid::router() should be compatible with Fuel\Core\Controller::router($resource, $arguments)

COREPATH/classes/controller/hybrid.php @ line 25
```
