### PR TITLE
Use of realpath to make VENDORPATH absolute like other constants.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -27,7 +27,7 @@ define('MBSTRING', function_exists('mb_get_info'));
 /**
  * Load the Composer autoloader if present
  */
-defined('VENDORPATH') or define('VENDORPATH', COREPATH.'..'.DS.'vendor'.DS);
+defined('VENDORPATH') or define('VENDORPATH', realpath(COREPATH.'..'.DS.'vendor').DS);
 if ( ! file_exists(VENDORPATH.'autoload.php'))
 {
 	die('Composer is not installed. Please run "php composer.phar update" in the root to install Composer');


### PR DESCRIPTION
Now VENDORPATH is an absolute path, but it is always relative to the core directory.
