### PR TITLE
Correct assignment of $valid_login from auth response

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -125,7 +125,7 @@ abstract class Controller_Rest extends \Controller
 		}
 		elseif (method_exists($this, $this->auth))
 		{
-			if ($valid_login = $this->{$this->auth}() instanceOf \Response)
+			if ( ($valid_login = $this->{$this->auth}()) instanceOf \Response)
 			{
 				return $valid_login;
 			}


### PR DESCRIPTION
Corrects the 'if' condition that was improperly assigning the result of the instanceof check to the $valid_login variable when a boolean was returned from the auth function and not the return boolean itself.
