### PR TITLE
Changed default image alt attribute to be empty instead of filename

### DIFF
--- a/classes/html.php
+++ b/classes/html.php
@@ -78,7 +78,7 @@ class Html
 			$src = \Uri::base(false).$src;
 		}
 		$attr['src'] = $src;
-		$attr['alt'] = (isset($attr['alt'])) ? $attr['alt'] : pathinfo($src, PATHINFO_FILENAME);
+		$attr['alt'] = (isset($attr['alt'])) ? $attr['alt'] : '';
 		return html_tag('img', $attr);
 	}
 

--- a/tests/html.php
+++ b/tests/html.php
@@ -135,7 +135,8 @@ class Test_Html extends TestCase
 
 		// External uri
 		$output = Html::img('http://google.com/image.png');
-		$expected = '<img src="http://google.com/image.png" />';
+		$expected = '<img src="http://google.com/image.png" alt="" />';
+		$this->assertEquals($expected, $output);
 	}
 
 	/**

--- a/tests/html.php
+++ b/tests/html.php
@@ -126,7 +126,7 @@ class Test_Html extends TestCase
 
 		// Internal uri
 		$output = Html::img('image.png');
-		$expected = '<img src="'. $image_path . '" alt="image" />';
+		$expected = '<img src="'. $image_path . '" alt="" />';
 		$this->assertEquals($expected, $output);
 
 		$output = Html::img('image.png', array('alt' => 'Image'));


### PR DESCRIPTION
What do you guys think of this? I can't really see the benefit of setting the alt to the filename.

Here's an example that was bugging me in my app when the image didn't exist.

![screen shot 2013-07-11 at 6 59 25 pm](https://f.cloud.github.com/assets/207171/785633/67723206-ea88-11e2-806c-66fa2a30b284.png)
