### PR TITLE
Change method visibility from private to public on useful methods

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -433,7 +433,7 @@ class Image_Gd extends \Image_Driver
 	 * @param  resource  $resource  Optionally add an image to the new transparent image.
 	 * @return resource  Returns the image in resource form.
 	 */
-	private function create_transparent_image($width, $height, $resource = null)
+	protected function create_transparent_image($width, $height, $resource = null)
 	{
 		$image = imagecreatetruecolor($width, $height);
 		$color = $this->create_color($image, null, 0);
@@ -469,7 +469,7 @@ class Image_Gd extends \Image_Driver
 	 * @param  boolean   $top
 	 * @param  boolean   $left
 	 */
-	private function round_corner(&$image, $radius, $antialias, $top, $left)
+	protected function round_corner(&$image, $radius, $antialias, $top, $left)
 	{
 		$this->debug("Rounding ".($top ? 'top' : 'bottom')." ".($left ? 'left' : 'right')." corner with a radius of ".$radius."px.");
 		$sX = $left ? -$radius : 0;
@@ -538,7 +538,7 @@ class Image_Gd extends \Image_Driver
 	 * @param  integer   $y          The position of the watermark on the Y-axis
 	 * @param  integer   $alpha      The transparency of the watermark, 0 (trans) to 100 (opaque)
 	 */
-	private function image_merge(&$image, $watermark, $x, $y, $alpha)
+	protected function image_merge(&$image, $watermark, $x, $y, $alpha)
 	{
 		$wsizes = $this->sizes($watermark);
 		$tmpimage = $this->create_transparent_image($wsizes->width, $wsizes->height);


### PR DESCRIPTION
Having attempted to extend this class to add some bespoke functionality, not having access to these methods has proven unhelpful. Is there a reason they're private?

None of the other drivers contain private methods.
