### PR TITLE
Fix \File::close_file() -> "flock(): <ID> is not a valid stream resource"

### DIFF
--- a/classes/file.php
+++ b/classes/file.php
@@ -713,15 +713,13 @@ class File
 	 */
 	public static function close_file($resource, $area = null)
 	{
-		fclose($resource);
-
 		// If locks aren't used, don't unlock
-		if ( ! static::instance($area)->use_locks())
+		if ( static::instance($area)->use_locks())
 		{
-			return;
+			flock($resource, LOCK_UN);
 		}
 
-		flock($resource, LOCK_UN);
+		fclose($resource);
 	}
 
 	/**


### PR DESCRIPTION
Update \File::close_file() and fixing an error thrown coming from unlocking a file-resource after closing the resource-handler.
