### PR TITLE
Added the reverse routing with regex's named groups to Router::get()

### DIFF
--- a/classes/router.php
+++ b/classes/router.php
@@ -109,28 +109,27 @@ class Router
 				}
 			}
 
-			// deal with the remaining regex's
-			if (preg_match_all('#\(.*?\)#', $url, $matches) !== false)
+			// deal with regex's groups
+			if (preg_match_all('#\((?:\?P<(\w+?)>)?.*?\)#', $url, $matches) !== false)
 			{
-				if (count($matches) == 1)
+				if (count($matches) == 2)
 				{
-					$search = array();
-					foreach($matches[0] as $match)
+					$indexed_group_count = 0;
+					foreach($matches[0] as $index => $target)
 					{
-						$search[] = $match;
-					}
-
-					$replace = array();
-					foreach($search as $key => $regex)
-					{
-						$replace = array_key_exists($key, $named_params) ? $named_params[$key] : '';
-
-						if (($pos = strpos($url,$regex)) !== false)
+						$replace = '';
+						if (array_key_exists($key = $matches[1][$index], $named_params) ||
+						    array_key_exists($key = '$'.($index + 1), $named_params) ||
+						    array_key_exists($key = $indexed_group_count++, $named_params))
 						{
-							$url = substr_replace($url,$replace,$pos,strlen($regex));
+							$replace = $named_params[$key];
+						}
+						
+						if (($pos = strpos($url, $target)) !== false)
+						{
+							$url = substr_replace($url, $replace, $pos, strlen($target));
 						}
 					}
-
 				}
 			}
 


### PR DESCRIPTION
Now routes.php can deal with the regex's named group, but Router::get() can not.

For example,

``` php:routes.php
<?php
return array(
    'thread/(?P<thread_id>\d+?)/post' => array('post', 'name' => 'post'),
    'country/(?P<country>\d+?)/state/(?P<state>\d+?)/location' => array('location', 'name' => 'location'),
);
```

``` php
Router::get('post', array('thread_id' => 1));
// => thread//post
```

This doesn't work.

This commit makes Router::get() to refer keys of $named_params to groups' names(thread_id, post_id) and the groups' indexes($1, $2...)

``` php
Router::get('post', array('thread_id' => 1));
Router::get('post', array('$1' => 1));
Router::get('post', array(1));
// => thread/1/post

Router::get('location', array('country' => 'japan', 'state' => 'tokyo'));
Router::get('location', array('$1' => 'japan', '$2' => 'tokyo'));
Router::get('location', array('japan', 'tokyo'));
Router::get('location', array('country' => 'japan', 'tokyo'));
Router::get('location', array('$1' => 'japan', 'tokyo'));
// => country/japan/state/tokyo/location
```
