### PR TITLE
[Cache] Redis class is in Fuel\Core, not \

### DIFF
--- a/classes/cache/storage/redis.php
+++ b/classes/cache/storage/redis.php
@@ -57,7 +57,7 @@ class Cache_Storage_Redis extends \Cache_Storage_Driver
 			// get the redis database instance
 			try
 			{
-				static::$redis = \Redis::instance($this->config['database']);
+				static::$redis = Redis::instance($this->config['database']);
 			}
 			catch (\Exception $e)
 			{


### PR DESCRIPTION
this makes Redis backend for Cache work on php54 (also tested on php53)

I don't really know why it even worked on php53
