### PR TITLE
Backup date default timezone before using date_default_timezone_set in Date unit test.

### DIFF
--- a/tests/date.php
+++ b/tests/date.php
@@ -76,10 +76,13 @@ class Test_Date extends TestCase
 	 */
 	public function test_format()
 	{
+		$default_timezone = date_default_timezone_get();
 		date_default_timezone_set('UTC');
 
 		$output = Date::forge( 1294176140 )->format("%m/%d/%Y");
 		$expected = "01/04/2011";
+
+		date_default_timezone_set($default_timezone);
 
 		$this->assertEquals($expected, $output);
 	}


### PR DESCRIPTION
Forcing date default timezone in unit test is not a good idea because it is breaking environment configuration in other unit tests.
This commit reverts original date default timezone before exiting the function test_format in Fuel\Core\Test_Date. 
