### PR TITLE
Add method to interrogate image driver about image type (extension)

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -876,6 +876,16 @@ abstract class Image_Driver
 	}
 
 	/**
+	 * Get the file extension (type) worked out on construct
+	 *
+	 * @return  string  File extension
+	 */
+	public function extension()
+	{
+		return $this->image_extension;
+	}
+
+	/**
 	 * Used for debugging image output.
 	 *
 	 * @param  string  $message


### PR DESCRIPTION
I wanted to convert an image to the file type of another image, so I felt it best to ask the other image what its type was.
