### PR TITLE
Update record on DB Session write

### DIFF
--- a/classes/session/db.php
+++ b/classes/session/db.php
@@ -185,6 +185,9 @@ class Session_Db extends \Session_Driver
 			{
 				// then update the cookie
 				$this->_set_cookie(array($this->keys['session_id']));
+
+				// and update the record
+				$this->record = \DB::select()->where('session_id', '=', $session['session_id'])->from($this->config['table'])->execute($this->config['database']);
 			}
 			else
 			{


### PR DESCRIPTION
If you have a shutdown handler which wants to write to the session then you get problems with duplicate `session_id`s when using the DB session driver because the record was not being set and it was trying to create a duplicate session record in the DB
