### PR TITLE
Fixed arb char property access error for whitelisted classes

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -226,7 +226,7 @@ class Security
 
 			foreach ($value as $k => $v)
 			{
-				$value->{$k} = static::htmlentities($v, $flags, $encoding, $double_encode);
+				$value->{trim($k)} = static::htmlentities($v, $flags, $encoding, $double_encode);
 			}
 		}
 		elseif (is_object($value))


### PR DESCRIPTION
I seemed to be receiving an arb exception which raised an error when adding various classes to the security.whitelisted_classes directive. Not entirely sure of the cause, or that it may be related to my file encoding; however adding a trim() to the $k variable on line 229 seems to have resolved it by stripping arbitrary characters.

ErrorException [ Error ]: Cannot access property started with '\0' in COREPATH/classes/security.php @ line 230

![fuel-property-access](https://f.cloud.github.com/assets/1147889/1101232/33054b2e-17b6-11e3-83c4-d8d3598c5ada.png)
