### PR TITLE
Fix default charset error for migrations in MySQL 5.5

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -400,7 +400,7 @@ class DBUtil
 
 		if ($is_default)
 		{
-			$charset = ' DEFAULT '.$charset;
+			$charset = ' DEFAULT CHARACTER SET '.$charset;
 		}
 		else
 		{


### PR DESCRIPTION
Fix for issue https://github.com/fuel/core/issues/1514
