### PR TITLE
Changed to allow replication connection

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -18,14 +18,9 @@ namespace Fuel\Core;
 abstract class Database_Connection
 {
 	/**
-	 * @var string Cache of the name of the master connection
+	 * @var string Cache of the name of the readonly connection
 	 */
-	protected static $_replication_master;
-
-	/**
-	 * @var string Cache of the name of the slave connection
-	 */
-	protected static $_replication_slave;
+	protected static $_readonly;
 
 	/**
 	 * @var  array  Database instances
@@ -56,23 +51,13 @@ abstract class Database_Connection
 		\Config::load('db', true);
 		if ($name === null)
 		{
-			if (\Config::get('db.replication.enable') and ($master = \Config::get('db.replication.master', array())) and ($slave = \Config::get('db.replication.slave', array())))
+			// Use the default instance name
+			$name = \Config::get('db.active');
+
+			if ( ! $writable and ($readonly = \Config::get("db.{$name}.readonly")))
 			{
-				if ($writable)
-				{
-					is_null(static::$_replication_master) and static::$_replication_master = \Arr::get($master, array_rand($master));
-					$name = static::$_replication_master;
-				}
-				else
-				{
-					is_null(static::$_replication_slave) and static::$_replication_slave = \Arr::get($slave, array_rand($slave));
-					$name = static::$_replication_slave;
-				}
-			}
-			else
-			{
-				// Use the default instance name
-				$name = \Config::get('db.active');
+				is_null(static::$_readonly) and static::$_readonly = \Arr::get($readonly, array_rand($readonly));
+				$name = static::$_readonly;
 			}
 		}
 

--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -227,7 +227,8 @@ class Database_Query
 		if ( ! is_object($db))
 		{
 			// Get the database instance
-			$db = \Database_Connection::instance($db);
+			// (If this query is a instance of Database_Query_Builder_Select then use the slave connection)
+			$db = \Database_Connection::instance($db, null, ! $this instanceof \Database_Query_Builder_Select);
 		}
 
 		// Compile the SQL query


### PR DESCRIPTION
This change allows replication connection.

When you want to use replication feature, you can set the flag in db.php.

``` php
<?php
return array(
    'default' => array(
        'connection'  => array(
            'dsn'        => 'mysql:host=localhost;dbname=default',
            'username'   => 'dbuser',
            'password'   => 'dbpass',
        ),
    ),
    'db1' => array(
        'type'        => 'pdo',
        'connection'  => array(
            'dsn'        => 'mysql:host=localhost;dbname=db1',
            'username'   => 'dbuser',
            'password'   => 'dbpass',
        ),
        'identifier'   => '`',
        'table_prefix' => '',
        'charset'      => 'utf8',
        'enable_cache' => true,
        'profiling'    => false,
    ),
    'db2' => array(
        'type'        => 'pdo',
        'connection'  => array(
            'dsn'        => 'mysql:host=localhost;dbname=db2',
            'username'   => 'dbuser',
            'password'   => 'dbpass',
        ),
        'identifier'   => '`',
        'table_prefix' => '',
        'charset'      => 'utf8',
        'enable_cache' => true,
        'profiling'    => false,
    ),
    'replication' => array(
        'enable' => true,
        'master' => array('db1'),
        'slave' => array('db1', 'db2'),
    )
);
```

Only Database_Query_Builder_Select uses the slave connection.
And other queries use the master connection.

Respectively, specify the multiple connection name, the destination is a random lottery.

I want your opinion.
