### PR TITLE
Add subset() method to Arr

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1209,7 +1209,7 @@ class Arr
 	}
 
 	/**
-	 * Return the subset of the array by the supplied keys.
+	 * Return the subset of the array defined by the supplied keys.
 	 *
 	 * Returns $default for missing keys, as with Arr::get()
 	 *

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1219,12 +1219,15 @@ class Arr
 	 *
 	 * @return  array  An array containing the same set of keys provided.
 	 */
-	public function subset($array, $keys, $default=null)
+	public function subset($array, $keys, $default = null)
 	{
 		$ret = [];
-		foreach ($keys as $key) {
+
+		foreach ($keys as $key)
+		{
 			$ret[$key] = \Arr::get($array, $key, $default);
 		}
+
 		return $ret;
 	}
 }

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1207,4 +1207,24 @@ class Arr
 		// return the value or the key of the array entry the next key points to
 		return $get_value ? $array[$keys[$index+1]] : $keys[$index+1];
 	}
+
+	/**
+	 * Return the subset of the array by the supplied keys.
+	 *
+	 * Returns $default for missing keys, as with Arr::get()
+	 *
+	 * @param   array    $array    the array containing the values
+	 * @param   array    $keys     list of keys (or indices) to return
+	 * @param   mixed    $default  value of missing keys; default null
+	 *
+	 * @return  array  An array containing the same set of keys provided.
+	 */
+	public function subset($array, $keys, $default=null)
+	{
+		$ret = [];
+		foreach ($keys as $key) {
+			$ret[$key] = \Arr::get($array, $key, $default);
+		}
+		return $ret;
+	}
 }

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1225,7 +1225,7 @@ class Arr
 
 		foreach ($keys as $key)
 		{
-			$ret[$key] = static::get($array, $key, $default);
+			static::set($ret, $key, static::get($array, $key, $default));
 		}
 
 		return $ret;

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1225,7 +1225,7 @@ class Arr
 
 		foreach ($keys as $key)
 		{
-			$ret[$key] = \Arr::get($array, $key, $default);
+			$ret[$key] = static::get($array, $key, $default);
 		}
 
 		return $ret;

--- a/classes/arr.php
+++ b/classes/arr.php
@@ -1219,7 +1219,7 @@ class Arr
 	 *
 	 * @return  array  An array containing the same set of keys provided.
 	 */
-	public function subset($array, $keys, $default = null)
+	public function subset(array $array, array $keys, $default = null)
 	{
 		$ret = [];
 


### PR DESCRIPTION
We found ourselves needing a version of filter_keys that created them - useful for forms.

Will create docs if there are no objections to the method.

We considered writing it in terms of Arr::merge but we decided to keep it simple for the 90% case of handling input data.
