### PR TITLE
In Format::forge()->to_csv(), escape enclosure by a double enclosure

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -193,12 +193,11 @@ class Format
 		$newline = \Config::get('format.csv.newline', "\n");
 		$delimiter or $delimiter = \Config::get('format.csv.delimiter', ',');
 		$enclosure = \Config::get('format.csv.enclosure', '"');
-		$escape = \Config::get('format.csv.escape', '\\');
 
 		// escape function
-		$escaper = function($items) use($enclosure, $escape) {
-			return array_map(function($item) use($enclosure, $escape){
-				return str_replace($enclosure, $escape.$enclosure, $item);
+		$escaper = function($items) use($enclosure) {
+			return array_map(function($item) use($enclosure){
+				return str_replace($enclosure, $enclosure.$enclosure, $item);
 			}, $items);
 		};
 


### PR DESCRIPTION
... not a backslash

First, in the [CSV RFC, section 2.7](http://tools.ietf.org/html/rfc4180#section-2) (it's not a specification of an Internet standard but it documents the format used for Comma-Separated Values)

_If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote.  For example:_

```
 "aaa","b""bb","ccc"
```

I've tested opening a file generating by Format->to_csv() in Excel 2000 on Windows and Open-office on Ubuntu, in the two cases, columns containing double-quote escaped by a backslash are not well parsed.

Sample:

```
"aaa","b""bb","ccc"
"aaa","b\"bb","ccc"
"ddd","eee","fff"
"ggg","h\"hh","iii"
```

Result in Open-office:

```
aaa    b"bb    ccc             
aaa    b\bb"   ccc"ddd"    eee fff"ggg"    h\hh"   iii
```

First line is OK. Lines 2, 3, 4 are merged.

Result in Excel 2000:

```
aaa    b"bb    ccc
aaa    b\bb"   ccc
ddd    eee     fff
ggg    h\hh"   iii
```

First line is OK. The result is better for lines 2 and 4, but their second column are not well parsed.
