### PR TITLE
Add a shortcut for getting error message of validation

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -570,6 +570,30 @@ class Validation
 	}
 
 	/**
+	 * Return error message
+	 *
+	 * Return specific error message or all error messages thrown during validation
+	 *
+	 * @param   string  fieldname
+	 * @param   mixed   value to return when not validated
+	 * @return  string|array  the error message or full array of error messages
+	 */
+	public function error_message($field = null, $default = false)
+	{
+		if ($field === null)
+		{
+			$messages = array();
+			foreach ($this->error() as $field => $e)
+			{
+				$messages[$field] = $e->get_message();
+			}
+			return $messages;
+		}
+
+		return array_key_exists($field, $this->errors) ? $this->errors[$field]->get_message() : $default;
+	}
+
+	/**
 	 * Show errors
 	 *
 	 * Returns all errors in a list or with set markup from $options param

--- a/tests/validation.php
+++ b/tests/validation.php
@@ -807,4 +807,34 @@ class Test_Validation extends TestCase
 
 		$this->assertEquals($expected, $test);
 	}
+
+	/**
+	 * Test for $validation->error_message()
+	 *
+	 * @test
+	 */
+	public function test_error_message() {
+		$post = array(
+			'title' => '',
+			'number' => 'ABC',
+		);
+
+		$val = Validation::forge(__FUNCTION__);
+		$val->add_field('title', 'Title', 'required');
+		$val->add_field('number', 'Number', 'required|valid_string[numeric]');
+
+		$val->run($post);
+
+		$expected = 'The field Title is required and must contain a value.';
+		$this->assertEquals($expected, $val->error_message('title'));
+
+		$expected = 'The valid string rule valid_string(numeric) failed for field Number';
+		$this->assertEquals($expected, $val->error_message('number'));
+
+		$expected = 'The field Title is required and must contain a value.';
+		$this->assertEquals($expected, current($val->error_message()));
+
+		$expected = 'No error';
+		$this->assertEquals($expected, $val->error_message('content', 'No error'));
+	}
 }


### PR DESCRIPTION
This function is a shortcut to getting the error message.
This is used in the following cases.

``` php
<?php

class Controller_Test extends Controller_Rest
{

    public function get_list()
    {
        $val = Validation::forge('test');
        $val->add_field('from', 'from', 'required|valid_date');
        $val->add_field('to', 'to', 'required|valid_date');

        if ( ! $val->run())
        {
            $this->response(array(
                'result' => 400,
                'error_messages' => $val->error_message()
            ));
        }
        else
        {
            // validated..
        }
    }
}
```
