### PR TITLE
Add escape tags flag to config of format

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -117,9 +117,10 @@ class Format
 	 * @param   mixed        $data
 	 * @param   null         $structure
 	 * @param   null|string  $basenode
+	 * @param   null|bool    whether to escape tags in node
 	 * @return  string
 	 */
-	public function to_xml($data = null, $structure = null, $basenode = null)
+	public function to_xml($data = null, $structure = null, $basenode = null, $escape_tags = null)
 	{
 		if ($data == null)
 		{
@@ -127,6 +128,7 @@ class Format
 		}
 
 		is_null($basenode) and $basenode = \Config::get('format.xml.basenode', 'xml');
+		is_null($escape_tags) and $escape_tags = \Config::get('format.xml.escape_tags', true);
 
 		// turn off compatibility mode as simple xml throws a wobbly if you don't.
 		if (ini_get('zend.ze1_compatibility_mode') == 1)
@@ -165,16 +167,25 @@ class Format
 				// recursive call if value is not empty
 				if( ! empty($value))
 				{
-					$this->to_xml($value, $node, $key);
+					$this->to_xml($value, $node, $key, $escape_tags);
 				}
 			}
 
 			else
 			{
 				// add single node.
-				$value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
+				$escaped = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
 
-				$structure->addChild($key, $value);
+				if ( ! $escape_tags and ($escaped !== (string) $value))
+				{
+					$dom = dom_import_simplexml($structure->addChild($key));
+					$owner = $dom->ownerDocument;
+					$dom->appendChild($owner->createCDATASection($value));
+				}
+				else
+				{
+					$structure->addChild($key, $escaped);
+				}
 			}
 		}
 

--- a/classes/format.php
+++ b/classes/format.php
@@ -120,7 +120,7 @@ class Format
 	 * @param   null|bool    whether to escape tags in node
 	 * @return  string
 	 */
-	public function to_xml($data = null, $structure = null, $basenode = null, $escape_tags = null)
+	public function to_xml($data = null, $structure = null, $basenode = null, $use_cdata = null)
 	{
 		if ($data == null)
 		{
@@ -128,7 +128,7 @@ class Format
 		}
 
 		is_null($basenode) and $basenode = \Config::get('format.xml.basenode', 'xml');
-		is_null($escape_tags) and $escape_tags = \Config::get('format.xml.escape_tags', true);
+		is_null($use_cdata) and $use_cdata = \Config::get('format.xml.use_cdata', false);
 
 		// turn off compatibility mode as simple xml throws a wobbly if you don't.
 		if (ini_get('zend.ze1_compatibility_mode') == 1)
@@ -167,16 +167,16 @@ class Format
 				// recursive call if value is not empty
 				if( ! empty($value))
 				{
-					$this->to_xml($value, $node, $key, $escape_tags);
+					$this->to_xml($value, $node, $key, $use_cdata);
 				}
 			}
 
 			else
 			{
 				// add single node.
-				$escaped = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
+				$encoded = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
 
-				if ( ! $escape_tags and ($escaped !== (string) $value))
+				if ($use_cdata and ($encoded !== (string) $value))
 				{
 					$dom = dom_import_simplexml($structure->addChild($key));
 					$owner = $dom->ownerDocument;
@@ -184,7 +184,7 @@ class Format
 				}
 				else
 				{
-					$structure->addChild($key, $escaped);
+					$structure->addChild($key, $encoded);
 				}
 			}
 		}

--- a/classes/format.php
+++ b/classes/format.php
@@ -117,7 +117,7 @@ class Format
 	 * @param   mixed        $data
 	 * @param   null         $structure
 	 * @param   null|string  $basenode
-	 * @param   null|bool    whether to escape tags in node
+	 * @param   null|bool    whether to use CDATA in nodes
 	 * @return  string
 	 */
 	public function to_xml($data = null, $structure = null, $basenode = null, $use_cdata = null)

--- a/config/format.php
+++ b/config/format.php
@@ -37,5 +37,6 @@ return array(
 	),
 	'xml' => array(
 		'basenode' => 'xml',
+		'escape_tags' => true,
 	),
 );

--- a/config/format.php
+++ b/config/format.php
@@ -37,6 +37,6 @@ return array(
 	),
 	'xml' => array(
 		'basenode' => 'xml',
-		'escape_tags' => true,
+		'use_cdata' => false,
 	),
 );

--- a/tests/format.php
+++ b/tests/format.php
@@ -184,7 +184,7 @@ line 2","Value 3"',
 <xml><articles><article><title>test</title><author>foo</author></article></articles></xml>
 ';
 
-		// $this->assertEquals($expected, Format::forge($array)->to_xml());
+		$this->assertEquals($expected, Format::forge($array)->to_xml());
 	}
 
 	/**
@@ -207,7 +207,7 @@ line 2","Value 3"',
 <root><articles><article><title>test</title><author>foo</author></article></articles></root>
 ';
 
-		// $this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'root'));
+		$this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'root'));
 	}
 
 	/**
@@ -230,7 +230,7 @@ line 2","Value 3"',
 <xml><articles><article><title>test</title><author>&lt;h1&gt;hero&lt;/h1&gt;</author></article></articles></xml>
 ';
 
-		// $this->assertEquals($expected, Format::forge($array)->to_xml());
+		$this->assertEquals($expected, Format::forge($array)->to_xml());
 	}
 
 	/**

--- a/tests/format.php
+++ b/tests/format.php
@@ -234,7 +234,7 @@ line 2","Value 3"',
 	}
 
 	/**
-	 * Test for Format::forge($foo)->to_xml(null, null, 'xml', false)
+	 * Test for Format::forge($foo)->to_xml(null, null, 'xml', true)
 	 *
 	 * @test
 	 */
@@ -253,6 +253,6 @@ line 2","Value 3"',
 <xml><articles><article><title>test</title><author><![CDATA[<h1>hero</h1>]]></author></article></articles></xml>
 ';
 
-		$this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'xml', false));
+		$this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'xml', true));
 	}
 }

--- a/tests/format.php
+++ b/tests/format.php
@@ -152,10 +152,107 @@ line 2","Value 3"',
 		$this->assertEquals(Format::forge($expected)->to_php(), Format::forge($xml, 'xml')->to_php());
 	}
 
-	function test_to_array_empty()
+	/**
+	 * Test for Format::forge(null)->to_array()
+	 *
+	 * @test
+	 */
+	public function test_to_array_empty()
 	{
 		$array = null;
 		$expected = array();
 		$this->assertEquals($expected, Format::forge($array)->to_array());
+	}
+
+	/**
+	 * Test for Format::forge($foo)->to_xml()
+	 *
+	 * @test
+	 */
+	public function test_to_xml()
+	{
+		$array = array(
+			'articles' => array(
+				array(
+					'title' => 'test',
+					'author' => 'foo',
+				)
+			)
+		);
+
+		$expected = '<?xml version="1.0" encoding="utf-8"?>
+<xml><articles><article><title>test</title><author>foo</author></article></articles></xml>
+';
+
+		// $this->assertEquals($expected, Format::forge($array)->to_xml());
+	}
+
+	/**
+	 * Test for Format::forge($foo)->to_xml(null, null, 'root')
+	 *
+	 * @test
+	 */
+	public function test_to_xml_basenode()
+	{
+		$array = array(
+			'articles' => array(
+				array(
+					'title' => 'test',
+					'author' => 'foo',
+				)
+			)
+		);
+
+		$expected = '<?xml version="1.0" encoding="utf-8"?>
+<root><articles><article><title>test</title><author>foo</author></article></articles></root>
+';
+
+		// $this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'root'));
+	}
+
+	/**
+	 * Test for Format::forge($foo)->to_xml() espace tags
+	 *
+	 * @test
+	 */
+	public function test_to_xml_escape_tags()
+	{
+		$array = array(
+			'articles' => array(
+				array(
+					'title' => 'test',
+					'author' => '<h1>hero</h1>',
+				)
+			)
+		);
+
+		$expected = '<?xml version="1.0" encoding="utf-8"?>
+<xml><articles><article><title>test</title><author>&lt;h1&gt;hero&lt;/h1&gt;</author></article></articles></xml>
+';
+
+		// $this->assertEquals($expected, Format::forge($array)->to_xml());
+	}
+
+	/**
+	 * Test for Format::forge($foo)->to_xml(null, null, 'xml', false)
+	 *
+	 * @test
+	 */
+	public function test_to_xml_cdata()
+	{
+		$array = array(
+			'articles' => array(
+				array(
+					'title' => 'test',
+					'author' => '<h1>hero</h1>',
+				)
+			)
+		);
+
+		$expected = '<?xml version="1.0" encoding="utf-8"?>
+<xml><articles><article><title>test</title><author><![CDATA[<h1>hero</h1>]]></author></article></articles></xml>
+';
+
+		$this->assertEquals($expected, Format::forge($array)->to_xml(null, null, 'xml', false));
 	}
 }


### PR DESCRIPTION
Current to_xml() cannot output the node containing tags. 
It is because all nodes are escaped compulsorily. 

This feature allows a user to decide whether to escape tags or not.

If $escape_tags is specified false, nodes containing tags will be outputted with CDATA. 
