### PR TITLE
Add $format option to \Cli::color for underline

### DIFF
--- a/classes/cli.php
+++ b/classes/cli.php
@@ -401,9 +401,10 @@ class Cli
 	 * @param	string	$text		the text to color
 	 * @param	string	$foreground the foreground color
 	 * @param	string	$background the background color
+	 * @param	string	$format		other formatting to apply. Currently only 'underline' is understood
 	 * @return	string	the color coded string
 	 */
-	public static function color($text, $foreground, $background = null)
+	public static function color($text, $foreground, $background = null, $format=null)
 	{
 		if (static::is_windows() and ! \Input::server('ANSICON'))
 		{
@@ -425,6 +426,11 @@ class Cli
 		if ($background !== null)
 		{
 			$string .= "\033[".static::$background_colors[$background]."m";
+		}
+
+		if ($format === 'underline')
+		{
+			$string .= "\033[4m";
 		}
 
 		$string .= $text."\033[0m";


### PR DESCRIPTION
Did it this way because other formats are available in SGR. Didn't fancy trying to merge all the various parts of the SGR escape codes, but this naive approach is heading towards bloat. I expect there's a termcap library or suchlike available for PHP that we could use in future with composer.
