### PR TITLE
overhead of calling a array_push function

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -824,7 +824,7 @@ class Arr
 				// numeric keys are appended
 				if (is_int($k))
 				{
-					array_key_exists($k, $array) ? array_push($array, $v) : $array[$k] = $v;
+					array_key_exists($k, $array) ? $array[] = $v : $array[$k] = $v;
 				}
 				elseif (is_array($v) and array_key_exists($k, $array) and is_array($array[$k]))
 				{

--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -203,7 +203,7 @@ class Autoloader
 		}
 		else
 		{
-			array_push(static::$core_namespaces, $namespace);
+			static::$core_namespaces[] = $namespace;
 		}
 	}
 

--- a/classes/finder.php
+++ b/classes/finder.php
@@ -141,7 +141,7 @@ class Finder
 		{
 			if ($pos === null)
 			{
-				array_push($this->paths, $this->prep_path($path));
+				$this->paths[] = $this->prep_path($path);
 			}
 			elseif ($pos === -1)
 			{
@@ -195,7 +195,7 @@ class Finder
 
 		foreach ($paths as $path)
 		{
-			array_push($this->flash_paths, $this->prep_path($path));
+			$this->flash_paths[] = $this->prep_path($path);
 		}
 
 		return $this;


### PR DESCRIPTION
Note: If you use array_push() to add one element to the array it's better to use $array[] = because in that way there is no overhead of calling a function.
http://www.php.net/manual/en/function.array-push.php
