### PR TITLE
fixed EXPLAIN attempts in PhpQuickProfiler

### DIFF
--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -243,7 +243,7 @@ class Database_MySQL_Connection extends \Database_Connection
 				}
 			}
 
-			$benchmark = \Profiler::start("Database ({$this->_instance})", $sql, $stacktrace);
+			$benchmark = \Profiler::start($this->_instance, $sql, $stacktrace);
 		}
 
 		if ( ! empty($this->_config['connection']['persistent'])

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -252,7 +252,7 @@ class Database_MySQLi_Connection extends \Database_Connection
 				}
 			}
 
-			$benchmark = \Profiler::start("Database ({$this->_instance})", $sql, $stacktrace);
+			$benchmark = \Profiler::start($this->_instance, $sql, $stacktrace);
 		}
 
 		if ( ! empty($this->_config['connection']['persistent']) and $this->_config['connection']['database'] !== static::$_current_databases[$this->_connection_id])

--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -202,7 +202,7 @@ class Database_PDO_Connection extends \Database_Connection
 				}
 			}
 
-			$benchmark = \Profiler::start("Database ({$this->_instance})", $sql, $stacktrace);
+			$benchmark = \Profiler::start($this->_instance, $sql, $stacktrace);
 		}
 
 		// run the query. if the connection is lost, try 3 times to reconnect

--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -631,18 +631,18 @@ class Mongo_Db
 	 *	@usage	$mongodb->get_cursor('foo', array('bar' => 'something'));
 	 */
 	public function get_cursor($collection = "")
-    {
-        if (empty($collection))
-        {
-            throw new \Mongo_DbException("In order to retrieve documents from MongoDB you must provide a collection name.");
-        }
+	{
+		if (empty($collection))
+		{
+			throw new \Mongo_DbException("In order to retrieve documents from MongoDB you must provide a collection name.");
+		}
 
-        $documents = $this->db->{$collection}->find($this->wheres, $this->selects)->limit((int) $this->limit)->skip((int) $this->offset)->sort($this->sorts);
+		$documents = $this->db->{$collection}->find($this->wheres, $this->selects)->limit((int) $this->limit)->skip((int) $this->offset)->sort($this->sorts);
 
-        $this->_clear();
+		$this->_clear();
 
-        return $documents;
-    }
+		return $documents;
+	}
 
 	/**
 	 *	Get the documents based upon the passed parameters
@@ -664,7 +664,7 @@ class Mongo_Db
 			'sort'			=> $this->sorts,
 			));
 
-			$benchmark = \Profiler::start("Database {$this->db}", $query);
+			$benchmark = \Profiler::start((string) $this->db, $query);
 		}
 
 		$documents = $this->get_cursor($collection);
@@ -693,7 +693,7 @@ class Mongo_Db
 	 *	@param	string	$collection		the collection name
 	 *	@usage	$mongodb->get_one('foo');
 	 */
-	 public function get_one($collection = "")
+	public function get_one($collection = "")
 	{
 		if (empty($collection))
 		{
@@ -709,7 +709,7 @@ class Mongo_Db
 			'where'			=> $this->wheres,
 			));
 
-			$benchmark = \Profiler::start("Database {$this->db}", $query);
+			$benchmark = \Profiler::start((string) $this->db, $query);
 		}
 
 		$returns = $this->db->{$collection}->findOne($this->wheres, $this->selects);
@@ -749,7 +749,7 @@ class Mongo_Db
 			'offset'		=> $this->offset,
 			));
 
-			$benchmark = \Profiler::start("Database {$this->db}", $query);
+			$benchmark = \Profiler::start((string) $this->db, $query);
 		}
 
 		$count = $this->db->{$collection}->find($this->wheres)->limit((int) $this->limit)->skip((int) $this->offset)->count($foundonly);
@@ -796,7 +796,7 @@ class Mongo_Db
 				'payload'		=> $insert,
 				));
 
-				$benchmark = \Profiler::start("Database {$this->db}", $query);
+				$benchmark = \Profiler::start((string) $this->db, $query);
 			}
 
 			$this->db->{$collection}->insert($insert, array('fsync' => true));
@@ -855,7 +855,7 @@ class Mongo_Db
 				'options'		=> $options,
 				));
 
-				$benchmark = \Profiler::start("Database {$this->db}", $query);
+				$benchmark = \Profiler::start((string) $this->db, $query);
 			}
 
 			$this->db->{$collection}->update($this->wheres, (($literal) ? $data : array('$set' => $data)), $options);
@@ -905,7 +905,7 @@ class Mongo_Db
 				'literal'		=> $literal,
 				));
 
-				$benchmark = \Profiler::start("Database {$this->db}", $query);
+				$benchmark = \Profiler::start((string) $this->db, $query);
 			}
 
 			$this->db->{$collection}->update($this->wheres, (($literal) ? $data : array('$set' => $data)), array('fsync' => true, 'multiple' => true));
@@ -947,7 +947,7 @@ class Mongo_Db
 				'where'			=> $this->wheres,
 				));
 
-				$benchmark = \Profiler::start("Database {$this->db}", $query);
+				$benchmark = \Profiler::start((string) $this->db, $query);
 			}
 
 			$this->db->{$collection}->remove($this->wheres, array('fsync' => true, 'justOne' => true));
@@ -989,7 +989,7 @@ class Mongo_Db
 				'where'			=> $this->wheres,
 				));
 
-				$benchmark = \Profiler::start("Database {$this->db}", $query);
+				$benchmark = \Profiler::start((string) $this->db, $query);
 			}
 
 			$this->db->{$collection}->remove($this->wheres, array('fsync' => true, 'justOne' => false));

--- a/classes/profiler.php
+++ b/classes/profiler.php
@@ -55,6 +55,7 @@ class Profiler
 				'sql' => \Security::htmlentities($sql),
 				'time' => static::$profiler->getMicroTime(),
 				'stacktrace' => $stacktrace,
+				'dbname' => $dbname,
 			);
 			return true;
 		}

--- a/vendor/phpquickprofiler/phpquickprofiler.php
+++ b/vendor/phpquickprofiler/phpquickprofiler.php
@@ -145,7 +145,7 @@ class PhpQuickProfiler {
 			$rs = false;
 			try {
 				$sql = 'EXPLAIN '.html_entity_decode($query['sql'], ENT_QUOTES);
-				$rs = \DB::query($sql, \DB::SELECT)->execute()->as_array();
+				$rs = \DB::query($sql, \DB::SELECT)->execute($query['dbname'])->as_array();
 			}
 			catch(Exception $e)
 			{}


### PR DESCRIPTION
Explain was always using default DB connection - fixed it, and also fixed indentation in get_cursor().

P.S. Already asked in twitter, will repost the question here - what happens with 1.8/develop fixes, considering that 1.7 is final? 1.7.x, or what?

upd: got it, waiting for 1.7.1 :)
