### PR TITLE
fixed $_GET not being cleaned after it is replaced in Input::uri()

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -180,6 +180,7 @@ class Input
 				{
 					$_SERVER['QUERY_STRING'] = $matches[2];
 					parse_str($matches[2], $_GET);
+					$_GET = \Security::clean($_GET);
 				}
 			}
 		}


### PR DESCRIPTION
`Input::uri()` is called after `Fuel::init()`, where all input is cleaned (via `Security::clean_input()`). Thus in several situations it can restore the original, "dirty" GET values.
