### PR TITLE
Bugfix on convert_number (impacts at least _resize and _crop_resize)

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -811,6 +811,12 @@ abstract class Image_Driver
 	{
 		// Sanitize double negatives
 		$input = str_replace('--', '', $input);
+		
+		// Depending on php configuration, float are sometimes converted to strings
+		// using commas instead of points. This notation can create issues since the
+		// conversion from string to float will return an integer.
+		// For instance: "1.2" / 10 == 0.12 but "1,2" / 10 == 0.1...
+		$input = str_replace(',', '.', $input);
 
 		$orig = $input;
 		$sizes = $this->sizes();


### PR DESCRIPTION
Depending on php configuration, float are sometimes converted to strings using commas instead of points. This notation can create issues since the conversion from string to float will return an integer.
For instance: "1.2" / 10 == 0.12 but "1,2" / 10 == 0.1...

This create issues in the _resize function for instance. Let's say we have an original image of 1000 by 800, and we call the resize method with only the width defined to 567.
Since the ratio is keep, calculated height is 453.6.
https://github.com/fuel/core/blob/1.8/develop/classes/image/driver.php#L267

On our computers (probably since we are in the french locale), such numbers will be converted in "453,6" by the convert_number function (without our fix).
https://github.com/fuel/core/blob/1.8/develop/classes/image/driver.php#L281

This will lead to rounding errors in https://github.com/fuel/core/blob/1.8/develop/classes/image/driver.php#L309 when calculating the height_ratio because "453,6" / 800 == 453 / 800 == 0.56625, where 453.6 / 800 == 0.567.

So in this case, the resized image will have a width of 1000 \* 0.56625 == 566 instead of 567.

Hope I have been clear :)
