### PR TITLE
Fix: Class variable has 2 distinct names

### DIFF
--- a/classes/image/imagemagick.php
+++ b/classes/image/imagemagick.php
@@ -17,7 +17,7 @@ class Image_Imagemagick extends \Image_Driver
 
 	protected $image_temp = null;
 	protected $accepted_extensions = array('png', 'gif', 'jpg', 'jpeg');
-	protected $size_cache = null;
+	protected $sizes_cache = null;
 	protected $im_path = null;
 
 	public function load($filename, $return_data = false, $force_extension = false)
@@ -181,7 +181,7 @@ class Image_Imagemagick extends \Image_Driver
 		$is_loaded_file = $filename == null;
 		if ( ! $is_loaded_file or $this->sizes_cache == null or !$usecache)
 		{
-			$reason = ($filename != null ? "filename" : ($this->size_cache == null ? 'cache' : 'option'));
+			$reason = ($filename != null ? "filename" : ($this->sizes_cache == null ? 'cache' : 'option'));
 			$this->debug("Generating size of image... (triggered by $reason)");
 
 			if ($is_loaded_file and ! empty($this->image_temp))


### PR DESCRIPTION
Declare with name $size_cache
Used one time with this name for debug
All others times, used with name $sizes_cache
