### PR TITLE
Bugfix on _resize when using BC Math and on some locales (as french)

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -289,8 +289,8 @@ abstract class Image_Driver
 			// See which is the biggest ratio
 			if (function_exists('bcdiv'))
 			{
-				$width_ratio  = bcdiv((float) $width, $sizes->width, 10);
-				$height_ratio = bcdiv((float) $height, $sizes->height, 10);
+				$width_ratio  = bcdiv($width, $sizes->width, 10);
+				$height_ratio = bcdiv($height, $sizes->height, 10);
 				$compare = bccomp($width_ratio, $height_ratio, 10);
 				if ($compare > -1)
 				{


### PR DESCRIPTION
Similar to #1571.

bcdiv use string parameters (http://php.net/manual/en/function.bcdiv.php), so the float conversion seems useless (since it has already been converted to a string by convert_number).

And on some locales, 2.3 will be converted to "2,3" instead of "2.3" when converting float to string, and bcdiv doesn't support that (always returning 0).

Thanks,
