### PR TITLE
Remove format 'html' in Rest controller

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -55,7 +55,6 @@ abstract class Controller_Rest extends \Controller
 		'jsonp'=> 'text/javascript',
 		'serialized' => 'application/vnd.php.serialized',
 		'php' => 'text/plain',
-		'html' => 'text/html',
 		'csv' => 'application/csv',
 	);
 


### PR DESCRIPTION
In fact, 'html' is not supported.

And Rest controller returns string 'Array' if array is passed on 1.8/develop.

On 1.7/master an error occurs:

```
Fuel\Core\PhpErrorException [ Warning ]:
strpos() expects parameter 1 to be string, array given
DOCROOT/index.php @ line 78
```
