### PR TITLE
Change default json_encode() option to be more secure

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -285,7 +285,7 @@ class Format
 		// To allow exporting ArrayAccess objects like Orm\Model instances they need to be
 		// converted to an array first
 		$data = (is_array($data) or is_object($data)) ? $this->to_array($data) : $data;
-		return $pretty ? static::pretty_json($data) : json_encode($data);
+		return $pretty ? static::pretty_json($data) : json_encode($data, \Config::get('format.json.encode.option', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
 	}
 
 	/**
@@ -488,7 +488,7 @@ class Format
 	 */
 	protected static function pretty_json($data)
 	{
-		$json = json_encode($data);
+		$json = json_encode($data, \Config::get('format.json.encode.option', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
 
 		if ( ! $json)
 		{

--- a/config/format.php
+++ b/config/format.php
@@ -39,4 +39,9 @@ return array(
 		'basenode' => 'xml',
 		'use_cdata' => false,
 	),
+	'json' => array(
+		'encode' => array(
+			'options' => JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP,
+		)
+	)
 );

--- a/tests/format.php
+++ b/tests/format.php
@@ -303,4 +303,29 @@ line 2","Value 3"',
 
 		$this->assertEquals($expected, $data);
 	}
+	/**
+	 * Test for Format::forge($foo)->to_json()
+	 *
+	 * @test
+	 */
+	public function test_to_json()
+	{
+		$array = array(
+			'articles' => array(
+				array(
+					'title' => 'test',
+					'author' => 'foo',
+					'tag' => '<tag>',
+					'apos' => 'McDonald\'s',
+					'quot' => '"test"',
+					'amp' => 'M&M',
+					
+				)
+			)
+		);
+
+		$expected = '{"articles":[{"title":"test","author":"foo","tag":"\u003Ctag\u003E","apos":"McDonald\u0027s","quot":"\u0022test\u0022","amp":"M\u0026M"}]}';
+
+		$this->assertEquals($expected, Format::forge($array)->to_json());
+	}
 }


### PR DESCRIPTION
Current implementation has no option of json_encode(). So json output might be a cause of XSS if it is interpreted in HTML contexts.

This PR changes Fuel's default option of Format class to be more secure, and make it configurable.
