### PR TITLE
Fix XSS in phpquickprofiler

### DIFF
--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -329,7 +329,7 @@ $printarray = function($items, $depth, &$class, &$count) use(&$printarray)
 		{
 			$output .= '<b>'.\Security::htmlentities($value).'</b>';
 		}
-		$output .= str_repeat('&rsaquo;&nbsp;', $depth).$item.'</td></tr>';
+		$output .= str_repeat('&rsaquo;&nbsp;', $depth).\Security::htmlentities($item).'</td></tr>';
 		if($class == '') $class = 'pqp-alt'; else $class = '';
 		is_array($value) and $output .= $printarray($value, $depth + 1, $class, $count);
 		is_object($value) and $output .= $printarray($value, $depth + 1, $class, $count);


### PR DESCRIPTION
With GET and POST, values are properly escaped, but not the keys.
