### PR TITLE
When destroying the session cookie, consider cookie domain and path.

### DIFF
--- a/classes/session/driver.php
+++ b/classes/session/driver.php
@@ -68,7 +68,7 @@ abstract class Session_Driver
 	public function destroy()
 	{
 		// delete the session cookie
-		\Cookie::delete($this->config['cookie_name']);
+ 		\Cookie::delete($this->config['cookie_name'], $this->config['cookie_path'], $this->config['cookie_domain'], null, $this->config['cookie_http_only']);
 
 		// reset the stored session data
 		$this->keys = $this->flash = $this->data = array();


### PR DESCRIPTION
This fix the problem the session cookie aren't deleted if cookie domain and path has set.
