### PR TITLE
Fix Using AFTER and COMMENT in correct order in DBUtil

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -394,6 +394,11 @@ class DBUtil
 				$sql .= ' PRIMARY KEY';
 			}
 
+			if (array_key_exists('COMMENT', $attr))
+			{
+				$sql .= ' COMMENT '.\DB::escape($attr['COMMENT'], $db ? $db : static::$connection);
+			}
+
 			if (array_key_exists('FIRST', $attr) and $attr['FIRST'] === true)
 			{
 				$sql .= ' FIRST';
@@ -401,11 +406,6 @@ class DBUtil
 			elseif (array_key_exists('AFTER', $attr) and strval($attr['AFTER']))
 			{
 				$sql .= ' AFTER '.\DB::quote_identifier($attr['AFTER'], $db ? $db : static::$connection);
-			}
-
-			if (array_key_exists('COMMENT', $attr))
-			{
-				$sql .= ' COMMENT '.\DB::escape($attr['COMMENT'], $db ? $db : static::$connection);
 			}
 
 			$sql_fields[] = $sql;


### PR DESCRIPTION
In DBUtil class SQL queries created with method add_fields are wrong if we have defined field 'after' and 'comment'

For example this code

``` php
        \Fuel\Core\DBUtil::add_fields('test', array(
            'col1'  => array('constraint' => 50, 'type' => 'varchar', 'after' => 'id', 'comment' => 'My first column')
        ));
``
will throw a SQL exception.
```
