### PR TITLE
Apply chmod on every Config_File->save(), remove specific chmod on crypt config

### DIFF
--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -189,7 +189,13 @@ abstract class Config_File implements Config_Interface
 			mkdir($path['dirname'], 0777, true);
 		}
 
-		return \File::update($path['dirname'], $path['basename'], $output);
+		$return = \File::update($path['dirname'], $path['basename'], $output);
+		if ($return)
+		{
+			\Config::load('file', true);
+			chmod($path['dirname'].DS.$path['basename'], \Config::get('file.chmod.files', 0666));
+		}
+		return $return;
 	}
 
 	/**

--- a/classes/crypt.php
+++ b/classes/crypt.php
@@ -70,13 +70,9 @@ class Crypt
 		// update the config if needed
 		if ($update === true)
 		{
-			// load the file config
-			\Config::load('file', true);
-
 			try
 			{
 				\Config::save('crypt', static::$config);
-				chmod(APPPATH.'config'.DS.'crypt.php', \Config::get('file.chmod.files', 0666));
 			}
 			catch (\FileAccessException $e)
 			{


### PR DESCRIPTION
The specific `chmod` on the `crypt.php` config file is an issue: the name of the crypt config file is not necessarily `crypt.php`.

With moving the `chmod` in `Config_File->save()`, the `chmod` will be executed for crypt config file, but also for all others config files.
