### PR TITLE
Error concerning session.http_header_name configuration

### DIFF
--- a/classes/session/driver.php
+++ b/classes/session/driver.php
@@ -542,7 +542,7 @@ abstract class Session_Driver
 		// if not found, was a session-id present in the HTTP header?
 		if ($cookie === false)
 		{
-			$cookie = \Input::headers($this->config['header_header_name'], false);
+			$cookie = \Input::headers($this->config['http_header_name'], false);
 		}
 
 		if ($cookie !== false)


### PR DESCRIPTION
The configuration and docs all indicate this is a typeo, 'header_header_name' should be 'http_header_name' here.

Signed-off-by: Ian Turgeon iturgeon@gmail.com
