### PR TITLE
Nested transaction feature.

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -12,7 +12,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-//namespace Fuel\Core;
+namespace Fuel\Core;
 
 
 

--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -745,7 +745,7 @@ abstract class Database_Connection
 		{ 
 			$result = $this->set_savepoint($this->_transaction_depth);
 			// If savepoint is not supported it is not an error
-			! isset($result) and $result = true;
+			isset($result) or $result = true;
 		}
 
 		$result and $this->_transaction_depth ++;
@@ -799,7 +799,7 @@ abstract class Database_Connection
 	 *  
 	 * @return bool
 	 */
-	public function rollback_transaction($rollback_all = false)
+	public function rollback_transaction($rollback_all = true)
 	{
 		if ($this->_transaction_depth > 0)
 		{
@@ -815,7 +815,7 @@ abstract class Database_Connection
 			{
 				$result = $this->rollback_savepoint($this->_transaction_depth - 1);
 				// If savepoint is not supported it is not an error
-				! isset($result) and $result = true;
+				isset($result) or $result = true;
 				
 				$result and $this->_transaction_depth -- ;
 			}
@@ -857,7 +857,8 @@ abstract class Database_Connection
 	 *                 false - failed to set savepoint;
 	 *                 null  - RDBMS does not support savepoints
 	 */
-	protected function set_savepoint($name) {
+	protected function set_savepoint($name) 
+	{
 		return null;
 	}
 
@@ -869,7 +870,8 @@ abstract class Database_Connection
 	 *                 false - failed to set savepoint;
 	 *                 null  - RDBMS does not support savepoints
 	 */
-	protected function release_savepoint($name) {
+	protected function release_savepoint($name) 
+	{
 		return null;
 	}
 
@@ -881,7 +883,8 @@ abstract class Database_Connection
 	 *                 false - failed to set savepoint;
 	 *                 null  - RDBMS does not support savepoints
 	 */
-	protected function rollback_savepoint($name) {
+	protected function rollback_savepoint($name) 
+	{
 		return null;
 	}
 	

--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-namespace Fuel\Core;
+//namespace Fuel\Core;
 
 
 
@@ -479,5 +479,41 @@ class Database_MySQL_Connection extends \Database_Connection
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
 		return true;
 	}
+	
+	/**
+	 * Sets savepoint of the transaction
+	 * 
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully; 
+	 *                 false - failed to set savepoint;
+	 */
+	protected function set_savepoint($name) {
+		$this->query(0, 'SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
 
+	/**
+	 * Release savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 */
+	protected function release_savepoint($name) {
+		$this->query(0, 'RELEASE SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
+
+	/**
+	 * Rollback savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 */
+	protected function rollback_savepoint($name) {
+		$this->query(0, 'ROLLBACK TO SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
+	
 }

--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-//namespace Fuel\Core;
+namespace Fuel\Core;
 
 
 

--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -37,11 +37,6 @@ class Database_MySQL_Connection extends \Database_Connection
 	protected $_identifier = '`';
 
 	/**
-	 * @var  bool  Allows transactions
-	 */
-	protected $_in_transaction = false;
-
-	/**
 	 * @var  string  Which kind of DB is used
 	 */
 	public $_db_type = 'mysql';
@@ -464,32 +459,24 @@ class Database_MySQL_Connection extends \Database_Connection
 		return array($errno, empty($errno)? null : $errno, empty($errno) ? null : mysql_error($this->_connection));
 	}
 
-	public function in_transaction()
-	{
-		return $this->_in_transaction;
-	}
-
-	public function start_transaction()
+	protected function driver_start_transaction()
 	{
 		$this->query(0, 'SET AUTOCOMMIT=0', false);
 		$this->query(0, 'START TRANSACTION', false);
-		$this->_in_transaction = true;
 		return true;
 	}
 
-	public function commit_transaction()
+	protected function driver_commit()
 	{
 		$this->query(0, 'COMMIT', false);
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
 		return true;
 	}
 
-	public function rollback_transaction()
+	protected function driver_rollback()
 	{
 		$this->query(0, 'ROLLBACK', false);
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
 		return true;
 	}
 

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -41,11 +41,6 @@ class Database_MySQLi_Connection extends \Database_Connection
 	protected $_identifier = '`';
 
 	/**
-	 * @var  bool  Allows transactions
-	 */
-	protected $_in_transaction = false;
-
-	/**
 	 * @var  string  Which kind of DB is used
 	 */
 	public $_db_type = 'mysql';
@@ -481,32 +476,24 @@ class Database_MySQLi_Connection extends \Database_Connection
 		return array($errno, empty($errno)? null : $errno, empty($errno) ? null : $this->_connection->error);
 	}
 
-	public function in_transaction()
-	{
-		return $this->_in_transaction;
-	}
-
-	public function start_transaction()
+	protected function driver_start_transaction()
 	{
 		$this->query(0, 'SET AUTOCOMMIT=0', false);
 		$this->query(0, 'START TRANSACTION', false);
-		$this->_in_transaction = true;
 		return true;
 	}
 
-	public function commit_transaction()
+	protected function driver_commit()
 	{
 		$this->query(0, 'COMMIT', false);
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
 		return true;
 	}
 
-	public function rollback_transaction()
+	protected function driver_rollback()
 	{
 		$this->query(0, 'ROLLBACK', false);
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
-		$this->_in_transaction = false;
 		return true;
 	}
 

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-//namespace Fuel\Core;
+namespace Fuel\Core;
 
 
 

--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-namespace Fuel\Core;
+//namespace Fuel\Core;
 
 
 
@@ -496,5 +496,41 @@ class Database_MySQLi_Connection extends \Database_Connection
 		$this->query(0, 'SET AUTOCOMMIT=1', false);
 		return true;
 	}
+	
+	/**
+	 * Sets savepoint of the transaction
+	 * 
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully; 
+	 *                 false - failed to set savepoint;
+	 */
+	protected function set_savepoint($name) {
+		$this->query(0, 'SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
 
+	/**
+	 * Release savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 */
+	protected function release_savepoint($name) {
+		$this->query(0, 'RELEASE SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
+
+	/**
+	 * Rollback savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 */
+	protected function rollback_savepoint($name) {
+		$this->query(0, 'ROLLBACK TO SAVEPOINT LEVEL'.$name, false);
+		return true;
+	}
+	
 }

--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -25,11 +25,6 @@ class Database_PDO_Connection extends \Database_Connection
 	protected $_identifier = '';
 
 	/**
-	 * @var  bool  $_in_transation  allows transactions
-	 */
-	protected $_in_transaction = false;
-
-	/**
 	 * @var  string  $_db_type  which kind of DB is used
 	 */
 	public $_db_type = '';
@@ -432,24 +427,13 @@ class Database_PDO_Connection extends \Database_Connection
 	}
 
 	/**
-	 * Returns wether the connection is in transaction
-	 *
-	 * @return bool
-	 */
-	public function in_transaction()
-	{
-		return $this->_in_transaction;
-	}
-
-	/**
 	 * Start a transaction
 	 *
 	 * @return bool
 	 */
-	public function start_transaction()
+	protected function driver_start_transaction()
 	{
 		$this->_connection or $this->connect();
-		$this->_in_transaction = true;
 		return $this->_connection->beginTransaction();
 	}
 
@@ -458,9 +442,8 @@ class Database_PDO_Connection extends \Database_Connection
 	 *
 	 * @return bool
 	 */
-	public function commit_transaction()
+	protected function driver_commit()
 	{
-		$this->_in_transaction = false;
 		return $this->_connection->commit();
 	}
 
@@ -468,9 +451,8 @@ class Database_PDO_Connection extends \Database_Connection
 	 * Rollback a transaction
 	 * @return bool
 	 */
-	public function rollback_transaction()
+	protected function driver_rollback()
 	{
-		$this->_in_transaction = false;
 		return $this->_connection->rollBack();
 	}
 }

--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-namespace Fuel\Core;
+//namespace Fuel\Core;
 
 
 class Database_PDO_Connection extends \Database_Connection
@@ -455,4 +455,44 @@ class Database_PDO_Connection extends \Database_Connection
 	{
 		return $this->_connection->rollBack();
 	}
+	
+	/**
+	 * Sets savepoint of the transaction
+	 * 
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully; 
+	 *                 false - failed to set savepoint;
+	 *                 null  - RDBMS does not support savepoints
+	 */
+	protected function set_savepoint($name) {
+		$result = $this->_connection->exec('SAVEPOINT LEVEL'.$name);
+		return $result !== false;
+	}
+
+	/**
+	 * Release savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 *                 null  - RDBMS does not support savepoints
+	 */
+	protected function release_savepoint($name) {
+		$result = $this->_connection->exec('RELEASE SAVEPOINT LEVEL'.$name);
+		return $result !== false;
+	}
+
+	/**
+	 * Rollback savepoint of the transaction
+	 *
+	 * @param string $name name of the savepoint
+	 * @return boolean true  - savepoint was set successfully;
+	 *                 false - failed to set savepoint;
+	 *                 null  - RDBMS does not support savepoints
+	 */
+	protected function rollback_savepoint($name) {
+		$result = $this->_connection->exec('ROLLBACK TO SAVEPOINT LEVEL'.$name);
+		return $result !== false;
+	}
+	
 }

--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-//namespace Fuel\Core;
+namespace Fuel\Core;
 
 
 class Database_PDO_Connection extends \Database_Connection

--- a/classes/db.php
+++ b/classes/db.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-namespace Fuel\Core;
+//namespace Fuel\Core;
 
 
 
@@ -389,16 +389,22 @@ class DB
 	}
 
 	/**
-	 * Rollsback all pending transactional queries
+	 * Rollsback pending transactional queries
+	 * Rollback to the current level uses SAVEPOINT,
+	 * it does not work if current RDBMS does not support them.
+	 * In this case system rollsback all queries and closes the transaction
 	 *
 	 *     DB::rollback_transaction();
 	 *
-	 * @param   string  db connection
+	 * @param   string  $db connection
+	 * @param   bool    $rollback_all:
+	 *             true  - rollback everything and close transaction;
+	 *             false - rollback only current level 
 	 * @return  bool
 	 */
-	public static function rollback_transaction($db = null)
+	public static function rollback_transaction($db = null, $rollback_all = false)
 	{
-		return \Database_Connection::instance($db)->rollback_transaction();
+		return \Database_Connection::instance($db)->rollback_transaction($rollback_all);
 	}
 
 }

--- a/classes/db.php
+++ b/classes/db.php
@@ -9,7 +9,7 @@
  * @license    http://kohanaphp.com/license
  */
 
-//namespace Fuel\Core;
+namespace Fuel\Core;
 
 
 

--- a/classes/db.php
+++ b/classes/db.php
@@ -402,7 +402,7 @@ class DB
 	 *             false - rollback only current level 
 	 * @return  bool
 	 */
-	public static function rollback_transaction($db = null, $rollback_all = false)
+	public static function rollback_transaction($db = null, $rollback_all = true)
 	{
 		return \Database_Connection::instance($db)->rollback_transaction($rollback_all);
 	}


### PR DESCRIPTION
Only first level is the real start/commit. All nested transactions only increment/decrement the transaction depth counter. Rollback resets a counter and rollbacks the transaction.

All rules are implemented in Database_Connection.php. Drivers (pdo, mysql, msqli) only implement pure transaction functions (begin_transaction, commit, rollback).
