### PR TITLE
html_tag should not self-close all tags

### DIFF
--- a/base.php
+++ b/base.php
@@ -146,7 +146,8 @@ if ( ! function_exists('html_tag'))
 {
 	function html_tag($tag, $attr = array(), $content = false)
 	{
-		$has_content = (bool) ($content !== false and $content !== null);
+		$void_elements = array("area","base","br","col","embed","hr","img","input","keygen","link","menuitem","meta","param","source","track","wbr");
+		$has_content = (bool) (($content !== false and $content !== null) or !in_array($tag, $void_elements);
 		$html = '<'.$tag;
 
 		$html .= ( ! empty($attr)) ? ' '.(is_array($attr) ? array_to_attr($attr) : $attr) : '';

--- a/base.php
+++ b/base.php
@@ -146,8 +146,7 @@ if ( ! function_exists('html_tag'))
 {
 	function html_tag($tag, $attr = array(), $content = false)
 	{
-		$void_elements = array("area","base","br","col","embed","hr","img","input","keygen","link","menuitem","meta","param","source","track","wbr");
-		$has_content = (bool) (($content !== false and $content !== null) or !in_array($tag, $void_elements);
+		$has_content = (bool) (($content !== false and $content !== null) or (property_exists('\Html', 'void_elements') and ! in_array($tag, \Html::$void_elements)));
 		$html = '<'.$tag;
 
 		$html .= ( ! empty($attr)) ? ' '.(is_array($attr) ? array_to_attr($attr) : $attr) : '';

--- a/classes/html.php
+++ b/classes/html.php
@@ -29,6 +29,8 @@ class Html
 {
 	public static $doctypes = null;
 	public static $html5 = true;
+	public static $void_elements = array("area","base","br","col","embed","hr","img","input","keygen","link","menuitem","meta","param","source","track","wbr");
+
 
 	/**
 	 * Creates an html link


### PR DESCRIPTION
Fixed html_tag to account for cases where there's no content in an element and the element is not a void element as per the HTML specification.  In this case, the element cannot be self-closed and requires a closing tag.

List of valid self-closing tags was pulled from http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
