### PR TITLE
fixed Content-Type and Content-Length for FCGI and NGINX setup

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -504,8 +504,8 @@ class Input
 					$headers[$key] = $value;
 				}
 
-				$value = static::server('CONTENT_TYPE') and $headers['Content-Type'] = $value;
-				$value = static::server('CONTENT_LENGTH') and $headers['Content-Length'] = $value;
+				$value = static::server('Content_Type', static::server('Content-Type')) and $headers['Content-Type'] = $value;
+				$value = static::server('Content_Length', static::server('Content-Length')) and $headers['Content-Length'] = $value;
 			}
 			else
 			{

--- a/classes/input.php
+++ b/classes/input.php
@@ -504,8 +504,8 @@ class Input
 					$headers[$key] = $value;
 				}
 
-				$value = static::server('Content-Type') and $headers['Content-Type'] = $value;
-				$value = static::server('Content-Length') and $headers['Content-Length'] = $value;
+				$value = static::server('CONTENT_TYPE') and $headers['Content-Type'] = $value;
+				$value = static::server('CONTENT_LENGTH') and $headers['Content-Length'] = $value;
 			}
 			else
 			{


### PR DESCRIPTION
\Input::server('Content-Type') should return the value of Content-Type field if available.
However, \Input::server('Content-Type') always returns null with lighttpd and mod_cgi.

In \Input::headers(), \Input::server() is called when getallheaders() is missing.
\Input::server() should be called with an underscored name, but actually with an hyphened name.
For example, \Input::server('Content-Type') is wrong and must be \Input::server('CONTENT_TYPE').
That is as well about Content-Length.

This bug should reproduce for FCGI and NGINX setup or other setups that do not have getallheaders().

Signed-off-by: Udagawa Kaito umireon@gmail.com
