### PR TITLE
Htmlentities for row data

### DIFF
--- a/vendor/phpquickprofiler/display.php
+++ b/vendor/phpquickprofiler/display.php
@@ -417,6 +417,7 @@ else {
 
 		$class = '';
 		foreach($output['logs']['console'] as $log) {
+			$log['data'] = \Security::htmlentities($log['data']);
 			$return_output .='<tr class="pqp-log-'.$log['type'].'">
 				<td class="pqp-type">'.$log['type'].'</td>
 				<td class="'.$class.'">';


### PR DESCRIPTION
At representation level, row data should be "\Security::htmlentitized" since data could contain html codes.
Example: if you try to log "&currency=EUR", quick profiler will display "¤cy=EUR".
