### PR TITLE
Add filesize check to _get() method

### DIFF
--- a/classes/cache/storage/file.php
+++ b/classes/cache/storage/file.php
@@ -323,6 +323,10 @@ class Cache_Storage_File extends \Cache_Storage_Driver
 		{
 			return false;
 		}
+		if ( ! filesize($file))
+		{
+			return false;
+		}
 
 		$handle = fopen($file, 'r');
 		if ( ! $handle)


### PR DESCRIPTION
Unfortunately, when the size of the cache file is 0 bytes in some trouble, error occurs in the following lines. 

``` php
$payload = fread($handle, filesize($file));
```

At that time, file lock of previous lives, it falls deadlock.

I experienced. ;)
