### PR TITLE
Escape double quotes inside property value

### DIFF
--- a/base.php
+++ b/base.php
@@ -126,7 +126,7 @@ if ( ! function_exists('array_to_attr'))
 				$property = $value;
 			}
 
-			$attr_str .= $property.'="'.$value.'" ';
+			$attr_str .= $property.'="'.str_replace('"', '&quot;', $value).'" ';
 		}
 
 		// We strip off the last space for return


### PR DESCRIPTION
When doing:

``` php
echo html_tag('img', array(
    'src' => 'whatever.png',
    'alt' => 'Look at "this" description',
));
// Will output <img src="whatever.png" alt="Look at "this" description" />
```

This is not expected behaviour. My fixed is based on this answer: http://stackoverflow.com/questions/4015345/how-to-properly-escape-quotes-inside-html-attributes

It's still legit to HTML inside attribute values (some JS tooltip plugins work like that), but the quote really has to be escaped.
