### PR TITLE
Fixed a bug when running PHPUnit with views being loaded multiple times.

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -237,7 +237,7 @@ class View
 			try
 			{
 				// Load the view within the current scope
-				include $__file_name;
+				include_once $__file_name;
 			}
 			catch (\Exception $e)
 			{


### PR DESCRIPTION
When running phpunit tests and creating a controller, if I use a dataProvider and call the same controller again and again with different data, I get errors ("Cannot redeclare my_function_name()") with functions defined in the global scale.
