### PR TITLE
Only look in child fieldsets when $flatten is true

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -412,8 +412,13 @@ class Fieldset
 			return $fields;
 		}
 
-		if ( ! array_key_exists($name, $this->fields) and $flatten)
+		if ( ! array_key_exists($name, $this->fields))
 		{
+			if ( ! $flatten)
+			{
+				return false;
+			}
+
 			foreach ($this->fieldset_children as $fieldset)
 			{
 				if (($field = $fieldset->field($name)) !== false)

--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -412,7 +412,7 @@ class Fieldset
 			return $fields;
 		}
 
-		if ( ! array_key_exists($name, $this->fields))
+		if ( ! array_key_exists($name, $this->fields) and $flatten)
 		{
 			foreach ($this->fieldset_children as $fieldset)
 			{


### PR DESCRIPTION
`$flatten` appears to decide whether we should recursively treat child fieldsets' fields as our own; the behaviour of `$fieldset->field('name')` should be the same as `$fieldset->field()['name']` - which is only valid for newer PHPs.
