### PR TITLE
Uri::main() fixing has a side effect

### DIFF
--- a/classes/form/instance.php
+++ b/classes/form/instance.php
@@ -106,7 +106,7 @@ class Form_Instance
 		$attributes = ! is_array($attributes) ? array('action' => $attributes) : $attributes;
 
 		// If there is still no action set, Form-post
-		if( ! array_key_exists('action', $attributes) or $attributes['action'] === null)
+		if( ! array_key_exists('action', $attributes) or $attributes['action'] === null or $attributes['action'] === '')
 		{
 			$attributes['action'] = \Uri::main();
 		}


### PR DESCRIPTION
I found that Uri::main() amendment #1641 has one side effect.  If form action has an empty string, the generated url gets wrong.
