### PR TITLE
\Log::_init() - Extended determinig name and location of logfile by new ...

### DIFF
--- a/classes/log.php
+++ b/classes/log.php
@@ -51,9 +51,21 @@ class Log
 		try
 		{
 			// determine the name and location of the logfile
-			$rootpath = \Config::get('log_path').date('Y').'/';
-			$filepath = \Config::get('log_path').date('Y/m').'/';
-			$filename = $filepath.date('d').'.php';
+			$path     = \Config::get('log_path');
+			$filename = \Config::get('log_filename');
+			
+			if($filename === null)
+			{
+				$rootpath = $path.date('Y').'/';
+				$filepath = $path.date('Y/m').'/';
+				$filename = $filepath.date('d').'.php';
+			}
+			else
+			{
+				$rootpath = $path;
+				$filepath = $path;
+				$filename = $path.$filename;
+			}
 
 			// get the required folder permissions
 			$permission = \Config::get('file.chmod.folders', 0777);

--- a/config/config.php
+++ b/config/config.php
@@ -126,10 +126,13 @@ return array(
 	 * Fuel::L_DEBUG
 	 * Fuel::L_INFO
 	 * Fuel::L_ALL
+	 *
+	 * log_filename		optional, if you want set explicit filename, null to composed in yyyy/mm folders with dd as filename
 	 */
 	'log_threshold'    => Fuel::L_WARNING,
 	'log_path'         => APPPATH.'logs/',
 	'log_date_format'  => 'Y-m-d H:i:s',
+	'log_filename'     => null,
 
 	/**
 	 * Security settings


### PR DESCRIPTION
...config "log_filename"

log_filename = 'fuelphp.log' - for loging is used only this one file in log_path dir.
log_filename = null - use original way

I made this extension, because I want use linux logrotation

Signed-off-by: Kristián Feldsam feldsam@gmail.com
