### PR TITLE
#1656 make sure it uses forward slashes on Windows

### DIFF
--- a/classes/asset/instance.php
+++ b/classes/asset/instance.php
@@ -266,7 +266,7 @@ class Asset_Instance
 						else
 						{
 							$file = $this->_asset_url.$file.($this->_add_mtime ? '?'.filemtime($file) : '');
-							$file = str_replace(DOCROOT, '', $file);
+							$file = str_replace(str_replace(DS, '/', DOCROOT), '', $file);
 						}
 					}
 				}
@@ -280,7 +280,7 @@ class Asset_Instance
 					}
 					else
 					{
-						$file = str_replace(DOCROOT, '', $file);
+						$file = str_replace(str_replace(DS, '/', DOCROOT), '', $file);
 					}
 				}
 			}


### PR DESCRIPTION
Fix the issue [#1656](https://github.com/fuel/core/issues/1656)

backslashes are replaced by forward slashes in the file path, but not in the DOCROOT, on Windows.
