### PR TITLE
Wrong slash for phpdoc @category is deprecated

### DIFF
--- a/classes/db.php
+++ b/classes/db.php
@@ -2,8 +2,7 @@
 /**
  * Database object creation helper methods.
  *
- * @package    Fuel/Database
- * @category   Base
+ * @package    Fuel\Database
  * @author     Kohana Team
  * @copyright  (c) 2009 Kohana Team
  * @license    http://kohanaphp.com/license


### PR DESCRIPTION
See: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/category.html
