### PR TITLE
Bugfix - Prevent infinite recursion

### DIFF
--- a/classes/ftp.php
+++ b/classes/ftp.php
@@ -453,16 +453,17 @@ class Ftp
 
 		if ($list !== false and count($list) > 0)
 		{
-			if (preg_match('/\/\.\.|\/\.$/', $item)) {
-				continue;
-			}
 			foreach ($list as $item)
 			{
 				// If we can't delete the item it's probaly a folder so
 				// we'll recursively call delete_dir()
 				if ( ! @ftp_delete($this->_conn_id, $item))
 				{
-					$this->delete_dir($item);
+					// don't recurse into current of parent directory
+					if ( ! preg_match('/\/\.\.|\/\.$/', $item)) 
+					{
+						$this->delete_dir($item);
+					}
 				}
 			}
 		}

--- a/classes/ftp.php
+++ b/classes/ftp.php
@@ -453,6 +453,9 @@ class Ftp
 
 		if ($list !== false and count($list) > 0)
 		{
+			if (preg_match('/\/\.\.|\/\.$/', $item)) {
+				continue;
+			}
 			foreach ($list as $item)
 			{
 				// If we can't delete the item it's probaly a folder so


### PR DESCRIPTION
When the recursive method list the files to make sure that the folder is empty (list_files), the delete_dir list again the self dir and the parent, and recursion is generated.

Logging:

``` php
function delete_dir($filepath) {
  Logger::log('Deleting $item: ' . $filepath);
  ...
  if ($list !== false and count($list) > 0) {
    foreach ($list as $item) {
       Logger::log('Deleting $item: ' . $item);
  ...
```

Output:

```
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
```
