### PR TITLE
Adding url_suffix fix for uri to url create method

### DIFF
--- a/classes/uri.php
+++ b/classes/uri.php
@@ -167,7 +167,7 @@ class Uri
 		$url .= ltrim($uri, '/');
 
 		// Add a url_suffix if defined and the url doesn't already have one
-		if (substr($url, -1) != '/' and (($suffix = strrchr($url, '.')) === false or strlen($suffix) > 4))
+	        if (substr($url, -1) != '/' and (($suffix = \Config::get('url_suffix')) == false or !strrpos($uri,$suffix)))
 		{
 			\Config::get('url_suffix') and $url .= \Config::get('url_suffix');
 		}

--- a/classes/uri.php
+++ b/classes/uri.php
@@ -167,7 +167,7 @@ class Uri
 		$url .= ltrim($uri, '/');
 
 		// Add a url_suffix if defined and the url doesn't already have one
-		if (substr($url, -1) != '/' and (($suffix = strrchr($url, '.')) === false or strlen($suffix) > 5))
+		if (substr($url, -1) != '/' and (($suffix = strrchr($url, '.')) === false or strlen($suffix) > 4))
 		{
 			\Config::get('url_suffix') and $url .= \Config::get('url_suffix');
 		}


### PR DESCRIPTION
`strlen($suffix) > 4` for two letter **.tld**, since one symbol plus slash plus point plus two letter tld is **5** (e.g. '**.ru/2**').
I discovered original issue when trying to get Route for one-symbol uri, url_suffix was added only for two symbol.

Imho, It would be better to change checking «whether uri has suffix» logic as:

``` php
if (substr($url, -1) != '/' and (($suffix = \Config::get('url_suffix')) == false or !strrpos($uri,$suffix)))
```
