### PR TITLE
Fixing "save_info" behavior on themes

### DIFF
--- a/classes/theme.php
+++ b/classes/theme.php
@@ -657,7 +657,7 @@ class Theme
 			throw new \ThemeException(sprintf('Could not find theme "%s".', $theme['name']));
 		}
 
-		if ( ! ($file = $this->find_file($this->config['info_file_name'], array($theme['name']))))
+		if ( ! ($file = $this->find_file($this->config['info_file_name'], array($theme))))
 		{
 			throw new \ThemeException(sprintf('Theme "%s" is missing "%s".', $theme['name'], $this->config['info_file_name']));
 		}


### PR DESCRIPTION
When using save_info it actually writes the file into fuel/app/config/{theme info filename} instead the respected theme's directory, if you look at line 619 (load_info function) you'll notice it passes array($theme) instead of array($theme['name']) this causes an inconsistent behavior between reads and writes.

This is applicable to 1.7.X as well.
