### PR TITLE
connect to database when getting driver name

### DIFF
--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -134,6 +134,10 @@ class Database_PDO_Connection extends \Database_Connection
 	 */
 	public function driver_name()
 	{
+		// Make sure the database is connected
+		$this->_connection or $this->connect();
+
+		// Getting driver name
 		return $this->_connection->getAttribute(\PDO::ATTR_DRIVER_NAME);
 	}
 


### PR DESCRIPTION
Getting driver name throws exception `Call to a member function getAttribute() on a non-object`, when database is not connected.
(This may happen when extending Query Builder with driver-dependent functionality, for instance with LIMIT and OFFSET on Ms Access or SQL Server.)
