### PR TITLE
Default to config::get should be empty array as we explicitly merge 2 lines below

### DIFF
--- a/classes/theme.php
+++ b/classes/theme.php
@@ -128,7 +128,7 @@ class Theme
 		if (empty($config))
 		{
 			\Config::load('theme', true, false, true);
-			$config = \Config::get('theme', false);
+			$config = \Config::get('theme', array());
 		}
 
 		// Order of this addition is important, do not change this.


### PR DESCRIPTION
Else the merge causes an error
