### PR TITLE
strict comparison of requests to stop recursion from type juggling

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -127,7 +127,7 @@ class View
 		}
 
 		// store the current request search paths to deal with out-of-context rendering
-		if (class_exists('Request', false) and $active = \Request::active() and \Request::main() != $active)
+		if (class_exists('Request', false) and $active = \Request::active() and \Request::main() !== $active)
 		{
 			$this->request_paths = $active->get_paths();
 		}


### PR DESCRIPTION
@cuphalfempty was getting a "Nesting level too deep – recursive dependency?" error, which we tracked down to this line.

This post explains the root cause of the problem - http://www.richardlord.net/blog/php-nesting-level-too-deep-recursive-dependency.
