### PR TITLE
fix check for opcache use

### DIFF
--- a/classes/config/php.php
+++ b/classes/config/php.php
@@ -28,7 +28,7 @@ class Config_Php extends \Config_File
 	public static function _init()
 	{
 		// do we have Opcache active?
-		static::$uses_opcache = PHP_VERSION_ID >= 50500 and function_exists('opcache_invalidate');
+		static::$uses_opcache = (PHP_VERSION_ID >= 50500 and function_exists('opcache_invalidate'));
 
 		// do we have APC active?
 		static::$uses_apc = function_exists('apc_compile_file');

--- a/classes/lang/php.php
+++ b/classes/lang/php.php
@@ -28,7 +28,7 @@ class Lang_Php extends \Lang_File
 	public static function _init()
 	{
 		// do we have Opcache active?
-		static::$uses_opcache = PHP_VERSION_ID >= 50500 and function_exists('opcache_invalidate');
+		static::$uses_opcache = (PHP_VERSION_ID >= 50500 and function_exists('opcache_invalidate'));
 
 		// do we have APC active?
 		static::$uses_apc = function_exists('apc_compile_file');


### PR DESCRIPTION
For some reason `uses_opcache` was set to true for me. PHP_VERSION_ID = 50509 & the opcache_invalidate function doest **not** exist. These extra parenthesis fix it.
