### PR TITLE
Update phpquickprofiler.php

### DIFF
--- a/vendor/phpquickprofiler/phpquickprofiler.php
+++ b/vendor/phpquickprofiler/phpquickprofiler.php
@@ -15,6 +15,8 @@
 
 - - - - - - - - - - - - - - - - - - - - - */
 
+include_once('display.php');
+
 class PhpQuickProfiler {
 
 	public $output = array();


### PR DESCRIPTION
Include once directive was added.
Fatal error: Call to undefined function displayPqp() in /var/www/clients/client0/web1/private/fuelphp-1.7.1/fuel/core/vendor/phpquickprofiler/phpquickprofiler.php on line 226
