### PR TITLE
Ensure tests clean up any changes made to the environment.

### DIFF
--- a/tests/debug.php
+++ b/tests/debug.php
@@ -20,12 +20,22 @@ namespace Fuel\Core;
  */
 class Test_Debug extends TestCase
 {
+    public function setUp()
+    {
+        // Remember old value, and set to browser mode.
+        $this->old_is_cli = \Fuel::$is_cli;
+        \Fuel::$is_cli = false;
+    }
+
+    public function tearDown()
+    {
+        // Restore original value
+        \Fuel::$is_cli = $this->old_is_cli;
+    }
+    
  	public function test_debug_dump_normally()
  	{
- 		// Set to browser mode.
- 		\Fuel::$is_cli = false;
-
-		$expected = '	<script type="text/javascript">function fuel_debug_toggle(a){if(document.getElementById){if(document.getElementById(a).style.display=="none"){document.getElementById(a).style.display="block"}else{document.getElementById(a).style.display="none"}}else{if(document.layers){if(document.id.display=="none"){document.id.display="block"}else{document.id.display="none"}}else{if(document.all.id.style.display=="none"){document.all.id.style.display="block"}else{document.all.id.style.display="none"}}}};</script><div class="fuelphp-dump" style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;"><h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">COREPATH/tests/debug.php @ line: 31</h1><pre style="overflow:auto;font-size:100%;"><strong>Variable #1:</strong>'."\n".'<i></i> <strong></strong> (Integer): 1'."\n\n\n".'<strong>Variable #2:</strong>'."\n".'<i></i> <strong></strong> (Integer): 2'."\n\n\n".'<strong>Variable #3:</strong>'."\n".'<i></i> <strong></strong> (Integer): 3'."\n\n\n".'</pre></div>';
+		$expected = '	<script type="text/javascript">function fuel_debug_toggle(a){if(document.getElementById){if(document.getElementById(a).style.display=="none"){document.getElementById(a).style.display="block"}else{document.getElementById(a).style.display="none"}}else{if(document.layers){if(document.id.display=="none"){document.id.display="block"}else{document.id.display="none"}}else{if(document.all.id.style.display=="none"){document.all.id.style.display="block"}else{document.all.id.style.display="none"}}}};</script><div class="fuelphp-dump" style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;"><h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">COREPATH/tests/debug.php @ line: 41</h1><pre style="overflow:auto;font-size:100%;"><strong>Variable #1:</strong>'."\n".'<i></i> <strong></strong> (Integer): 1'."\n\n\n".'<strong>Variable #2:</strong>'."\n".'<i></i> <strong></strong> (Integer): 2'."\n\n\n".'<strong>Variable #3:</strong>'."\n".'<i></i> <strong></strong> (Integer): 3'."\n\n\n".'</pre></div>';
 
 		ob_start();
  		\Debug::dump(1, 2, 3);
@@ -37,10 +47,7 @@ class Test_Debug extends TestCase
 
   	public function test_debug_dump_by_call_user_func_array()
  	{
- 		// Set to browser mode.
- 		\Fuel::$is_cli = false;
-
-		$expected = '<div class="fuelphp-dump" style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;"><h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">COREPATH/tests/debug.php @ line: 46</h1><pre style="overflow:auto;font-size:100%;"><strong>Variable #1:</strong>'."\n".'<i></i> <strong></strong> (Integer): 1'."\n\n\n".'<strong>Variable #2:</strong>'."\n".'<i></i> <strong></strong> (Integer): 2'."\n\n\n".'<strong>Variable #3:</strong>'."\n".'<i></i> <strong></strong> (Integer): 3'."\n\n\n".'</pre></div>';
+		$expected = '<div class="fuelphp-dump" style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;"><h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">COREPATH/tests/debug.php @ line: 53</h1><pre style="overflow:auto;font-size:100%;"><strong>Variable #1:</strong>'."\n".'<i></i> <strong></strong> (Integer): 1'."\n\n\n".'<strong>Variable #2:</strong>'."\n".'<i></i> <strong></strong> (Integer): 2'."\n\n\n".'<strong>Variable #3:</strong>'."\n".'<i></i> <strong></strong> (Integer): 3'."\n\n\n".'</pre></div>';
 
 		ob_start();
  		call_user_func_array('\\Debug::dump', array(1, 2, 3));
@@ -52,9 +59,6 @@ class Test_Debug extends TestCase
 
   	public function test_debug_dump_by_call_fuel_func_array()
  	{
- 		// Set to browser mode.
- 		\Fuel::$is_cli = false;
-
 		$expected = '<div class="fuelphp-dump" style="font-size: 13px;background: #EEE !important; border:1px solid #666; color: #000 !important; padding:10px;"><h1 style="border-bottom: 1px solid #CCC; padding: 0 0 5px 0; margin: 0 0 5px 0; font: bold 120% sans-serif;">COREPATH/base.php @ line: 491</h1><pre style="overflow:auto;font-size:100%;"><strong>Variable #1:</strong>
 <i></i> <strong></strong> (Integer): 1
 

--- a/tests/html.php
+++ b/tests/html.php
@@ -20,6 +20,19 @@ namespace Fuel\Core;
  */
 class Test_Html extends TestCase
 {
+	public function setUp()
+	{
+		$this->old_url_suffix = Config::get('url_suffix');
+		$this->old_index_file = Config::get('index_file');
+		$this->old_base_url = Config::get('base_url');
+	}
+
+	public function tearDown()
+	{
+		Config::set('url_suffix', $this->old_url_suffix);
+		Config::set('index_file', $this->old_index_file);
+		Config::set('base_url', $this->old_base_url);
+	}
 
 	/**
 	 * Tests Html::meta()
@@ -58,8 +71,9 @@ class Test_Html extends TestCase
 	public function test_anchor()
 	{
 		// Query string tests
-		Config::set('url_suffix', '');
-		Config::set('index_file', '');
+		Config::set('url_suffix', null);
+		Config::set('index_file', null);
+		Config::set('base_url', null);
 
 		// External uri
 		$output = Html::anchor('http://google.com', 'Go to Google');
@@ -92,10 +106,6 @@ class Test_Html extends TestCase
 		$this->assertEquals($expected, $output);
 		$_SERVER['HTTP_HOST'] = $host;
 
-		// Get original values to reset once done
-		$index_file = Config::get('index_file');
-		$url_suffix = Config::get('url_suffix');
-
 		$output = Html::anchor('search?q=query', 'Search');
 		$expected = '<a href="search?q=query">Search</a>';
 		$this->assertEquals($expected, $output);
@@ -105,10 +115,6 @@ class Test_Html extends TestCase
 		$output = Html::anchor('search?q=query', 'Search');
 		$expected = '<a href="search.html?q=query">Search</a>';
 		$this->assertEquals($expected, $output);
-
-		// Reset to original values
-		Config::set('index_file', $index_file);
-		Config::set('url_suffix', $url_suffix);
 	}
 
 	/**

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -38,6 +38,11 @@ class Test_Pagination extends TestCase
 		$rp->setValue($this->request, $this->request);
 	}
 
+	protected function setUp()
+	{
+		$this->old_base_url = Config::get('base_url');
+	}
+
 	public function tearDown()
 	{
 		// remove the fake uri
@@ -60,6 +65,9 @@ class Test_Pagination extends TestCase
 		$rp = new \ReflectionProperty($request, 'active');
 		$rp->setAccessible(true);
 		$rp->setValue($request, false);
+
+		// ensure base_url is reset even if an exception occurs
+		Config::set('base_url', $this->old_base_url);
 	}
 
 /**********************************
@@ -129,9 +137,6 @@ class Test_Pagination extends TestCase
 		$test = $_make_link->invoke($pagination, 1);
 		$expected = 'http://docs.fuelphp.com/welcome/index/1';
 		$this->assertEquals($expected, $test);
-
-		// reset base_url
-		Config::set('base_url', null);
 	}
 
 	public function test_uri_segment_set_pagination_url_after_forging_fail()
@@ -610,9 +615,6 @@ class Test_Pagination extends TestCase
 		$test = $_make_link->invoke($pagination, 1);
 		$expected = 'http://docs.fuelphp.com/?p=1';
 		$this->assertEquals($expected, $test);
-
-		// reset base_url
-		Config::set('base_url', null);
 	}
 
 	public function test_query_string_get_total_pages()

--- a/tests/uri.php
+++ b/tests/uri.php
@@ -20,6 +20,19 @@ namespace Fuel\Core;
  */
 class Test_Uri extends TestCase
 {
+	public function setUp()
+	{
+		$this->old_url_suffix = Config::get('url_suffix');
+		$this->old_index_file = Config::get('index_file');
+		$this->old_base_url = Config::get('base_url');
+	}
+
+	public function tearDown()
+	{
+		Config::set('url_suffix', $this->old_url_suffix);
+		Config::set('index_file', $this->old_index_file);
+		Config::set('base_url', $this->old_base_url);
+	}
 
 	/**
 	 * Tests Uri::create()


### PR DESCRIPTION
Fixed-up cherry pick of https://github.com/fuel/core/pull/1703

This is desirable because changes to the environment can influence
the pass/fail status of other tests, which makes them dependent on
the order in which they are executed.  This matters when running
subsets of tests with --group, or when using phpunit-randomizer,
for example.
