### PR TITLE
Add logging Exception in shutdown

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -69,6 +69,10 @@ register_shutdown_function(function ()
 			\Cli::beep();
 			exit(1);
 		}
+		else
+		{
+			logger(\Fuel::L_ERROR, 'shutdown - ' . $e->getMessage()." in ".$e->getFile()." on ".$e->getLine());
+		}
 	}
 	return \Error::shutdown_handler();
 });


### PR DESCRIPTION
Exceptions in shutdown event are gone. So I lost my time, because of my stupid miss configuration.
This PR helps the person like me. :-)
