### PR TITLE
Auto detect AspectMock on testing

### DIFF
--- a/bootstrap_phpunit.php
+++ b/bootstrap_phpunit.php
@@ -40,8 +40,31 @@ if ( ! is_file(VENDORPATH.'autoload.php'))
 }
 require VENDORPATH.'autoload.php';
 
-// Load in the Fuel autoloader
-require COREPATH.'classes'.DIRECTORY_SEPARATOR.'autoloader.php';
+if (class_exists('AspectMock\Kernel'))
+{
+	// Configure AspectMock
+	$kernel = \AspectMock\Kernel::getInstance();
+	$kernel->init(array(
+		'debug' => true,
+		'appDir' => __DIR__.'/../',
+		'includePaths' => array(
+			APPPATH, COREPATH, PKGPATH,
+		),
+		'excludePaths' => array(
+			APPPATH.'tests', COREPATH.'tests',
+		),
+		'cacheDir' => APPPATH.'tmp/AspectMock',
+	));
+
+	// Load in the Fuel autoloader
+	$kernel->loadFile(COREPATH.'classes'.DIRECTORY_SEPARATOR.'autoloader.php');
+}
+else
+{
+	// Load in the Fuel autoloader
+	require COREPATH.'classes'.DIRECTORY_SEPARATOR.'autoloader.php';
+}
+
 class_alias('Fuel\\Core\\Autoloader', 'Autoloader');
 
 // Boot the app


### PR DESCRIPTION
If AspectMock is installed, `bootstrap_phpunit.php` detects it and configure it.

Fuel v1 uses static methods a lot, so it is difficult to write tests without AspectMock.

Of course AspectMock is optional. If not installed, the same as before.
