### PR TITLE
overhead

### DIFF
--- a/classes/profiler.php
+++ b/classes/profiler.php
@@ -66,7 +66,7 @@ class Profiler
 		if (static::$profiler)
 		{
 			static::$query['time'] = (static::$profiler->getMicroTime() - static::$query['time']) *1000;
-			array_push(static::$profiler->queries, static::$query);
+			static::$profiler->queries[] = static::$query;
 			static::$profiler->queryCount++;
 		}
 	}


### PR DESCRIPTION
http://de1.php.net/manual/en/function.array-push.php
Note: If you use array_push() to add one element to the array it's better to use $array[] = because in that way there is no overhead of calling a function.
