### PR TITLE
Fixed typo in Autoloader

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -13,7 +13,7 @@
 namespace Fuel\Core;
 
 /**
- * The Autloader is responsible for all class loading.  It allows you to define
+ * The Autoloader is responsible for all class loading.  It allows you to define
  * different load paths based on namespaces.  It also lets you set explicit paths
  * for classes to be loaded from.
  *


### PR DESCRIPTION
The description in classes/autoloader.php class is missing an 'o'.
