### PR TITLE
HttpException namespace fix

### DIFF
--- a/classes/httpexceptions.php
+++ b/classes/httpexceptions.php
@@ -13,7 +13,7 @@
 namespace Fuel\Core;
 
 
-class HttpNotFoundException extends \HttpException
+class HttpNotFoundException extends HttpException
 {
 	public function response()
 	{
@@ -21,7 +21,7 @@ class HttpNotFoundException extends \HttpException
 	}
 }
 
-class HttpServerErrorException extends \HttpException
+class HttpServerErrorException extends HttpException
 {
 	public function response()
 	{


### PR DESCRIPTION
Locally when I start a fresh Fuel project, I got the error below when attempting to visit 404 pages. Turns out, since `HttpNotFoundException` was extended from `\HttpException`, rather than `HttpException`, which is the class from the PHP [HTTP module](http://php.net/manual/en/book.http.php) instead of Fuel's. I attempted to fix that by simply respecting the `Fuel\Core` namespace.

![image](https://cloud.githubusercontent.com/assets/821001/3583732/1f8f27c0-0c0e-11e4-9d8d-942b9843d067.png)
