### PR TITLE
This appears to fix the encrypt/decrypt issues with the new phpseclib.

### DIFF
--- a/classes/crypt.php
+++ b/classes/crypt.php
@@ -96,12 +96,25 @@ class Crypt
 	 *
 	 * @param	string	value to encrypt
 	 * @param	string	optional custom key to be used for this encryption
+	 * @param	int	optional key length
 	 * @access	public
 	 * @return	string	encrypted value
 	 */
-	public static function encode($value, $key = false)
+	public static function encode($value, $key = false, $keylength = false)
 	{
-		$key ? static::$crypter->setKey($key) : static::$crypter->setKey(static::safe_b64decode(static::$config['crypto_key']));
+		if (!$key) {
+			$key = static::safe_b64decode(static::$config['crypto_key']);
+			// Used for backwards compatibility with encrypted data prior
+			// to FuelPHP 1.7.2, when phpseclib was updated, and became a
+			// bit smarter about figuring out key lengths.
+			$keylength = 128;
+		}
+
+		if ($keylength) {
+			static::$crypter->setKeyLength($keylength);
+		}
+
+		static::$crypter->setKey($key);
 		static::$crypter->setIV(static::safe_b64decode(static::$config['crypto_iv']));
 
 		$value = static::$crypter->encrypt($value);
@@ -116,12 +129,24 @@ class Crypt
 	 *
 	 * @param	string	value to decrypt
 	 * @param	string	optional custom key to be used for this encryption
+	 * @param	int	optional key length
 	 * @access	public
 	 * @return	string	encrypted value
 	 */
-	public static function decode($value, $key = false)
+	public static function decode($value, $key = false, $keylength = false)
 	{
-		$key ? static::$crypter->setKey($key) : static::$crypter->setKey(static::safe_b64decode(static::$config['crypto_key']));
+		if (!$key) {
+			$key = static::safe_b64decode(static::$config['crypto_key']);
+			// Used for backwards compatibility with encrypted data prior
+			// to FuelPHP 1.7.2, when phpseclib was updated, and became a
+			// bit smarter about figuring out key lengths.
+			$keylength = 128;
+		}
+
+		if ($keylength) {
+			static::$crypter->setKeyLength($keylength);
+		}
+		static::$crypter->setKey($key);
 		static::$crypter->setIV(static::safe_b64decode(static::$config['crypto_iv']));
 
 		$value = static::safe_b64decode($value);


### PR DESCRIPTION
I wrote a quick test to confirm this is fixed.. you can see it at http://pastebin.com/ZmiHujmS

I didn't try to covert it to a proper phpunit test, as I haven't ever looked at getting that working with fuel. Hopefully there'll be enough there for someone with a proper build environment to convert it to a sensible test.

Also, it's interesting that the new phpseclib is -massively- faster at encrypting and decrypting.  I actually thought there was an error with my tests when I got it working against 1.7.2, it ran almost instantly, as opposed to a 1 or 2 second delay.
