### PR TITLE
Pacakge and module paths should always be lower case

### DIFF
--- a/classes/module.php
+++ b/classes/module.php
@@ -148,6 +148,7 @@ class Module
 		else
 		{
 			$paths = \Config::get('module_paths', array());
+			$module = strtolower($module);
 
 			foreach ($paths as $path)
 			{

--- a/classes/package.php
+++ b/classes/package.php
@@ -142,6 +142,7 @@ class Package
 		{
 			$paths = \Config::get('package_paths', array());
 			empty($paths) and $paths = array(PKGPATH);
+			$package = strtolower($package);
 
 			foreach ($paths as $path)
 			{


### PR DESCRIPTION
Package and Module clasess load method checks a lower cased path while exists does not. This PR fixes this, by adding lower case convert to exists methods.
