### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "fuel/core",
+	"description" : "FuelPHP 1.x Core",
+	"type": "fuel-package",
+	"homepage": "https://github.com/fuel/core",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "FuelPHP Development Team",
+			"email": "team@fuelphp.com"
+		}
+	],
+	"require": {
+		"composer/installers": "~1.0"
+	}
+}


### PR DESCRIPTION
I would like to add composer.json to all FuelPHP 1.x repositories.
It could increase flexibility of composer installation.
