### PR TITLE
the rules of 'Inflector' are load in config file.

### DIFF
--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -3,7 +3,7 @@
  * Part of the Fuel framework.
  *
  * @package    Fuel
- * @version    1.7
+ * @version    1.8
  * @author     Fuel Development Team
  * @license    MIT License
  * @copyright  2010 - 2014 Fuel Development Team
@@ -15,30 +15,38 @@ namespace Fuel\Core;
 /**
  * Some of this code was written by Flinn Mueller.
  *
- * @package		Fuel
- * @category	Core
- * @copyright	Flinn Mueller
- * @link		http://docs.fuelphp.com/classes/inlector.html
+ * @package     Fuel
+ * @category    Core
+ * @copyright   Flinn Mueller
+ * @link        http://docs.fuelphp.com/classes/inlector.html
  */
 class Inflector
 {
 
+        /**
+         * Array contenting uncountable words
+         * @var array 
+         */
 	protected static $uncountable_words;
 
+        /**
+         * Array contenting singular rules
+         * @var array 
+         */
         protected static $singular_rules;
 	
+        /**
+         *  Array contenting plural rules
+         * @var array 
+         */
         protected static $plural_rules;
-	        
+
 	public static function _init()
 	{
-            \Config::load('inflector', true, false, true);
-            
-            static::$uncountable_words = \Config::get('inflector.uncountable_words');
-            
-            static::$singular_rules = \Config::get('inflector.singular_rules');
-            
-            static::$plural_rules = \Config::get('inflector.plural_rules');
-
+                \Config::load('inflector', true, false, true);
+                static::$uncountable_words = \Config::get('inflector.uncountable_words');
+                static::$singular_rules    = \Config::get('inflector.singular_rules');
+                static::$plural_rules      = \Config::get('inflector.plural_rules');
   	}
 
 	/**

--- a/classes/inflector.php
+++ b/classes/inflector.php
@@ -23,63 +23,23 @@ namespace Fuel\Core;
 class Inflector
 {
 
-	protected static $uncountable_words = array(
-		'equipment', 'information', 'rice', 'money',
-		'species', 'series', 'fish', 'meta'
-	);
+	protected static $uncountable_words;
 
-	protected static $plural_rules = array(
-		'/^(ox)$/i'                 => '\1\2en',     // ox
-		'/([m|l])ouse$/i'           => '\1ice',      // mouse, louse
-		'/(matr|vert|ind)ix|ex$/i'  => '\1ices',     // matrix, vertex, index
-		'/(x|ch|ss|sh)$/i'          => '\1es',       // search, switch, fix, box, process, address
-		'/([^aeiouy]|qu)y$/i'       => '\1ies',      // query, ability, agency
-		'/(hive)$/i'                => '\1s',        // archive, hive
-		'/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',    // half, safe, wife
-		'/sis$/i'                   => 'ses',        // basis, diagnosis
-		'/([ti])um$/i'              => '\1a',        // datum, medium
-		'/(p)erson$/i'              => '\1eople',    // person, salesperson
-		'/(m)an$/i'                 => '\1en',       // man, woman, spokesman
-		'/(c)hild$/i'               => '\1hildren',  // child
-		'/(buffal|tomat)o$/i'       => '\1\2oes',    // buffalo, tomato
-		'/(bu|campu)s$/i'           => '\1\2ses',    // bus, campus
-		'/(alias|status|virus)$/i'  => '\1es',       // alias
-		'/(octop)us$/i'             => '\1i',        // octopus
-		'/(ax|cris|test)is$/i'      => '\1es',       // axis, crisis
-		'/s$/'                     => 's',          // no change (compatibility)
-		'/$/'                      => 's',
-	);
+        protected static $singular_rules;
+	
+        protected static $plural_rules;
+	        
+	public static function _init()
+	{
+            \Config::load('inflector', true, false, true);
+            
+            static::$uncountable_words = \Config::get('inflector.uncountable_words');
+            
+            static::$singular_rules = \Config::get('inflector.singular_rules');
+            
+            static::$plural_rules = \Config::get('inflector.plural_rules');
 
-	protected static $singular_rules = array(
-		'/(matr)ices$/i'         => '\1ix',
-		'/(vert|ind)ices$/i'     => '\1ex',
-		'/^(ox)en/i'             => '\1',
-		'/(alias)es$/i'          => '\1',
-		'/([octop|vir])i$/i'     => '\1us',
-		'/(cris|ax|test)es$/i'   => '\1is',
-		'/(shoe)s$/i'            => '\1',
-		'/(o)es$/i'              => '\1',
-		'/(bus|campus)es$/i'     => '\1',
-		'/([m|l])ice$/i'         => '\1ouse',
-		'/(x|ch|ss|sh)es$/i'     => '\1',
-		'/(m)ovies$/i'           => '\1\2ovie',
-		'/(s)eries$/i'           => '\1\2eries',
-		'/([^aeiouy]|qu)ies$/i'  => '\1y',
-		'/([lr])ves$/i'          => '\1f',
-		'/(tive)s$/i'            => '\1',
-		'/(hive)s$/i'            => '\1',
-		'/([^f])ves$/i'          => '\1fe',
-		'/(^analy)ses$/i'        => '\1sis',
-		'/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
-		'/([ti])a$/i'            => '\1um',
-		'/(p)eople$/i'           => '\1\2erson',
-		'/(m)en$/i'              => '\1an',
-		'/(s)tatuses$/i'         => '\1\2tatus',
-		'/(c)hildren$/i'         => '\1\2hild',
-		'/(n)ews$/i'             => '\1\2ews',
-		'/([^us])s$/i'           => '\1',
-	);
-
+  	}
 
 	/**
 	 * Add order suffix to numbers ex. 1st 2nd 3rd 4th 5th

--- a/config/inflector.php
+++ b/config/inflector.php
@@ -1,0 +1,69 @@
+<?php
+
+
+return array(
+    'uncountable_words' => array(
+        'equipment', 
+        'information', 
+        'rice', 
+        'money',
+        'species', 
+        'series', 
+        'fish', 
+        'meta'
+    ),
+    
+    'singular_rules' => array(
+        '/(matr)ices$/i'         => '\1ix',
+        '/(vert|ind)ices$/i'     => '\1ex',
+        '/^(ox)en/i'             => '\1',
+        '/(alias)es$/i'          => '\1',
+        '/([octop|vir])i$/i'     => '\1us',
+        '/(cris|ax|test)es$/i'   => '\1is',
+        '/(shoe)s$/i'            => '\1',
+        '/(o)es$/i'              => '\1',
+        '/(bus|campus)es$/i'     => '\1',
+        '/([m|l])ice$/i'         => '\1ouse',
+        '/(x|ch|ss|sh)es$/i'     => '\1',
+        '/(m)ovies$/i'           => '\1\2ovie',
+        '/(s)eries$/i'           => '\1\2eries',
+        '/([^aeiouy]|qu)ies$/i'  => '\1y',
+        '/([lr])ves$/i'          => '\1f',
+        '/(tive)s$/i'            => '\1',
+        '/(hive)s$/i'            => '\1',
+        '/([^f])ves$/i'          => '\1fe',
+        '/(^analy)ses$/i'        => '\1sis',
+        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
+        '/([ti])a$/i'            => '\1um',
+        '/(p)eople$/i'           => '\1\2erson',
+        '/(m)en$/i'              => '\1an',
+        '/(s)tatuses$/i'         => '\1\2tatus',
+        '/(c)hildren$/i'         => '\1\2hild',
+        '/(n)ews$/i'             => '\1\2ews',
+        '/([^us])s$/i'           => '\1',
+    ),	    
+    
+    'plural_rules' => array(        
+        '/^(ox)$/i'                 => '\1\2en',     // ox
+        '/([m|l])ouse$/i'           => '\1ice',      // mouse, louse
+        '/(matr|vert|ind)ix|ex$/i'  => '\1ices',     // matrix, vertex, index
+        '/(x|ch|ss|sh)$/i'          => '\1es',       // search, switch, fix, box, process, address
+        '/([^aeiouy]|qu)y$/i'       => '\1ies',      // query, ability, agency
+        '/(hive)$/i'                => '\1s',        // archive, hive
+        '/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',    // half, safe, wife
+        '/sis$/i'                   => 'ses',        // basis, diagnosis
+        '/([ti])um$/i'              => '\1a',        // datum, medium
+        '/(p)erson$/i'              => '\1eople',    // person, salesperson
+        '/(m)an$/i'                 => '\1en',       // man, woman, spokesman
+        '/(c)hild$/i'               => '\1hildren',  // child
+        '/(buffal|tomat)o$/i'       => '\1\2oes',    // buffalo, tomato
+        '/(bu|campu)s$/i'           => '\1\2ses',    // bus, campus
+        '/(alias|status|virus)$/i'  => '\1es',       // alias
+        '/(octop)us$/i'             => '\1i',        // octopus
+        '/(ax|cris|test)is$/i'      => '\1es',       // axis, crisis
+        '/s$/'                      => 's',          // no change (compatibility)
+        '/$/'                       => 's',
+    ),
+
+);
+

--- a/config/inflector.php
+++ b/config/inflector.php
@@ -1,69 +1,88 @@
 <?php
+/**
+ * Part of the Fuel framework.
+ *
+ * @package    Fuel
+ * @version    1.8
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2014 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+/**
+ * NOTICE:
+ *
+ * If you need to make modifications to the default configuration, copy
+ * this file to your app/config folder, and make them in there.
+ *
+ * This will allow you to upgrade fuel without losing your custom config.
+ */
 
 
 return array(
-    'uncountable_words' => array(
-        'equipment', 
-        'information', 
-        'rice', 
-        'money',
-        'species', 
-        'series', 
-        'fish', 
-        'meta'
-    ),
     
-    'singular_rules' => array(
-        '/(matr)ices$/i'         => '\1ix',
-        '/(vert|ind)ices$/i'     => '\1ex',
-        '/^(ox)en/i'             => '\1',
-        '/(alias)es$/i'          => '\1',
-        '/([octop|vir])i$/i'     => '\1us',
-        '/(cris|ax|test)es$/i'   => '\1is',
-        '/(shoe)s$/i'            => '\1',
-        '/(o)es$/i'              => '\1',
-        '/(bus|campus)es$/i'     => '\1',
-        '/([m|l])ice$/i'         => '\1ouse',
-        '/(x|ch|ss|sh)es$/i'     => '\1',
-        '/(m)ovies$/i'           => '\1\2ovie',
-        '/(s)eries$/i'           => '\1\2eries',
-        '/([^aeiouy]|qu)ies$/i'  => '\1y',
-        '/([lr])ves$/i'          => '\1f',
-        '/(tive)s$/i'            => '\1',
-        '/(hive)s$/i'            => '\1',
-        '/([^f])ves$/i'          => '\1fe',
-        '/(^analy)ses$/i'        => '\1sis',
-        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
-        '/([ti])a$/i'            => '\1um',
-        '/(p)eople$/i'           => '\1\2erson',
-        '/(m)en$/i'              => '\1an',
-        '/(s)tatuses$/i'         => '\1\2tatus',
-        '/(c)hildren$/i'         => '\1\2hild',
-        '/(n)ews$/i'             => '\1\2ews',
-        '/([^us])s$/i'           => '\1',
-    ),	    
+        'uncountable_words' => array(
+                'equipment', 
+                'information', 
+                'rice', 
+                'money',
+                'species', 
+                'series', 
+                'fish', 
+                'meta'
+        ),
     
-    'plural_rules' => array(        
-        '/^(ox)$/i'                 => '\1\2en',     // ox
-        '/([m|l])ouse$/i'           => '\1ice',      // mouse, louse
-        '/(matr|vert|ind)ix|ex$/i'  => '\1ices',     // matrix, vertex, index
-        '/(x|ch|ss|sh)$/i'          => '\1es',       // search, switch, fix, box, process, address
-        '/([^aeiouy]|qu)y$/i'       => '\1ies',      // query, ability, agency
-        '/(hive)$/i'                => '\1s',        // archive, hive
-        '/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',    // half, safe, wife
-        '/sis$/i'                   => 'ses',        // basis, diagnosis
-        '/([ti])um$/i'              => '\1a',        // datum, medium
-        '/(p)erson$/i'              => '\1eople',    // person, salesperson
-        '/(m)an$/i'                 => '\1en',       // man, woman, spokesman
-        '/(c)hild$/i'               => '\1hildren',  // child
-        '/(buffal|tomat)o$/i'       => '\1\2oes',    // buffalo, tomato
-        '/(bu|campu)s$/i'           => '\1\2ses',    // bus, campus
-        '/(alias|status|virus)$/i'  => '\1es',       // alias
-        '/(octop)us$/i'             => '\1i',        // octopus
-        '/(ax|cris|test)is$/i'      => '\1es',       // axis, crisis
-        '/s$/'                      => 's',          // no change (compatibility)
-        '/$/'                       => 's',
-    ),
+        'singular_rules' => array(
+                '/(matr)ices$/i'         => '\1ix',
+                '/(vert|ind)ices$/i'     => '\1ex',
+                '/^(ox)en/i'             => '\1',
+                '/(alias)es$/i'          => '\1',
+                '/([octop|vir])i$/i'     => '\1us',
+                '/(cris|ax|test)es$/i'   => '\1is',
+                '/(shoe)s$/i'            => '\1',
+                '/(o)es$/i'              => '\1',
+                '/(bus|campus)es$/i'     => '\1',
+                '/([m|l])ice$/i'         => '\1ouse',
+                '/(x|ch|ss|sh)es$/i'     => '\1',
+                '/(m)ovies$/i'           => '\1\2ovie',
+                '/(s)eries$/i'           => '\1\2eries',
+                '/([^aeiouy]|qu)ies$/i'  => '\1y',
+                '/([lr])ves$/i'          => '\1f',
+                '/(tive)s$/i'            => '\1',
+                '/(hive)s$/i'            => '\1',
+                '/([^f])ves$/i'          => '\1fe',
+                '/(^analy)ses$/i'        => '\1sis',
+                '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
+                '/([ti])a$/i'            => '\1um',
+                '/(p)eople$/i'           => '\1\2erson',
+                '/(m)en$/i'              => '\1an',
+                '/(s)tatuses$/i'         => '\1\2tatus',
+                '/(c)hildren$/i'         => '\1\2hild',
+                '/(n)ews$/i'             => '\1\2ews',
+                '/([^us])s$/i'           => '\1',
+        ),	    
+    
+        'plural_rules' => array(        
+                '/^(ox)$/i'                 => '\1\2en',     // ox
+                '/([m|l])ouse$/i'           => '\1ice',      // mouse, louse
+                '/(matr|vert|ind)ix|ex$/i'  => '\1ices',     // matrix, vertex, index
+                '/(x|ch|ss|sh)$/i'          => '\1es',       // search, switch, fix, box, process, address
+                '/([^aeiouy]|qu)y$/i'       => '\1ies',      // query, ability, agency
+                '/(hive)$/i'                => '\1s',        // archive, hive
+                '/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',    // half, safe, wife
+                '/sis$/i'                   => 'ses',        // basis, diagnosis
+                '/([ti])um$/i'              => '\1a',        // datum, medium
+                '/(p)erson$/i'              => '\1eople',    // person, salesperson
+                '/(m)an$/i'                 => '\1en',       // man, woman, spokesman
+                '/(c)hild$/i'               => '\1hildren',  // child
+                '/(buffal|tomat)o$/i'       => '\1\2oes',    // buffalo, tomato
+                '/(bu|campu)s$/i'           => '\1\2ses',    // bus, campus
+                '/(alias|status|virus)$/i'  => '\1es',       // alias
+                '/(octop)us$/i'             => '\1i',        // octopus
+                '/(ax|cris|test)is$/i'      => '\1es',       // axis, crisis
+                '/s$/'                      => 's',          // no change (compatibility)
+                '/$/'                       => 's',
+        ),
 
 );
-


### PR DESCRIPTION
I removed Inflector's rules of the array to config file, because in latin language the grammatical rules follow different patterns and today I can't change this values.

Thus, the core stayed more flexible.
