### PR TITLE
Fix passing db connection name to methods of DB class in dbutil

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -342,7 +342,7 @@ class DBUtil
 				$_prefix = 'CHANGE ';
 			}
 			$sql = "\n\t".$_prefix;
-			$sql .= \DB::quote_identifier($field);
+			$sql .= \DB::quote_identifier($field, $db ? $db : static::$connection);
 			$sql .= (array_key_exists('NAME', $attr) and $attr['NAME'] !== $field) ? ' '.\DB::quote_identifier($attr['NAME'], $db ? $db : static::$connection).' ' : '';
 			$sql .= array_key_exists('TYPE', $attr) ? ' '.$attr['TYPE'] : '';
 
@@ -372,7 +372,7 @@ class DBUtil
 
 			if(array_key_exists('DEFAULT', $attr))
 			{
-				$sql .= ' DEFAULT '.(($attr['DEFAULT'] instanceof \Database_Expression) ? $attr['DEFAULT']  : \DB::quote($attr['DEFAULT']));
+				$sql .= ' DEFAULT '.(($attr['DEFAULT'] instanceof \Database_Expression) ? $attr['DEFAULT']  : \DB::quote($attr['DEFAULT'], $db ? $db : static::$connection));
 			}
 
 			if(array_key_exists('NULL', $attr) and $attr['NULL'] === true)


### PR DESCRIPTION
fc8111e is small commit that is runned in my application.
d6febcf is large commit. This looks like to be corrected by following other. But it have not been runned even once.

Please choose to take only fc8111e or both.
You can take only fc8111e or both.

If this merged close #1767
