### PR TITLE
[bugfix] Fieldset->delete isset/unset correct instance value

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -391,9 +391,9 @@ class Fieldset
 	 */
 	public function delete($name)
 	{
-		if (isset($this->field[$name]))
+		if (isset($this->fields[$name]))
 		{
-			unset($this->field[$name]);
+			unset($this->fields[$name]);
 		}
 
 		return $this;


### PR DESCRIPTION
hi

I try to `delete` function, remove Fieldset_Field instance from the Fieldset, but can't.
I think, Fieldset class have not `$field` but `$fields`.

thanks.
