### PR TITLE
variable 'namespaced' is never used

### DIFF
--- a/classes/autoloader.php
+++ b/classes/autoloader.php
@@ -224,7 +224,6 @@ class Autoloader
 
 		$loaded = false;
 		$class = ltrim($class, '\\');
-		$namespaced = ($pos = strripos($class, '\\')) !== false;
 
 		if (empty(static::$auto_initialize))
 		{


### PR DESCRIPTION
The variable $namespaced in load method seems to be unused.
