### PR TITLE
Update XML boolean format.

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -136,9 +136,10 @@ class Format
 	 * @param   null         $structure
 	 * @param   null|string  $basenode
 	 * @param   null|bool    whether to use CDATA in nodes
+	 * @param   mixed        if true, element values are true/false. if 1, 1/0.
 	 * @return  string
 	 */
-	public function to_xml($data = null, $structure = null, $basenode = null, $use_cdata = null)
+	public function to_xml($data = null, $structure = null, $basenode = null, $use_cdata = null, $bool_representation = null)
 	{
 		if ($data == null)
 		{
@@ -147,6 +148,7 @@ class Format
 
 		is_null($basenode) and $basenode = \Config::get('format.xml.basenode', 'xml');
 		is_null($use_cdata) and $use_cdata = \Config::get('format.xml.use_cdata', false);
+		is_null($bool_representation) and $bool_representation = \Config::get('format.xml.bool_representation', null);
 
 		// turn off compatibility mode as simple xml throws a wobbly if you don't.
 		if (ini_get('zend.ze1_compatibility_mode') == 1)
@@ -185,10 +187,21 @@ class Format
 				// recursive call if value is not empty
 				if( ! empty($value))
 				{
-					$this->to_xml($value, $node, $key, $use_cdata);
+					$this->to_xml($value, $node, $key, $use_cdata, $bool_representation);
 				}
 			}
-
+			elseif ($bool_representation and is_bool($value))
+			{
+				if ($bool_representation === true)
+				{
+					$bool = $value ? 'true' : 'false';
+				}
+				else
+				{
+					$bool = $value ? '1' : '0';
+				}
+				$structure->addChild($key, $bool);
+			}
 			else
 			{
 				// add single node.

--- a/config/format.php
+++ b/config/format.php
@@ -39,6 +39,7 @@ return array(
 	'xml' => array(
 		'basenode' => 'xml',
 		'use_cdata' => false,
+		'bool_representation' => null,
 	),
 	'json' => array(
 		'encode' => array(

--- a/tests/format.php
+++ b/tests/format.php
@@ -43,6 +43,7 @@ class Test_Format extends TestCase
 			'xml' => array(
 				'basenode' => 'xml',
 				'use_cdata' => false,
+				'bool_representation' => null,
 			),
 			'json' => array(
 				'encode' => array(
@@ -109,6 +110,26 @@ John;Doe;john@doe.com;52939494;1;dfdfdf;35353',
 				'"Value 1","35","123123"
 "Value 1","Value
 line 2","Value 3"',
+			),
+		);
+	}
+
+	public static function array_provider5()
+	{
+		return array(
+			array(
+				array(
+					array('field1' => 'Value 1', 'field2' => 35, 'field3' => true, 'field4' => false),
+				),
+				'<?xml version="1.0" encoding="utf-8"?>
+<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4/></item></xml>
+',
+				'<?xml version="1.0" encoding="utf-8"?>
+<xml><item><field1>Value 1</field1><field2>35</field2><field3>true</field3><field4>false</field4></item></xml>
+',
+				'<?xml version="1.0" encoding="utf-8"?>
+<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4>0</field4></item></xml>
+',
 			),
 		);
 	}
@@ -381,6 +402,22 @@ line 2","Value 3"',
 ';
 
 		$this->assertEquals($expected, Format::forge($array)->to_xml());
+	}
+
+	/**
+	 * Test for Format::forge($foo)->to_xml(null, null, null, null, true)
+	 *
+	 * @test
+	 * @dataProvider array_provider5
+	 */
+	public function test_to_xml_boolean($array, $default, $true, $number)
+	{
+		// default
+		$this->assertEquals($default, Format::forge($array)->to_xml());
+		// true/false
+		$this->assertEquals($true, Format::forge($array)->to_xml(null, null, null, null, true));
+		// 1/0
+		$this->assertEquals($number, Format::forge($array)->to_xml(null, null, null, null, 1));
 	}
 
 	/**


### PR DESCRIPTION
## XML Schema

http://www.w3.org/TR/xmlschema-2/#boolean

> An instance of a datatype that is defined as ·boolean· can have the following legal literals {true, false, 1, 0}.
## FuelPHP behaviour

``` php
array('true' => true, 'false' => false)
```
### current format

``` xml
<xml><true>1</true><false/></xml>
```

`false` is formatted to empty string.
It's PHP type casting works.
http://php.net/manual/en/language.types.string.php#language.types.string.casting
### new format

I add `bool_representation` option to change XML outputs.

If `bool_representation` is 
`true`:

``` xml
<xml><true>true</true><false>false</false></xml>
```

`1`:

``` xml
<xml><true>1</true><false>0</false></xml>
```

false value, such as `null`:

``` xml
<xml><true>1</true><false/></xml>
```

Signed-off-by: Haruaki Otake aaharu@hotmail.com
