### PR TITLE
Fix enclose_numbers config

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -227,7 +227,7 @@ class Format
 		$delimiter or $delimiter = \Config::get('format.csv.delimiter', \Config::get('format.csv.export.delimiter', ','));
 		$enclosure = \Config::get('format.csv.enclosure', \Config::get('format.csv.export.enclosure', '"'));
 		$escape = \Config::get('format.csv.escape', \Config::get('format.csv.export.escape', '\\'));
-		is_null($enclose_numbers) and $enclose_numbers = \Config::get('format.csv.delimit_numbers',  true);
+		is_null($enclose_numbers) and $enclose_numbers = \Config::get('format.csv.enclose_numbers', true);
 
 		// escape, delimit and enclose function
 		$escaper = function($items, $enclose_numbers) use($enclosure, $escape, $delimiter) {

--- a/tests/format.php
+++ b/tests/format.php
@@ -179,7 +179,7 @@ line 2","Value 3"',
 	}
 
 	/**
-	 * Test for Format::forge($foo)->to_csv() without delimiting numbers
+	 * Test for Format::forge($foo)->to_csv() without enclosuring numbers
 	 *
 	 * @test
 	 * @dataProvider array_provider2


### PR DESCRIPTION
[doc](http://www.fuelphp.com/docs/classes/format.html) and [config](https://github.com/fuel/core/blob/22c047ff7a9418a7043f41dfba8611c98f174797/config/format.php#L37) are `enclose_numbers`.
But, `delimit_numbers` in `to_csv()`.

Signed-off-by: Haruaki Otake aaharu@hotmail.com
