### PR TITLE
fix soap execute & parameters

### DIFF
--- a/classes/request/soap.php
+++ b/classes/request/soap.php
@@ -128,7 +128,7 @@ class Request_Soap extends \Request_Driver
 		// Execute the request & and hide all output
 		try
 		{
-			$body = $this->connection()->__soapCall($this->function, $this->params, array(), $this->get_headers(), $headers);
+			$body = $this->connection()->__soapCall($this->function, array('parameters' => $this->params), array(), $this->get_headers(), $headers);
 			$this->response_info = $headers;
 
 			$mime = $this->response_info('content_type', 'application/soap+xml');


### PR DESCRIPTION
It seems the `__soapCall` method expects the parameters to be wrapped in an array with 'parameters' as its key. It's mentioned in the comments at http://php.net/manual/en/soapclient.soapcall.php

With this update, the Soap service at http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl worked for me.
