### PR TITLE
Removed the need for the validation request method to be post

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -329,7 +329,7 @@ class Validation
 	 */
 	public function run($input = null, $allow_partial = false, $temp_callables = array())
 	{
-		if (is_null($input) and \Input::method() != 'POST')
+		if (is_null($input))
 		{
 			return false;
 		}


### PR DESCRIPTION
I was having a problem when using the validate function in a sub-request which used a custom request method.

When creating a new request with a different method, the Input::method() will always return the newly defined method inside that request, rather than GET, POST or ACTION causing this function to return false, making validating impossible.

Removing this solves that problem, and doesn't appear to cause any problems that I can see. Please, correct me if I'm wrong?
