### PR TITLE
enable create table in sqlite3

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -123,7 +123,17 @@ class DBUtil
 		{
 			$key_name = \DB::quote_identifier(implode('_', $primary_keys), $db ? $db : static::$connection);
 			$primary_keys = \DB::quote_identifier($primary_keys, $db ? $db : static::$connection);
-			$sql .= ",\n\tPRIMARY KEY ".$key_name." (" . implode(', ', $primary_keys) . ")";
+			$sql .= ",\n\tPRIMARY KEY ";
+			if (strtolower(\Config::get('db.'.($db ? $db : \Config::get('db.active')).'.type')) === 'pdo')
+			{
+				$dsn = \Config::get('db.'.($db ? $db : \Config::get('db.active')).'.connection.dsn');
+				$_dsn_find_collon = strpos($dsn, ':');
+				if (($_dsn_find_collon ? substr($dsn, 0, $_dsn_find_collon) : null) !== 'sqlite')
+				{
+					$sql .= $key_name;
+				}
+			}
+			$sql .= $key_name." (" . implode(', ', $primary_keys) . ")";
 		}
 
 		empty($foreign_keys) or $sql .= static::process_foreign_keys($foreign_keys, $db);


### PR DESCRIPTION
Modified classes/dbutil.php to enable create table in sqlite3.
Previous code can't create table with primary index in sqlite3,
because previous code generate

``` sql
PRIMARY KEY 'id' ('id')
```

but sqlite3 supports

``` sql
PRIMARY KEY ('id')
```

I used config/db.php setting string to check whether the database is sqlite3.

The following code using `Database_Connection` is another way to do it.

``` php
$sql .= ",\n\tPRIMARY KEY ";
if (strtolower(\Config::get('db.'.($db ? $db : \Config::get('db.active')).'.type')) === 'pdo')
{
  if (strtolower(\Database_Connection::instance($db)->driver_name()) !== 'sqlite')
  {
    $sql .= $key_name;
  }
}
$sql .= $key_name." (" . implode(', ', $primary_keys) . ")";
```
