### PR TITLE
Allow look up headers in a case-insensitive way

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -513,7 +513,7 @@ class Input
 			}
 		}
 
-		return empty($headers) ? $default : ((func_num_args() === 0) ? $headers : \Arr::get($headers, $index, $default));
+		return empty($headers) ? $default : ((func_num_args() === 0) ? $headers : \Arr::get(array_change_key_case($headers), strtolower($index), $default));
 	}
 
 	/**


### PR DESCRIPTION
nginx may use lowercase response headers and that’s ok according to [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.
