### PR TITLE
Fix passing arg to process_charset() in DBUtil::process_fields()

### DIFF
--- a/classes/dbutil.php
+++ b/classes/dbutil.php
@@ -380,7 +380,7 @@ class DBUtil
 				}
 			}
 
-			$sql .= array_key_exists('CHARSET', $attr) ? static::process_charset($attr['CHARSET'], $db) : '';
+			$sql .= array_key_exists('CHARSET', $attr) ? static::process_charset($attr['CHARSET'], false, $db) : '';
 
 			if (array_key_exists('UNSIGNED', $attr) and $attr['UNSIGNED'] === true)
 			{


### PR DESCRIPTION
## What I did

``` php
DBUtil::create_table('foo', [
// snip
    'some_column' => ['type' => 'varchar', 'constraint' => 255, 'charset' => 'utf8_bin'],
], ['id']);
```
## Expected sql fragment

``` sql
`some_column` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL
```
## What I got

``` sql
`some_column` varchar(255)DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_bin NOT NULL
```
