### PR TITLE
Discard Database_Connection instance on disconnect for mysqli

### DIFF
--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -183,6 +183,11 @@ class Database_MySQLi_Connection extends \Database_Connection
 			// Database is probably not disconnected
 			$status = ! ($this->_connection instanceof \MySQLi);
 		}
+		if($status)
+		{
+			unset(self::$instances[$this->_instance]);
+			unset(static::$_readonly[$this->_instance]);
+		}
 
 		return $status;
 	}


### PR DESCRIPTION
## What I did

``` php
$db = \Database_Connection::instance('my_db_setting');
$this->assertEquals(true, $db->start_transaction());
\DB::query('SELECT 1;')->execute($db);
$this->assertEquals(true, $db->disconnect());
$db = \Database_Connection::instance('my_db_setting');
\DB::query('SELECT 2;')->execute($db); // <- /path/to/fuel/app/tests/foo.php:13
$this->assertEquals(true, $db->start_transaction());
```

Note that I have used mysqli. (`'type' => 'mysqli'` on config/db.php)
## What I got

> Fuel\Core\PhpErrorException: mysqli::ping(): Couldn't fetch mysqli
> 
> /path/to/fuel/core/bootstrap.php:109
> /path/to/fuel/core/classes/database/mysqli/connection.php:205
> /path/to/fuel/core/classes/database/query.php:287
> /path/to/fuel/app/tests/foo.php:13

Because `$this->_connection` has mysqli object already [`mysqli::close()`](http://jp2.php.net/manual/en/mysqli.close.php) called after `disconnect()`.
mysqli object does not have connection status nor method for reconnect.
## Detail

At first I try to replace `$status = $this->_connection->close();` with `$this->_connection = null;` to be reconnected on `execute()`.

```
150313  6:08:56   166 Connect   foo@localhost on test_foo
          166 Query SET NAMES utf8
          166 Query START TRANSACTION
          166 Query SELECT 1
          166 Quit
          167 Connect   foo@localhost on test_foo
          167 Query SET NAMES utf8
          167 Query SELECT 2
          167 Query SAVEPOINT LEVEL1
          167 Quit
```

However Database_Connection object has state of transaction.
There is `SAVEPOINT LEVEL1` instead of `START TRANSACTION` in MySQL general log avobe.

I think it is better to recreate object than to control state of object carefully.

```
150313  6:05:43   160 Connect   foo@localhost on test_foo
          160 Query SET NAMES utf8
          160 Query START TRANSACTION
          160 Query SELECT 1
          160 Quit
          161 Connect   foo@localhost on test_foo
          161 Query SET NAMES utf8
          161 Query SELECT 2
          161 Query START TRANSACTION
          161 Quit
```

This is general log with code in this pull request.
