### PR TITLE
fixed bug: indexed param gets lost on recursion

### DIFF
--- a/classes/arr.php
+++ b/classes/arr.php
@@ -327,7 +327,7 @@ class Arr
 			$curr_key[] = $key;
 			if (is_array($val) and ($indexed or array_values($val) !== $val))
 			{
-				static::flatten_assoc($val, $glue, false);
+				static::flatten($val, $glue, false, $indexed);
 			}
 			else
 			{

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -323,6 +323,49 @@ class Test_Arr extends TestCase
 	}
 
 	/**
+	 * Tests Arr::flatten_assoc() with recursive arrays
+	 *
+	 * @test
+	 */
+	public function test_flatten_recursive_index()
+	{
+		$people = array(
+			array(
+				"name" => "Jack",
+				"age" => 21,
+				"children" => array(
+					array(
+						"name" => "Johnny",
+						"age" => 4,
+					),
+					array(
+						"name" => "Jimmy",
+						"age" => 3,
+					)
+				)
+			),
+			array(
+				"name" => "Jill",
+				"age" => 23
+			)
+		);
+
+		$expected = array(
+			"0:name" => "Jack",
+			"0:age" => 21,
+			"0:children:0:name" => "Johnny",
+			"0:children:0:age" => 4,
+			"0:children:1:name" => "Jimmy",
+			"0:children:1:age" => 3,
+			"1:name" => "Jill",
+			"1:age" => 23
+		);
+
+		$output = Arr::flatten($people, ':');
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
 	 * Tests Arr::merge_assoc()
 	 *
 	 * @test


### PR DESCRIPTION
Recursive arrays where sub-arrays have indexed columns were getting ignored even if the $indexed parameter was set to true.  Also recursed on static::flatten as calling static::flatten_assoc was a straight pass through and unnecessary.
