### PR TITLE
Remove ORDER BY from sql count_last_query

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -254,7 +254,7 @@ abstract class Database_Connection
 			if (stripos($sql, 'ORDER BY') !== false)
 			{
 				// Remove ORDER BY from the SQL to improve performacnce
-				$sql = preg_replace('/ORDER BY.*?(?=\\)|$)/mi', '', $sql);
+				$sql = preg_replace('/ORDER BY [^,\s)]*(?:\s*,\s*[^,\s)]+)*/mi', '', $sql);
 			}
 
 			// Get the total rows from the last query executed

--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -250,6 +250,12 @@ abstract class Database_Connection
 				// Remove OFFSET from the SQL
 				$sql = preg_replace('/\sOFFSET\s+\d+/i', '', $sql);
 			}
+			
+			if (stripos($sql, 'ORDER BY') !== false)
+			{
+				// Remove ORDER BY from the SQL to improve performacnce
+				$sql = preg_replace('/ORDER BY.*?(?=\\)|$)/mi', '', $sql);
+			}
 
 			// Get the total rows from the last query executed
 			$result = $this->query


### PR DESCRIPTION
Since we don't need "ORDER BY" on count statements and its slows down some queries, we can remove it
