### PR TITLE
File::create_dir : Use name of directory instead of basepath to handle symbolic links

### DIFF
--- a/classes/file.php
+++ b/classes/file.php
@@ -175,7 +175,7 @@ class File
 		}
 
 		// unify the path separators, and get the part we need to add to the basepath
-		$new_dir = substr(str_replace(array('\\', '/'), DS, $new_dir), strlen($basepath));
+		$new_dir = substr(str_replace(array('\\', '/'), DS, $new_dir), strpos($new_dir, $name));
 
 		// recursively create the directory. we can't use mkdir permissions or recursive
 		// due to the fact that mkdir is restricted by the current users umask


### PR DESCRIPTION
If we try to create a directory with any symbolic link in the $name path, the $basepath can be different from static::instance($area)->get_path() path.

eg. :

```
 /data/with/a/long/path/link -> /dev/link_container
```

``` php
File::create_dir("/data/with/a/long/path/", "link/child"); // Will fail
```

With this modification we use the name of the created folder to create the substring instead of the basepath for creating our directories.
