### PR TITLE
Added support to Controller_Rest for additional headers in response

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -170,15 +170,23 @@ abstract class Controller_Rest extends \Controller
 	 *
 	 * @param   mixed
 	 * @param   int
+     * @param   array
 	 * @return  object  Response instance
 	 */
-	protected function response($data = array(), $http_status = null)
+	protected function response($data = array(), $http_status = 200, $headers = array())
 	{
 		// set the correct response header
 		if (method_exists('Format', 'to_'.$this->format))
 		{
 			$this->response->set_header('Content-Type', $this->_supported_formats[$this->format]);
 		}
+
+        // set additional headers as defined by $headers
+        if (!empty($headers)) {
+            foreach ($headers as $header => $value) {
+                $this->response->set_header($header, $value);
+            }
+        }
 
 		// no data returned?
 		if ((is_array($data) and empty($data)) or ($data == ''))


### PR DESCRIPTION
Signed-off-by: Andrew Heebner andrew.heebner@gmail.com

Simply put, I needed a quick option to add additional headers to the output of response().  Added a quick additional parameter to response(), as well as a quick loop to set the headers.

This was required by myself for rate-limiting, and access control headers.  Figured it could be handy for other users as well, rather than working around the response to set the headers.

Also updated `$status` to default to a 200 OK.  You technically can't return a null HTTP status code, so this ensures that something (valid) is at least returned.
