### PR TITLE
Fix issue if path is symlink in File_Area:get_path

### DIFF
--- a/classes/file/area.php
+++ b/classes/file/area.php
@@ -143,6 +143,13 @@ class File_Area
 		// make sure we have a dirname to work with
 		isset($pathinfo['dirname']) or $pathinfo['dirname'] = '';
 
+		//Make sure dirname path is realpath (symlink?)
+		$dirname_realpath = realpath($pathinfo['dirname']);
+		if ( $dirnameRealpath != $pathinfo['dirname'] )
+		{
+			$pathinfo['dirname'] = $dirnameRealpath;
+		}
+
 		// do we have a basedir, and is the path already prefixed by the basedir? then just deal with the double dots...
 		if ( ! empty($this->basedir) && substr($pathinfo['dirname'], 0, strlen($this->basedir)) == $this->basedir)
 		{


### PR DESCRIPTION
My app/tmp folder is symlinked to a folder outside the root, as I use a deployment system. When ever I tried to do File::download it would tell me file not found. 

I am using an Area restricted to `APPPATH.'tmp'`and downloading a file using `File::download`, but the `File_Are::get_path` would return a long path which included path of the area concatenated with path of the file Im downloading

ie. `/var/www/shared/fuel/app/tmp/var/www/release/xxxxxxx/fuel/app/tmp/download.zip`

So I quickly thought this would resolve the issue.
