### PR TITLE
add support for random_bytes and openssl_random_pseudo_bytes

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -333,7 +333,15 @@ class Security
 	 */
 	public static function generate_token()
 	{
-		$token_base = time() . uniqid() . \Config::get('security.token_salt', '') . mt_rand(0, mt_getrandmax());
+
+		if (function_exists('random_bytes')) {
+			$token_base = \Config::get('security.token_salt', '') . random_bytes(32);
+		} else if (function_exists('openssl_random_pseudo_bytes')) {
+			$token_base = \Config::get('security.token_salt', '') . openssl_random_pseudo_bytes(32);
+		} else {
+			$token_base = time() . uniqid() . \Config::get('security.token_salt', '') . mt_rand(0, mt_getrandmax());
+		}
+
 		if (function_exists('hash_algos') and in_array('sha512', hash_algos()))
 		{
 			$token = hash('sha512', $token_base);


### PR DESCRIPTION
`openssl_random_pseudo_bytes` is better than `mt_rand` in randomness and adopted by various projects such as Symfony Security component, Laravel.
`random_bytes` can be used in PHP 7.0 alpha. I didn't see any issue in the [result](https://gist.github.com/masakielastic/76ec50728d259626cf14) of benchmark.
