### PR TITLE
Fix valid_date function

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -1045,7 +1045,7 @@ class Validation
 		{
 			if ($format)
 			{
-				return date($format, mktime($parsed['hour'], $parsed['minute'], $parsed['second'], $parsed['month'], $parsed['day'], $parsed['year']));
+				return date($format, mktime($parsed['hour'], $parsed['minute'], $parsed['second'], $parsed['month'] ?: 1, $parsed['day'] ?: 1, $parsed['year']));
 			}
 			else
 			{


### PR DESCRIPTION
When validate date format values such as 'Y' or 'Y-m' using 'valid_date' the validated value changes from before validation.

**Example**
input value: 2015-07
validated value: 2015-06

``` php
$val = Validation::forge();
$val->add('date_format_value', '')->add_rule('valid_date', 'Y-m');   // 2015-07 
$val->run();
$validated_input = $val->validated();
echo $validated_input['date_format_value'];  // 2015-06
```

Signed-off-by: Kazufumi Suenaga kzfms07@gmail.com
