### PR TITLE
Fix format.php (data format is invalid)

### DIFF
--- a/tests/format.php
+++ b/tests/format.php
@@ -122,7 +122,7 @@ line 2","Value 3"',
 					array('field1' => 'Value 1', 'field2' => 35, 'field3' => true, 'field4' => false),
 				),
 				'<?xml version="1.0" encoding="utf-8"?>
-<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4/></item></xml>
+<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4></field4></item></xml>
 ',
 				'<?xml version="1.0" encoding="utf-8"?>
 <xml><item><field1>Value 1</field1><field2>35</field2><field3>true</field3><field4>false</field4></item></xml>


### PR DESCRIPTION
When I exec `php oil test`, following error occured.
I thought that provided xml data format of `<field4>` is invalid.

```
1) Fuel\Core\Test_Format::test_to_xml_boolean with data set #0 (array(array('Value 1', 35, true, false)), '<?xml version="1.0" encoding=.../xml>\n', '<?xml version="1.0" encoding=.../xml>\n', '<?xml version="1.0" encoding=.../xml>\n')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?xml version="1.0" encoding="utf-8"?>
-<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4/></item></xml>
+<xml><item><field1>Value 1</field1><field2>35</field2><field3>1</field3><field4></field4></item></xml>
 '

/home/vagrant/chachat/fuel/core/tests/format.php:414

FAILURES!
Tests: 389, Assertions: 481, Failures: 1.
```
