### PR TITLE
replace escaped wildcard from #1959

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -319,7 +319,7 @@ abstract class Controller_Rest extends \Controller
 			});
 
 			// Check each of the acceptable formats against the supported formats
-			$find = array('*', '/');
+			$find = array('\*', '/');
 			$replace = array('.*', '\/');
 			foreach ($acceptable as $pattern => $quality)
 			{


### PR DESCRIPTION
The str_replace is now performed after a preg_quote so the \* will be escaped. Ref #1959 
