### PR TITLE
Add guard clause for create_function

### DIFF
--- a/classes/debug.php
+++ b/classes/debug.php
@@ -313,8 +313,8 @@ JS;
 	 */
 	public static function file_lines($filepath, $line_num, $highlight = true, $padding = 5)
 	{
-		// deal with eval'd code
-		if (strpos($filepath, 'eval()\'d code') !== false)
+		// deal with eval'd code and runtime-created function
+		if (strpos($filepath, 'eval()\'d code') !== false or strpos($filepath, 'runtime-created function') !== false)
 		{
 			return '';
 		}


### PR DESCRIPTION
[create_function](http://php.net/manual/en/function.create-function.php) is similar to eval when an error occurs. So added guard clause.

```
$ cat /tmp/sample.php
<?php
set_error_handler(function ($no, $srt, $file) {
  echo $file, PHP_EOL;
});

$fun = create_function('', 'echo $undef;');
$fun();

eval('echo $undef;');

echo $undef;
```

```
$ php /tmp/sample.php
/tmp/sample.php(6) : runtime-created function
/tmp/sample.php(9) : eval()'d code
/tmp/sample.php
```
