### PR TITLE
Fix config to not cache closure results

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -192,14 +192,15 @@ class Config
 		}
 		elseif ( ! isset(static::$itemcache[$item]))
 		{
-			$val = \Fuel::value(\Arr::get(static::$items, $item, static::$default_check_value));
+			$raw_val = \Arr::get(static::$items, $item, static::$default_check_value);
+			$val = \Fuel::value($raw_val);
 
-			if ($val === static::$default_check_value)
+			if ($raw_val === static::$default_check_value)
 			{
 				return $default;
 			}
 
-			if ( ! is_scalar($val))
+			if ( ! is_scalar($raw_val))
 			{
 				return $val;
 			}


### PR DESCRIPTION
A closure can only be used as a config value in a php config file, so this could be moved to classes/config/php.php, but that would make it basically a duplication of code.

This changes the check for whether to skip caching to be done on the raw value from config, rather than the value parsed by Fuel::value(), so as to also catch closures being returned.

This fix means that with the use of closures for config options we are running the closure every time the config option is retrieved which could slow down code, however it means that a closure can be used to generate different results each time it is called. For example a closure as a config option to generate tokens which you don't want to be the same every time.
