### PR TITLE
Bugfix config get

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -199,7 +199,7 @@ class Config
 			static::$itemcache[$item] = $val;
 		}
 
-		return static::$itemcache[$item];
+		return \Fuel::value(static::$itemcache[$item]);
 	}
 
 	/**

--- a/classes/config.php
+++ b/classes/config.php
@@ -179,11 +179,11 @@ class Config
 	 */
 	public static function get($item, $default = null)
 	{
-		if (isset(static::$items[$item]))
+		if (array_key_exists($item, static::$items))
 		{
 			return static::$items[$item];
 		}
-		elseif ( ! isset(static::$itemcache[$item]))
+		elseif ( ! array_key_exists($item, static::$itemcache))
 		{
 			// cook up something unique
 			$miss = new \stdClass();


### PR DESCRIPTION
Use of `array_key_exists` rather than `isset` allows for null as a valid (positive) value, which is the point of using `$miss`.

Also added back in the `Fuel::value()` wrapped around the return value to fix a break in backwards compatibility. Now done after the value has been cached so that config options which are closures can be cached but can also provide different values on subsequent calls.
