### PR TITLE
Fix call to inaccessible protected method within PhpErrorException class.

### DIFF
--- a/classes/errorhandler.php
+++ b/classes/errorhandler.php
@@ -34,7 +34,7 @@ class PhpErrorException extends \ErrorException
 			if (\Fuel::$env != \Fuel::PRODUCTION and ($this->code & error_reporting()) == $this->code)
 			{
 				static::$count++;
-				\Errorhandler::show_php_error(new \ErrorException($this->message, $this->code, 0, $this->file, $this->line));
+				\Errorhandler::exception_handler(new \ErrorException($this->message, $this->code, 0, $this->file, $this->line));
 			}
 		}
 		elseif (\Fuel::$env != \Fuel::PRODUCTION


### PR DESCRIPTION
The `PhpErrorException` class currently calls a protected static method on the `ErrorHandler` class which is not directly accessible. If we made the protected function public, PHP errors generated here would be displayed even in Production environments. We do not want this, thus we are calling the public `exception_handler` method instead.
