### PR TITLE
The Read Preferences option of mongoDB driver to be set from the Config

### DIFF
--- a/classes/mongo/db.php
+++ b/classes/mongo/db.php
@@ -155,6 +155,11 @@ class Mongo_Db
 		{
 			$options['replicaSet'] = $config['replicaset'];
 		}
+		
+		if ( ! empty($config['readPreference']))
+		{
+			$options['readPreference'] = $config['readPreference'];
+		}
 
 		$connection_string = "mongodb://";
 


### PR DESCRIPTION
The Read Preferences option of mongoDB driver to be set from the Config.

http://php.net/manual/en/mongo.readpreferences.php

For example,
/fuel/app/config/db.php

> 'mongo' => array(
>       'default' => array(
>                   'hostname'   => 'db1,db2,db3',
>                   'database'   => 'test',
>                   'replicaset' => 'myrep',
>                   'readPreference' => \MongoClient::RP_PRIMARY_PREFERRED
>                ),
>     ),
