### PR TITLE
SQL statements use brackets

### DIFF
--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -271,7 +271,7 @@ class Database_Query
 		if (is_null($this->_type))
 		{
 			// get the SQL statement type without having to duplicate the entire statement
-			$stmt = preg_split("/[\s]+/", substr($sql, 0, 10), 2);
+			$stmt = preg_split("/[\s]+/", substr(ltrim($sql, '('), 0, 10), 2);
 			switch(strtoupper(reset($stmt)))
 			{
 				case 'DESCRIBE':

--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -271,7 +271,7 @@ class Database_Query
 		if (is_null($this->_type))
 		{
 			// get the SQL statement type without having to duplicate the entire statement
-			$stmt = preg_split("/[\s]+/", substr(ltrim($sql, '('), 0, 10), 2);
+			$stmt = preg_split('/[\s]+/', ltrim(substr($sql, 0, 11), '('), 2);
 			switch(strtoupper(reset($stmt)))
 			{
 				case 'DESCRIBE':


### PR DESCRIPTION
fuelphp1.7, can use brackets for SQL statements.
But it doesn't work for above fuelphp1.8.

ex. (SELECT foo, ...) union (SELECT bar, ...)

https://github.com/fuel/core/commit/646240c631daa51777d0734ec61a348894c8a0ff#diff-30fb281dc6c1d9fc15067b17b7e3ac7cL273

This is repair commit for 1.9/develop.
And cherry-pick to 1.8/master please.
