### PR TITLE
fix Assets always_resolve ignoring absolute url

### DIFF
--- a/classes/asset/instance.php
+++ b/classes/asset/instance.php
@@ -392,7 +392,7 @@ class Asset_Instance
 			}
 
 			// only do a file search if the asset is not a URI
-			if ($this->_always_resolve or ! preg_match('|^(\w+:)?//|', $filename))
+			if ( ! preg_match('|^(\w+:)?//|', $filename))
 			{
 				// and only if the asset is local to the applications base_url
 				if ($this->_always_resolve or ! preg_match('|^(\w+:)?//|', $this->_asset_url) or strpos($this->_asset_url, \Config::get('base_url')) === 0)


### PR DESCRIPTION
Assets config "always_resolve" exactly always resolve, even if filename is absolute.

```
  // setting my Asset URL to 'http://static.example.org/' and always_resolve = true,
  echo Asset::img('icons/myicon.png');  // resolved.
  echo Asset::img('https://www.google.co.jp/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png');  // resolved: always error "Could not find asset"
```

I think it is unexpected.
I'm sorry if I'm mistaken.
