### PR TITLE
Request class should ignore Content-Type header's attributes

### DIFF
--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -355,6 +355,9 @@ abstract class Request_Driver
 	 */
 	public function set_response($body, $status, $mime = null, $headers = array(), $accept_header = null)
 	{
+		// Strip attribs from mime type to avoid over-specific matching
+		$mime = strstr($mime, ';', true) ?: $mime;
+
 		// did we use an accept header? If so, validate the returned mimetype
 		if ( ! $this->mime_in_header($mime, $accept_header))
 		{

--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -361,7 +361,7 @@ abstract class Request_Driver
 		// did we use an accept header? If so, validate the returned mimetype
 		if ( ! $this->mime_in_header($mime, $accept_header))
 		{
-			throw new \OutOfRangeException('The mimetype "'.$mime.'" of the returned response is not acceptable according to the accept header send.');
+			throw new \OutOfRangeException('The mimetype "'.$mime.'" of the returned response is not acceptable according to the accept header sent.');
 		}
 
 		// do we have auto formatting enabled and can we format this mime type?

--- a/tests/request.php
+++ b/tests/request.php
@@ -60,6 +60,7 @@ class Test_Request extends TestCase
 			['application/json', '["x",1,2]', 'application/*', ['x', 1, 2]],
 			['application/json', '[]', 'application/json', []],
 			['application/json', '[1, 2, 3]', 'application/csv', null],
+			['application/json; charset=utf8', '[1, 2, 3]', 'application/json', [1, 2, 3]],
 		];
 	}
 

--- a/tests/request.php
+++ b/tests/request.php
@@ -12,6 +12,15 @@
 
 namespace Fuel\Core;
 
+class FakeRequest extends Request_Driver {
+	public function execute(array $additional_params = array()) { /* nop */ }
+
+	public function test_mime_in_header($mime, $accept_header)
+	{
+		return $this->mime_in_header($mime, $accept_header);
+	}
+}
+
 /**
  * Request class tests
  *
@@ -20,5 +29,53 @@ namespace Fuel\Core;
  */
 class Test_Request extends TestCase
 {
- 	public function test_foo() {}
+	public function mime_testpairs()
+	{
+		return [
+			['application/json', '*/*', true],
+			['application/xml', '*/*', true],
+			['image/jpeg', '*/*', true],
+			['application/json', 'image/*', false],
+			['application/json', 'application/*', true],
+			['image/jpeg', 'image/*', true],
+			['image/jpeg', 'image/jpeg', true],
+			['image/jpeg', 'image/png', false],
+		];
+	}
+
+	/**
+	 * @dataProvider mime_testpairs
+	 */
+	public function test_mime_type_matching($response_mime, $accept_header, $expected)
+	{
+		$req = FakeRequest::forge('ignore');
+		$this->assertSame($expected, $req->test_mime_in_header($response_mime, $accept_header));
+	}
+
+	public function auto_format_testdata()
+	{
+		return [
+			['text/csv', "\"first\",\"second\",\"third\"\n\"1\",\"2\",\"3\"\n", '*/*', [['first' => '1', 'second' => '2', 'third' => '3']]],
+			['application/json', '{"foo": "bar"}', '*/*', ['foo' => 'bar']],
+			['application/json', '["x",1,2]', 'application/*', ['x', 1, 2]],
+			['application/json', '[]', 'application/json', []],
+			['application/json', '[1, 2, 3]', 'application/csv', null],
+		];
+	}
+
+	/**
+	 * @dataProvider auto_format_testdata
+	 */
+	public function test_mime_type_auto_format($response_mime, $response_data, $accept_header, $parsed_data)
+	{
+		$req = FakeRequest::forge('ignore');
+		$req->set_auto_format(true);
+
+		if ($parsed_data === null)
+		{
+			$this->setExpectedException('\OutOfRangeException');
+		}
+		$req->set_response($response_data, 200, $response_mime, [], $accept_header);
+		$this->assertEquals($parsed_data, $req->response()->body());
+	}
 }


### PR DESCRIPTION
Currently, if you make a request with an `Accept` header of, say, `application/json`, and the server responds with `Content-Type: application/json; charset=utf-8`, Fuel throws an exception:

```
OutOfRangeException [ Error ]:
The mimetype "application/json; charset=utf-8" of the returned response is not acceptable according to the accept header send.
```

These commits add a test suite for this and fix the problem (as well as the spelling mistake in the exception message :P)
