### PR TITLE
fix module reserved routes

### DIFF
--- a/classes/module.php
+++ b/classes/module.php
@@ -122,20 +122,8 @@ class Module
 				// load and add the module routes
 				$module_routes = \Fuel::load($path);
 
-				$route_names = array();
-				foreach($module_routes as $name => $_route)
-				{
-					if ($name === '_root_')
-					{
-						$name = $module;
-					}
-					elseif (strpos($name, $module.'/') !== 0 and $name != $module and $name !== '_404_')
-					{
-						$name = $module.'/'.$name;
-					}
-
-					$route_names[] = $name;
-				};
+				$routes = \Router::parse_module_routes($module_routes, $module);
+				$route_names = array_keys($routes);
 
 				// delete the defined module routes
 				\Router::delete($route_names);

--- a/classes/request.php
+++ b/classes/request.php
@@ -280,28 +280,7 @@ class Request
 				// load and add the module routes
 				$module_routes = \Fuel::load($module_path);
 
-				$reserve_routes = array(
-					'_root_' => $module,
-					'_403_'  => '_403_',
-					'_404_'  => '_404_',
-					'_500_'  => '_500_',
-					$module  => $module,
-				);
-
-				$prepped_routes = array();
-				foreach($module_routes as $name => $_route)
-				{
-					if (isset($reserve_routes[$name]))
-					{
-						$name = $reserve_routes[$name];
-					}
-					elseif (strpos($name, $module.'/') !== 0)
-					{
-						$name = $module.'/'.$name;
-					}
-
-					$prepped_routes[$name] = $_route;
-				};
+				$prepped_routes = \Router::parse_module_routes($module_routes, $module);
 
 				// update the loaded list of routes
 				\Router::add($prepped_routes, null, true);

--- a/classes/router.php
+++ b/classes/router.php
@@ -197,6 +197,42 @@ class Router
 	}
 
 	/**
+	 * It parses the module routes
+	 *
+	 * @param   array   $module_routes
+	 * @param   string  $module_name
+	 * @return  array
+	 * @see     Fuel\Core\Request::__construct, Fuel\Core\Module::unload
+	 */
+	public static function parse_module_routes(array $module_routes, $module_name)
+	{
+		$routes = array();
+
+		foreach ($module_routes as $name => $path)
+		{
+			if ($name === '_root_')
+			{
+				$name = $module_name;
+			}
+
+			// Exception routings. Redundant condition for short-circuit evaluation
+			elseif ($name[0] === '_' and preg_match('/\A_(4|5)\d{2}_\z/', $name)) {
+				// do nothing
+			}
+
+			// Add if there is no module name
+			elseif (strpos($name, $module_name . '/') !== 0 and $name !== $module_name)
+			{
+				$name = $module_name . '/' . $name;
+			}
+
+			$routes[$name] = $path;
+		};
+
+		return $routes;
+	}
+
+	/**
 	 * Processes the given request using the defined routes
 	 *
 	 * @param   \Request  $request  the given Request object


### PR DESCRIPTION
Routing "_400_" which is defined in the module has been fixed a problem that is not called. Consider the possibility that in the future new exception is added, it was to handle the 400 series to 500 series as a reserved route.

```
example: fuel/modules/api/config/routes.php
return array(
    '_400_'   => 'api/controller/400',
    '_403_'   => 'api/controller/403',
    '_500_'   => 'api/controller/500',
);
result
api/_400_  // not called
_403_
_500_
```

In addition, it seems "Module :: unload" at 400, 403, 500 has not been properly handled. The problem I think most impact was not.
