### PR TITLE
Corrected the configuration's DSN index in mysql/connection.php

### DIFF
--- a/classes/database/mysql/connection.php
+++ b/classes/database/mysql/connection.php
@@ -60,7 +60,7 @@ class Database_MySQL_Connection extends \Database_PDO_Connection
 		// add the charset to the DSN if needed
 		if ($this->_config['charset'] and strpos($this->_config['connection']['dsn'], ';charset=') === false)
 		{
-			$this->_config['dsn'] .= ';charset='.$this->_config['charset'];
+			$this->_config['connection']['dsn'] .= ';charset='.$this->_config['charset'];
 		}
 
 		// create the PDO instance


### PR DESCRIPTION
This solves an undefined index notification that was occurring as of v1.8, even with the $this->config change. Looks like it was a simple oversight in 23e88d.
