### PR TITLE
Fix table prefix on joins

### DIFF
--- a/classes/database/query/builder/join.php
+++ b/classes/database/query/builder/join.php
@@ -152,7 +152,7 @@ class Database_Query_Builder_Join extends \Database_Query_Builder
 		// Add the alias if needed
 		if ($this->_alias)
 		{
-			$sql .= ' AS '.$db->quote_identifier($this->_alias);
+			$sql .= ' AS '.$db->quote_table($this->_alias);
 		}
 
 		$conditions = array();


### PR DESCRIPTION
The table prefix is been dropped of of the final query, this change fixes that. See http://bin.fuelphp.com/snippet/view/NO for an example of what is happening.