### PR TITLE
String concatenation does not work in the initialization of static variables

### DIFF
--- a/classes/fuel.php
+++ b/classes/fuel.php
@@ -375,7 +375,7 @@ class Fuel
 	{
 		// framework default paths
 		static $search = array('\\', APPPATH, COREPATH, PKGPATH, DOCROOT, VENDORPATH);
-		static $replace = array(DS, 'APPPATH'.DS, 'COREPATH'.DS, 'PKGPATH'.DS, 'DOCROOT'.DS, 'VENDORPATH'.DS);
+		static $replace = array(DS, 'APPPATH/', 'COREPATH/', 'PKGPATH/', 'DOCROOT/', 'VENDORPATH/');
 
 		// additional paths configured than need cleaning
 		$extra = \Config::get('security.clean_paths', array());


### PR DESCRIPTION
When running in php 5.5.9 I receive the error:

Parse error: syntax error, unexpected '.', expecting ',' or ';' in /var/www/platform.beachfrontreach.com/fuel/core/classes/fuel.php on line 378