### PR TITLE
adds an exit status for fatal exceptions in cli mode, fixes #2037

### DIFF
--- a/classes/errorhandler.php
+++ b/classes/errorhandler.php
@@ -234,7 +234,13 @@ class Errorhandler
 				\Cli::write('Stack trace:');
 				\Cli::write(\Debug::backtrace($e->getTrace()));
 			}
-			return;
+
+			if ( ! $fatal)
+			{
+				return;
+			}
+
+			exit(1);
 		}
 
 		if ($fatal)


### PR DESCRIPTION
Adds an explicit exit with failure code in CLI mode on uncaught fatal exceptions. Fixes issue #2037.

Signed-off-by: iturgeon