### PR TITLE
Fix Composer dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
 	],
 	"require": {
 		"composer/installers": "~1.0",
-        "phpseclib/phpseclib": "2.0.0",
-        "monolog/monolog": "1.18.*",
-        "michelf/php-markdown": "1.*"
+		"phpseclib/phpseclib": "^2.0.0",
+		"monolog/monolog": "^1.18.0",
+		"michelf/php-markdown": "^1.0"
 	}
 }


### PR DESCRIPTION
Allow developers to use any compatible version of Fuel Core dependencies instead of specified ones (for example, monolog 1.22.X instead of monolog 1.18.X)

Merging this in 1.8.0 branch will allow us to upgrade to 1.8.0.4 instead of keeping stuck at 1.8.0.3