### PR TITLE
fix if concatenated string is empty

### DIFF
--- a/classes/database/query/builder/join.php
+++ b/classes/database/query/builder/join.php
@@ -186,9 +186,10 @@ class Database_Query_Builder_Join extends \Database_Query_Builder
 			// Split the condition
 			list($c1, $op, $c2, $chaining) = $condition;
 
+			$c_string = $c1 . $op . $c2;
 
 			// Just a chaining character?
-			if (empty($c1.$op.$c2))
+			if (empty($c_string))
 			{
 				$conditions[] = $chaining;
 			}


### PR DESCRIPTION
php7 fix - empty cannot be run on return value