### PR TITLE
fix not to override view variable with empty value in `View::unsanitize()`

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -349,6 +349,8 @@ class View
 				$var[$key] = $this->unsanitize($value);
 			}
 		}
+
+		return $var;
 	}
 
 	/**

--- a/tests/view.php
+++ b/tests/view.php
@@ -12,6 +12,41 @@
 
 namespace Fuel\Core;
 
+class Arraylike implements \ArrayAccess, \IteratorAggregate
+{
+	private $items;
+
+	public function __construct($items)
+	{
+		$this->items = $items;
+	}
+
+	public function offsetExists($offset)
+	{
+		return isset($this->items[$offset]);
+	}
+
+	public function offsetGet($offset)
+	{
+		return $this->items[$offset];
+	}
+
+	public function offsetSet($offset, $value)
+	{
+		$this->items[$offset] = $value;
+	}
+
+	public function offsetUnset($offset)
+	{
+		unset($this->items[$offset]);
+	}
+
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->items);
+	}
+}
+
 /**
  * View class tests
  *
@@ -20,5 +55,20 @@ namespace Fuel\Core;
  */
 class Test_View extends TestCase
 {
- 	public function test_foo() {}
+	public function test_unsanitize()
+	{
+		$ds = DIRECTORY_SEPARATOR;
+		$child = new View(implode($ds, [__DIR__, 'view', 'child.txt']), [
+			'items' => new Arraylike(['name' => 'test']),
+		]);
+		$parent = new \View(implode($ds, [__DIR__, 'view', 'parent.txt']), [
+			'child1' => $child,
+			'child2' => $child,
+		]);
+
+		$result = $parent->render();
+		$views = explode("\n", $result);
+		$this->assertSame('<p>test</p>', trim($views[0]));
+		$this->assertSame('<p>test</p>', trim($views[1]));
+	}
 }

--- a/tests/view/child.txt
+++ b/tests/view/child.txt
@@ -1,0 +1,1 @@
+<p><?php echo $items['name']; ?></p>

--- a/tests/view/parent.txt
+++ b/tests/view/parent.txt
@@ -1,0 +1,2 @@
+<?php echo $child1; ?>
+<?php echo $child2; ?>


### PR DESCRIPTION
related to: #1973 

If view variable implements `Traversable` and `ArrayAccess` interface, the variable is processed in `View::unsanitize()` with the code below:

https://github.com/fuel/core/blob/ae82e94023f2ca9fb279b0b2e19a13e5c459d3d1/classes/view.php#L343-L351
```
		// deal with array's or array emulating objects
		elseif (is_array($var) or ($var instanceOf \Traversable and $var instanceOf \ArrayAccess))
		{
			// recurse on array values
			foreach($var as $key => $value)
			{
				$var[$key] = $this->unsanitize($value);
			}
		}
```

Since `View::unsanitize()` does not return value currently, this process overrides `$var` entry with empty value.

So, If the variable is shared among two views, first view is rendered with given variable, but second view is rendered with empty variable.

This pull request changes `View::unsanitize()` behavior to return processed `$var`, in order to address the problem above.