### PR TITLE
Input_Instance->param doesn't work without HTTP Parameter

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -299,7 +299,7 @@ class Input_Instance
 	 */
 	public function all()
 	{
-		return array_merge($this->input_get, $this->input_post, $this->input_put, $this->input_patch, $this->input_delete);
+		return array_merge((array)$this->input_get, (array)$this->input_post, (array)$this->input_put, (array)$this->input_patch, (array)$this->input_delete);
 	}
 
 	/**


### PR DESCRIPTION
A code `Input_Instance->param('size', 1)` without http PUT parameters doesn't work w/ PHP7.1.

```
#2 /usr/share/nginx/mandarin.io/fuel/core/classes/input/instance.php(302): array_merge(Array, Array, '', Array, Array) 
```

To fix that, cast as an array for every parameters in function all().