### PR TITLE
Null don't have to be escaped in Security::htmlentities()

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -213,7 +213,7 @@ class Security
 		is_null($double_encode) and $double_encode = \Config::get('security.htmlentities_double_encode', false);
 
 		// Nothing to escape for non-string scalars, or for already processed values
-		if (is_bool($value) or is_int($value) or is_float($value) or in_array($value, $already_cleaned, true))
+		if (is_null($value) or is_bool($value) or is_int($value) or is_float($value) or in_array($value, $already_cleaned, true))
 		{
 			return $value;
 		}
@@ -238,7 +238,7 @@ class Security
 				$value[$k] = static::htmlentities($v, $flags, $encoding, $double_encode);
 			}
 		}
-		elseif ($value and ($value instanceof \Iterator or get_class($value) == 'stdClass'))
+		elseif (($value instanceof \Iterator or get_class($value) == 'stdClass'))
 		{
 			// Add to $already_cleaned variable
 			$already_cleaned[] = $value;

--- a/classes/security.php
+++ b/classes/security.php
@@ -238,7 +238,7 @@ class Security
 				$value[$k] = static::htmlentities($v, $flags, $encoding, $double_encode);
 			}
 		}
-		elseif (($value instanceof \Iterator or get_class($value) == 'stdClass'))
+		elseif ($value instanceof \Iterator or get_class($value) == 'stdClass')
 		{
 			// Add to $already_cleaned variable
 			$already_cleaned[] = $value;


### PR DESCRIPTION
I've stumbled upon the "get_class() expects parameter 1 to be object, null given" warning in PHP 7.2 and I have see #2081, but my PR is imho a faster solution than https://github.com/fuel/core/commit/8a44a112c7a9a7eee54f6990a9913daf96a230a1, because `null` will be immediately returned instead of go through all `if` cases.