### PR TITLE
Session_Db::write fixes

### DIFF
--- a/classes/session/db.php
+++ b/classes/session/db.php
@@ -200,6 +200,7 @@ class Session_Db extends \Session_Driver
 				{
 					// create the new session record
 					list($notused, $result) = \DB::insert($this->config['table'], array_keys($session))->values($session)->execute($this->config['database']);
+					$this->record = \DB::select()->where('session_id', '=', $this->keys['session_id'])->from($this->config['table'])->execute($this->config['database']);
 				}
 				else
 				{
@@ -231,6 +232,10 @@ class Session_Db extends \Session_Driver
 							logger(\Fuel::L_ERROR, 'Session update failed, session record could not be recovered using the previous id');
 							$result = false;
 						}
+					}
+					else
+					{
+						$this->record = \DB::select()->where('session_id', '=', $this->keys['session_id'])->from($this->config['table'])->execute($this->config['database']);
 					}
 				}
 


### PR DESCRIPTION
Session_Db::write - save Database_Result_Cached object to the $this->record after insert/update session

This commit will fix bug https://fuelphp.com/forums/discussion/comment/21618
For reproduce this bug you should create action with code:
```php
	    \Fuel\Core\Session::rotate();
	    \Fuel\Core\Session::write();
	    \Fuel\Core\Session::write();
```
line 203 - will fix ` Duplicate entry` error
lines 236 - 239 will fix the `Session update failed, session record recovered using previous id. Lost rotation data?` message in logs.