### PR TITLE
fix: Exception may not be thrown when the request fails

### DIFF
--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -160,7 +160,10 @@ class Request_Curl extends \Request_Driver
 		{
 			// Split the headers from the body
 			$raw_headers = explode("\n", str_replace("\r", "", substr($body, 0, $this->response_info['header_size'])));
-			$body = $this->response_info['header_size'] >= strlen($body) ? '' : substr($body, $this->response_info['header_size']);
+			if (is_string($body))
+			{
+				$body = $this->response_info['header_size'] >= strlen($body) ? '' : substr($body, $this->response_info['header_size']);
+			}
 
 			// Convert the header data
 			foreach ($raw_headers as $header)


### PR DESCRIPTION
I am writing in Google Translate, so I apologize if it is difficult to understand sentences.

# Overview

If "CURLOPT_HEADER" is set to true and curl_exec returns false, no exception will be raised.
When $ body is false, I think I should not overwrite it.

# Steps to reproduce

for example, Access https with cURL to invalid SSL certificate URL.

```
$url = "https://xxxxx"; // Specify the URL of an invalid SSL certificate site

try
{
	$curl = \Request::forge($url, 'curl');
	$curl->set_options([
		CURLOPT_HEADER         => false,
		CURLOPT_SSL_VERIFYPEER => true,
	]);
	$response = $curl->execute()->response();

	var_dump(
		$response,
		"Success!!"
	);
}
catch(\Exception $e)
{
	var_dump(
		$e->getCode(),
		$e->getMessage()
	);
}
```

1. When CURLOPT_HEADER = false.
Expected exception occurred.

> int(51)
> string(104) "Unable to communicate securely with peer: requested domain name does not match the server's certificate."


2. But when CURLOPT_HEADER = true.
Exception does not occur and it is processed as a normal response.

> object(Fuel\Core\Response)#12 (3) {
>  ["status"]=>
>  int(0)
>  ["headers"]=>
>  array(0) {
>  }
>  ["body"]=>
>  string(0) ""
>}
>string(9) "Success!!"
