### PR TITLE
Fixed:Unprocessed $incomplete is lost.

### DIFF
--- a/classes/format.php
+++ b/classes/format.php
@@ -514,7 +514,7 @@ class Format
 			}
 			else
 			{
-				$incomplete = $row;
+				$incomplete = $incomplete . $row;
 			}
 		}
 


### PR DESCRIPTION
When CSV data including newline in a column was split by preg_split(), saome data was was lost.