### PR TITLE
Allow higher versions of monolog/monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"composer/installers": "~1.0",
 		"phpseclib/phpseclib": "^2.0.0",
 		"paragonie/sodium_compat": "^1.6",
-		"monolog/monolog": "1.18.*",
+		"monolog/monolog": "^1.18",
 		"michelf/php-markdown": "1.7.0"
 	}
 }


### PR DESCRIPTION
I can't update fuel/core to 1.8.0.4 or 1.8.1.* because of a dependency that requires monolog/monolog ~1.22.
This PR will allow higher versions of monolog without BC breaks.