### PR TITLE
Backport for 1.8: Allow higher versions of monolog/monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"composer/installers": "~1.0",
 		"phpseclib/phpseclib": "^2.0.0",
 		"paragonie/sodium_compat": "^1.6",
-		"monolog/monolog": "1.18.*",
+		"monolog/monolog": "^1.18",
 		"michelf/php-markdown": "1.7.0"
 	}
 }


### PR DESCRIPTION
This PR is a backport of #2094 into the `1.8/master` branch. I simply cherry-picked the commit from the `1.9/develop` branch.