### PR TITLE
Prevent parameters from getting set to blank string

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -552,7 +552,7 @@ class Input_Instance
 		// store the parsed data based on the request method
 		if ($method == 'put' or $method == 'patch' or $method == 'delete')
 		{
-			$this->{'input_'.$method} = $php_input;
+			$this->{'input_'.$method} = (array) $php_input;
 		}
 	}
 }


### PR DESCRIPTION
Exception:  array_merge(): Argument #5 is not an array in /var/www/feather/fuel/core/classes/input/instance.php on line 266

In many cases we pass input parameters in our URL for delete actions ie:
```
/rest/groups/1/delete
```

Unfortunately with the updates to the input class in v1.8.1 and up, if you don't pass over a data parameter in your ajax request and ONLY pass your parameters in the URL, then the $php_input here is actually a blank string, and setting $this->input_delete to a blank string causing the exception at the top of this request.  Here is a sample request with parameters passed entirely in the URL:
```
$.ajax({
  url: '//admin/rest/users/{$user->id}/remove_image',
  method: 'delete'
});
```

If $php_input is ever anything other than an array then the exception at the top is thrown, so the easiest way is to just cast it as an array.  But perhaps you want to add some kind of array validation to ensure that the input is valid?