### PR TITLE
using symbol for boundary is not accepted

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -499,7 +499,7 @@ class Input_Instance
 			$boundary = $matches[1];
 
 			// split content by boundary and get rid of last -- element
-			$blocks = preg_split('/-+'.$boundary.'/', $php_input);
+			$blocks = preg_split('/-+' . preg_quote($boundary, '/') . '/', $php_input);
 			array_pop($blocks);
 
 			// loop data blocks


### PR DESCRIPTION
Sorry for bothering you.
If i use '+++++' for boundary, preg_split method is abended.
I suggest to use preg_quote.