### PR TITLE
allow to use ORDER BY `group`

### DIFF
--- a/classes/database/connection.php
+++ b/classes/database/connection.php
@@ -375,7 +375,7 @@ abstract class Database_Connection
 			if (stripos($sql, 'ORDER BY') !== false)
 			{
 				// Remove ORDER BY clauses from the SQL to improve count query performance
-				$sql = preg_replace('/ORDER BY (.+?)(?=LIMIT|GROUP|PROCEDURE|INTO|FOR|LOCK|\)|$)/mi', '', $sql);
+				$sql = preg_replace('/ORDER BY (.+?)(?=LIMIT|GROUP BY|PROCEDURE|INTO|FOR|LOCK|\)|$)/mi', '', $sql);
 			}
 
 			// Get the total rows from the last query executed


### PR DESCRIPTION
I'm sorry to bother you. and thank you for your awesome framework.
If I use `group` in the key of ORDER BY, it's become syntax error.

before preg_replace
```
ORDER BY `group` ASC
```
after preg_replace
```
group` ASC
```

I propose to change the pattern.
I refered these select syntax.
https://dev.mysql.com/doc/refman/5.5/en/select.html
https://www.postgresql.org/docs/9.5/sql-select.html