### PR TITLE
Add a "float" type for routes

### DIFF
--- a/classes/route.php
+++ b/classes/route.php
@@ -115,6 +115,7 @@ class Route
 			':everything',
 			':alnum',
 			':num',
+			':float',
 			':alpha',
 			':segment',
 		), array(
@@ -122,6 +123,7 @@ class Route
 			'.*',
 			'[[:alnum:]]+',
 			'[[:digit:]]+',
+			'[0-9\.,]+',
 			'[[:alpha:]]+',
 			'[^/]*',
 		), $this->path);


### PR DESCRIPTION
It would be nice to have a "float" type for routing. The "num" doesn't allow decimal points and it needn't be an entire segment that can grab everything.  