### PR TITLE
Fix warning for PHP 7.3

### DIFF
--- a/classes/session/memcached.php
+++ b/classes/session/memcached.php
@@ -320,7 +320,7 @@ class Session_Memcached extends \Session_Driver
 
 						default:
 							// unknown property
-							continue;
+							continue 2;
 					}
 
 					$validated[$name] = $value;


### PR DESCRIPTION
We encountered following error in the Fuel Core 1.8
![selection_096](https://user-images.githubusercontent.com/1627445/57223821-a497bb00-7007-11e9-8ec0-310d0328d836.png)

This is due to BC changes from `PHP 7.2` to `7.3`:
https://www.php.net/manual/en/migration73.incompatible.php
```
continue statements targeting switch control flow structures will now generate a warning.
In PHP such continue statements are equivalent to break, while they behave as continue 2 in other languages.
```

Not sure if to target `1.8` or `1.9` but it would be nice to maybe release this in `1.8.?`minor branch also.