### PR TITLE
Ppsl: Input_Instance lazy reading for php://input

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -87,9 +87,6 @@ class Input_Instance
 		// store the associated request
 		$this->request = $new;
 
-		// get php raw input
-		$this->raw_input = file_get_contents('php://input');
-
 		// was an input instance passed?
 		if ($input)
 		{
@@ -328,6 +325,12 @@ class Input_Instance
 	 */
 	public function raw()
 	{
+		if ($this->raw_input === null)
+		{
+			// get php raw input
+			$this->raw_input = file_get_contents('php://input');
+		}
+		
 		return $this->raw_input;
 	}
 


### PR DESCRIPTION
We should use on demand lazy reading for php://input, otherwise in nested Requests with php 5.6+ we have redundant re-reading it, and have unnecessary memory consumption and potentially DDoS, depending on the settings of frontend server, typically nginx (client_max_body_size).

In addition, subsequent internal requests (simple example of this is POST request to nonexistent page ("404" route) with POST body size ~= nginx.client_max_body_size (fn $routerequest) ) has redundant re-reading it too, and ideally we should read php://input one times per user initial external request, store it in private(?) static class member and reuse it in all Input_Instance's objects