### PR TITLE
Ppsl: final step Input_Instance lazy reading php://input

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -42,7 +42,7 @@ class Input_Instance
 	/**
 	 * @var  string  $raw  raw PHP input
 	 */
-	protected $raw_input = null;
+	protected static $raw_input = null;
 
 	/**
 	 * @var  array  $get  All GET input
@@ -325,13 +325,13 @@ class Input_Instance
 	 */
 	public function raw()
 	{
-		if ($this->raw_input === null)
+		if (static::$raw_input === null)
 		{
 			// get php raw input
-			$this->raw_input = file_get_contents('php://input');
+			static::$raw_input = file_get_contents('php://input');
 		}
 		
-		return $this->raw_input;
+		return static::$raw_input;
 	}
 
 	/**


### PR DESCRIPTION
As in 9d6f4e6118acd7197eb9def0b1c8f396f6eafe15 , in subsequent \Requests with php 5.6+ we have redundant re-reading 'php://input'  one time per request (simple example is request to non-exist page that leads to forge 2 Request instances - for initial request and for 404 == 2 times 'php://input' reading) , and this commit fix this by reading php://input on demand 1 time to class' static var, not object attr + retains what was achieved by previous commit

NOTE: this can potentially break functionality of Input_Instance's child user's classes