### PR TITLE
FIX bug Core\Package::load() $result always true when $package is array

### DIFF
--- a/classes/package.php
+++ b/classes/package.php
@@ -55,7 +55,9 @@ class Package
 					$pkg = $path;
 					$path = null;
 				}
-				$result = $result and static::load($pkg, $path);
+				// MUST use external brackets due to prio('and') < prio('=') < prio('&&') - 
+				// don't remove them xor replace 'and' with '&&'
+				$result = (static::load($pkg, $path) and $result);
 			}
 			return $result;
 		}


### PR DESCRIPTION
$result = true;
$result = $result and static::load($pkg, $path);

=> $result is always true regardless of load subcall return val, due to ops priority: prio('and') < prio('=') < prio('&&')

for ex. http://sandbox.onlinephpfunctions.com/code/e3faf45b7ba1bf8b553d527cb2d1a781efbad057

```php
$result = true and false;
var_dump($result);  // bool(true)

$result = true && false;
var_dump($result);  // bool(false)
```

Also **MUST** use brackets due to ops priorities