### PR TITLE
FIX Asset_Instance::render - unnecessary replace '\' with '/' in css/js when inlining asset file

### DIFF
--- a/classes/asset/instance.php
+++ b/classes/asset/instance.php
@@ -449,7 +449,7 @@ class Asset_Instance
 			}
 
 			// deal with stray backslashes on Windows
-			$file = str_replace('\\', '/', $file);
+			$inline or ( $file = str_replace('\\', '/', $file) );
 
 			// call the renderer for this type
 			if (isset($this->_renderers[$type]))


### PR DESCRIPTION
If I understand correctly, this code is intended to convert the Windows path to uri path:
```php
$file = str_replace('\\', '/', $file)
```

But if we already have inline contents in $file (L420, L437), then we replace backslash inside of it loaded content