### PR TITLE
generalize fix #2135 for appropriate DB drivers

### DIFF
--- a/classes/database/mysqli/cached.php
+++ b/classes/database/mysqli/cached.php
@@ -118,13 +118,11 @@ class Database_MySQLi_Cached extends \Database_Result implements \SeekableIterat
 			$this->_row = $this->_results[$this->_current_row];
 
 			// sanitize the data if needed
-			if ( ($this->_row !== null) and $this->_sanitization_enabled)
-			{
-				$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
-			}
+			$this->_sanitizate();
 		}
 		else
 		{
+			// auto sanitized row in rewind()->next()
 			$this->rewind();
 		}
 
@@ -145,10 +143,7 @@ class Database_MySQLi_Cached extends \Database_Result implements \SeekableIterat
 		isset($this->_results[$this->_current_row]) and $this->_row = $this->_results[$this->_current_row];
 
 		// sanitize the data if needed
-		if ( ($this->_row !== null) and $this->_sanitization_enabled)
-		{
-			$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
-		}
+		$this->_sanitizate();
 		
 		return $this->_row;
 	}
@@ -194,10 +189,7 @@ class Database_MySQLi_Cached extends \Database_Result implements \SeekableIterat
 		$result = $this->_results[$offset];
 
 		// sanitize the data if needed
-		if ($this->_sanitization_enabled)
-		{
-			$result = \Security::clean($result, null, 'security.output_filter');
-		}
+		$this->_sanitizate();
 
 		return $result;
 	}

--- a/classes/database/mysqli/result.php
+++ b/classes/database/mysqli/result.php
@@ -81,10 +81,7 @@ class Database_MySQLi_Result extends \Database_Result
 		}
 
 		// sanitize the data if needed
-		if ($this->_sanitization_enabled)
-		{
-			$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
-		}
+		$this->_sanitizate();
 
 		return $this->_row;
 	}

--- a/classes/database/pdo/cached.php
+++ b/classes/database/pdo/cached.php
@@ -110,13 +110,11 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 			$this->_row = $this->_results[$this->_current_row];
 
 			// sanitize the data if needed
-			if ($this->_sanitization_enabled)
-			{
-				$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
-			}
+			$this->_sanitizate();
 		}
 		else
 		{
+			// auto sanitized row in rewind()->next()
 			$this->rewind();
 		}
 
@@ -132,7 +130,14 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	{
 		parent::next();
 
+		$this->_row = null;
+		
 		isset($this->_results[$this->_current_row]) and $this->_row = $this->_results[$this->_current_row];
+
+		// sanitize the data if needed
+		$this->_sanitizate();
+
+		return $this->_row;
 	}
 
 	/**************************
@@ -176,10 +181,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 		$result = $this->_results[$offset];
 
 		// sanitize the data if needed
-		if ($this->_sanitization_enabled)
-		{
-			$result = \Security::clean($result, null, 'security.output_filter');
-		}
+		$this->_sanitizate();
 
 		return $result;
 	}

--- a/classes/database/pdo/result.php
+++ b/classes/database/pdo/result.php
@@ -78,10 +78,7 @@ class Database_PDO_Result extends \Database_Result
 		}
 
 		// sanitize the data if needed
-		if ($this->_sanitization_enabled)
-		{
-			$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
-		}
+		$this->_sanitizate();
 
 		return $this->_row;
 	}

--- a/classes/database/result.php
+++ b/classes/database/result.php
@@ -280,6 +280,17 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 		return $this->_sanitization_enabled;
 	}
 
+	/**
+	 *  sanitizates the current row
+	 */
+	protected function _sanitizate()
+	{
+		if ( ($this->_row !== null) and $this->_sanitization_enabled)
+		{
+			$this->_row = \Security::clean($this->_row, null, 'security.output_filter');
+		}
+	}
+	
 	/**************************
 	 * Countable methods
 	 *************************/


### PR DESCRIPTION
- next() should return next row (or null if out of result), as do Database_MySQLi_Result::next() (https://www.php.net/manual/en/mysqli-result.fetch-array.php "Returns an array of strings that corresponds to the fetched row or NULL if there are no more rows in resultset.") not only for mysqli, but for all appropriate drivers, e.g. PDO driver and all similar future drivers
- current() - rewind() now sanitize data in next() (rewind() -> next()) in appropriate drivers
- deduplicate sanitization code as helper fn of base abstract Result class \Database_Result