### PR TITLE
FIX \Database_Query caching should working as described in the doc

### DIFF
--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -319,7 +319,7 @@ class Database_Query
 		}
 
 		// fetch the result caching flag
-		$caching = $this->_caching or $db->caching();
+		$caching = isset($this->_caching) ? $this->_caching : $db->caching();
 
 		if ($caching and ! empty($this->_lifetime) and $this->_type === \DB::SELECT)
 		{


### PR DESCRIPTION
> You can control the type of result object returned globally, per database connection, using the enable_cache configuration item, on the defined database connection, in your db.php config file. By default, caching is enabled. You can override the global setting per query, using [caching($bool)]

But 
```php
$caching = $this->_caching or $db->caching();
```
ignores $this->_caching when it is either `null` or `false`, and set `$caching` from $db $caching (usually) config value, regardless of `$this->_caching` may be `false`, and only has sense when db caching is `false` and this caching is `true`.

N.B. `isset` checks together is variable set and is not `null`