### PR TITLE
Fix memcached cache delete_all()

### DIFF
--- a/classes/cache/storage/memcached.php
+++ b/classes/cache/storage/memcached.php
@@ -145,22 +145,20 @@ class Cache_Storage_Memcached extends \Cache_Storage_Driver
 	 */
 	public function delete_all($section)
 	{
-		// determine the section index name
-		$section = $this->config['cache_id'].(empty($section) ? '' : '.'.$section);
-
-		// get the directory index
 		$index = static::$memcached->get($this->config['cache_id'].'__DIR__');
 
 		if (is_array($index))
 		{
-			// limit the delete if we have a valid section
-			if ( ! empty($section))
+			if (empty($section))
 			{
-				$dirs = in_array($section, $index) ? array($section) : array();
+				// delete everything in the index
+				$dirs = $index;
 			}
 			else
 			{
-				$dirs = $index;
+				// delete just the section
+				$section_key = $this->config['cache_id'].(empty($section) ? '' : '.'.$section);
+				$dirs = in_array($section_key, $index) ? array($section_key) : array();
 			}
 
 			// loop through the indexes, delete all stored keys, then delete the indexes

--- a/tests/cache/storage/memcached.php
+++ b/tests/cache/storage/memcached.php
@@ -20,5 +20,90 @@ namespace Fuel\Core;
  */
 class Test_Cache_Storage_Memcached extends TestCase
 {
- 	public function test_foo() {}
+	 public function test_foo() {}
+
+	 public function test_delete_all()
+	 {
+ 		 \Config::set('cache.memcached.cache_id', '');
+
+		 \Cache::set('section_name.item', 'value');
+		 $a = \Cache::get('section_name.item'); // 'value'
+
+
+		 \Cache::delete_all(); // expected to remove everything
+
+		 $b = 'unchanged';
+		 try{
+			 $b = \Cache::get('section_name.item');
+		 } catch(\CacheNotFoundException $e){
+			 $b = 'error';
+		 }
+
+		 $this->assertEquals($a, 'value');
+		 $this->assertEquals($b, 'error');
+	 }
+
+	 public function test_delete_all_with_cache_id()
+	 {
+ 		 \Config::set('cache.memcached.cache_id', 'test');
+
+		 \Cache::set('section_name.item', 'value');
+		 $a = \Cache::get('section_name.item'); // 'value'
+
+
+		 \Cache::delete_all(); // expected to remove everything
+
+		 $b = 'unchanged';
+		 try{
+			 $b = \Cache::get('section_name.item');
+		 } catch(\CacheNotFoundException $e){
+			 $b = 'error';
+		 }
+
+		 $this->assertEquals($a, 'value');
+		 $this->assertEquals($b, 'error');
+	 }
+
+	 public function test_delete_all_with_section()
+	 {
+ 		 \Config::set('cache.memcached.cache_id', '');
+
+		 \Cache::set('section_name.item', 'value');
+		 $a = \Cache::get('section_name.item'); // 'value'
+
+
+		 \Cache::delete_all('section_name');
+
+		 $b = 'unchanged';
+		 try{
+			 $b = \Cache::get('section_name.item');
+		 } catch(\CacheNotFoundException $e){
+			 $b = 'error';
+		 }
+
+		 $this->assertEquals($a, 'value');
+		 $this->assertEquals($b, 'error');
+	 }
+
+	 public function test_delete_all_with_section_with_cache_id()
+	 {
+
+		 \Config::set('cache.memcached.cache_id', 'test');
+
+		 \Cache::set('section_name.item', 'value');
+		 $a = \Cache::get('section_name.item'); // 'value'
+
+
+		 \Cache::delete_all('section_name');
+
+		 $b = 'unchanged';
+		 try{
+			 $b = \Cache::get('section_name.item');
+		 } catch(\CacheNotFoundException $e){
+			 $b = 'error';
+		 }
+
+		 $this->assertEquals($a, 'value');
+		 $this->assertEquals($b, 'error');
+	 }
 }


### PR DESCRIPTION
The problem in the memcached cache driver prevents
\Cache::delete_all() from removingall the keys in the cache index.

The change allows that branch of the code to execute and includes
tests for the different states of cache_id and deleting with and
without a section in the arguments.

Signed-off-by: iturgeon <iturgeon@gmail.com>

fixes #2143 