### PR TITLE
fix typo HTTP_AUTHENTICATION => HTTP_AUTHORIZATION

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -428,9 +428,9 @@ abstract class Controller_Rest extends \Controller
 		}
 
 		// most other servers
-		elseif (\Input::server('HTTP_AUTHENTICATION'))
+		elseif (\Input::server('HTTP_AUTHORIZATION'))
 		{
-			if (strpos(strtolower(\Input::server('HTTP_AUTHENTICATION')), 'basic') === 0)
+			if (strpos(strtolower(\Input::server('HTTP_AUTHORIZATION')), 'basic') === 0)
 			{
 				list($username, $password) = explode(':', base64_decode(substr(\Input::server('HTTP_AUTHORIZATION'), 6)));
 			}


### PR DESCRIPTION
[Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication):
> a request contains a header field in the form of `Authorization: Basic <credentials>`