### PR TITLE
Do clearstatcache() before deleting files

### DIFF
--- a/classes/cache/storage/file.php
+++ b/classes/cache/storage/file.php
@@ -104,7 +104,9 @@ class Cache_Storage_File extends \Cache_Storage_Driver
 	 */
 	public function delete()
 	{
-		if (is_file($file = static::$path.$this->identifier_to_path($this->identifier).'.cache'))
+		$file = static::$path.$this->identifier_to_path($this->identifier).'.cache';
+		clearstatcache(true, $file);
+		if(is_file($file))
 		{
 			unlink($file);
 			$this->reset();

--- a/classes/file.php
+++ b/classes/file.php
@@ -682,6 +682,7 @@ class File
 	public static function delete($path, $area = null)
 	{
 		$path = rtrim(static::instance($area)->get_path($path), '\\/');
+		clearstatcache(true, $path);
 
 		if ( ! is_file($path) and ! is_link($path))
 		{

--- a/classes/finder.php
+++ b/classes/finder.php
@@ -501,6 +501,7 @@ class Finder
 					try
 					{
 						// Cache has expired
+						clearstatcache(true, $dir.$file);
 						is_file($dir.$file) and unlink($dir.$file);
 					}
 					catch (Exception $e)

--- a/classes/session/file.php
+++ b/classes/session/file.php
@@ -62,7 +62,7 @@ class Session_File extends \Session_Driver
 						clearstatcache(true, $this->config['path'] . $file);
 						if (is_file($this->config['path'] . $file))
 						{
-							@unlink($this->config['path'] . $file);
+							unlink($this->config['path'] . $file);
 						}
 					}
 				}

--- a/classes/session/file.php
+++ b/classes/session/file.php
@@ -59,7 +59,11 @@ class Session_File extends \Session_Driver
 						strpos($file, $this->config['cookie_name'].'_') === 0 and
 						filemtime($this->config['path'] . $file) < $expire)
 					{
-						@unlink($this->config['path'] . $file);
+						clearstatcache(true, $this->config['path'] . $file);
+						if (is_file($this->config['path'] . $file))
+						{
+							@unlink($this->config['path'] . $file);
+						}
 					}
 				}
 
@@ -84,6 +88,7 @@ class Session_File extends \Session_Driver
 		{
 			// delete the session file
 			$file = $this->config['path'].$this->config['cookie_name'].'_'.$this->keys['session_id'];
+			clearstatcache(true, $file);
 			if (is_file($file))
 			{
 				unlink($file);


### PR DESCRIPTION
How are you, WanWizard. I wish you good health.

FuelPHP is lightly processed, so we're using it in large projects. However, large projects are prone to errors when purging large numbers of files. I want to suppress this problem.
In Laravel and CakePHP, they are use clearstatcache() function. I think the same approach is ok.

Thanks.