### PR TITLE
image presets can now be arrays

### DIFF
--- a/classes/image/driver.php
+++ b/classes/image/driver.php
@@ -83,10 +83,10 @@ abstract class Image_Driver
 	public function preset($name)
 	{
 		$vars = func_get_args();
-		if (isset($this->config['presets'][$name]))
+		if (\Arr::get($this->config['presets'], $name))
 		{
 			$old_config   = $this->config;
-			$this->config = array_merge($this->config, $this->config['presets'][$name]);
+			$this->config = array_merge($this->config, \Arr::get($this->config['presets'], $name));
 			foreach ($this->config['actions'] AS $action)
 			{
 				$func = $action[0];

--- a/config/image.php
+++ b/config/image.php
@@ -22,7 +22,7 @@
  *
  */
 
-return array(
+return [
 	/**
 	 * -------------------------------------------------------------------------
 	 *  Driver
@@ -167,16 +167,33 @@ return array(
 	 *
 	 *  Example:
 	 *
-	 *      'example' => array(
+	 *      'example' => [
 	 *          'quality' => 100,
 	 *          'bgcolor' => null,
-	 *          'actions' => array(
-	 *              array('crop_resize', 200, 200),
-	 *              array('border', 20, "#f00"),
-	 *              array('rounded', 10),
-	 *              array('output', 'png')
-	 *          )
-	 *      )
+	 *          'actions' => [
+	 *              ['crop_resize', 200, 200],
+	 *              ['border', 20, "#f00"],
+	 *              ['rounded', 10],
+	 *              ['output', 'png']
+	 *          ]
+	 *      ],
+	 * 		'example_multilevel' => [
+	 * 			'thumbnail' => [
+	 * 				'quality' => 100,
+	 * 				'bgcolor' => null,
+	 * 				'actions' => [
+	 * 					 ['crop_resize', 175, 175]
+	 * 				]
+	 * 			],
+	 * 			'preview' => [
+	 * 				'quality' => 100,
+	 * 				'bgcolor' => null,
+	 * 				'actions' => [
+	 * 					 ['crop_resize', 200, 400]
+	 * 				]
+	 * 			]
+	 * 		]
+	 *
 	 *
 	 *  [!] WARNING:
 	 *
@@ -185,5 +202,5 @@ return array(
 	 *
 	 */
 
-	'presets' => array(),
-);
+	'presets' => [],
+];

--- a/config/image.php
+++ b/config/image.php
@@ -22,7 +22,7 @@
  *
  */
 
-return [
+return array(
 	/**
 	 * -------------------------------------------------------------------------
 	 *  Driver
@@ -167,32 +167,32 @@ return [
 	 *
 	 *  Example:
 	 *
-	 *      'example' => [
+	 *      'example' => array(
 	 *          'quality' => 100,
 	 *          'bgcolor' => null,
-	 *          'actions' => [
-	 *              ['crop_resize', 200, 200],
-	 *              ['border', 20, "#f00"],
-	 *              ['rounded', 10],
-	 *              ['output', 'png']
-	 *          ]
-	 *      ],
-	 * 		'example_multilevel' => [
-	 * 			'thumbnail' => [
+	 *          'actions' => array(
+	 *              array('crop_resize', 200, 200),
+	 *              array('border', 20, "#f00"),
+	 *              array('rounded', 10),
+	 *              array('output', 'png')
+	 *          )
+	 *      ),
+	 * 		'example_multilevel' => array(
+	 * 			'thumbnail' => array(
 	 * 				'quality' => 100,
 	 * 				'bgcolor' => null,
-	 * 				'actions' => [
-	 * 					 ['crop_resize', 175, 175]
-	 * 				]
-	 * 			],
-	 * 			'preview' => [
+	 * 				'actions' => array(
+	 * 					 array('crop_resize', 175, 175)
+	 * 				)
+	 * 			),
+	 * 			'preview' => array(
 	 * 				'quality' => 100,
 	 * 				'bgcolor' => null,
-	 * 				'actions' => [
-	 * 					 ['crop_resize', 200, 400]
-	 * 				]
-	 * 			]
-	 * 		]
+	 * 				'actions' => array(
+	 * 					 array('crop_resize', 200, 400)
+	 * 				)
+	 * 			)
+	 * 		)
 	 *
 	 *
 	 *  [!] WARNING:
@@ -202,5 +202,5 @@ return [
 	 *
 	 */
 
-	'presets' => [],
-];
+	'presets' => array(),
+);


### PR DESCRIPTION
Image presets can now be organised better: 
```
Model_Event_Image::TYPE_BANNER => [
			'175x175' => [
				'quality' => 100,
				'actions' => [
					['crop_resize', 175, 175]
				],
			],
			'1250x750' => [
				'quality' => 100,
				'actions' => [
					['crop_resize', 1250, 750]
				],
			]
		],

		Model_Event_Image::TYPE_AVATAR => [
			'175x175' => [
				'quality' => 100,
				'actions' => [
					['crop_resize', 175, 175]
				],
			],
...
```