### PR TITLE
Modify catch taret from Exception to Throwable, to clarify view error…

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -226,7 +226,7 @@ class View
 		{
 			return $this->render();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			\Errorhandler::exception_handler($e);
 
@@ -257,7 +257,7 @@ class View
 				// Load the view within the current scope
 				include $__file_name;
 			}
-			catch (\Exception $e)
+			catch (\Throwable $e)
 			{
 				// Delete the output buffer
 				ob_end_clean();


### PR DESCRIPTION
When a view throws an Error (not an Exception), previous Fuel\Core\View::__toString() could not catch it.  
This behavior caused debugging difficulties at PHP 7.3.x or earlier, because the backtrace is destroyed and only COREPATH/\bootstrap.php's shutdown handler is shown on "Fatal Error" page.  
This behavior can be recognized by the following view code:

```
<?php
$foo = null;
$foo->bar(); // ErrorException [ Fatal Error ]: Method Parser\View::__toString() must not throw an exception, caught Error: Call to a member function bar() on null
```

This commit modifies try...catch target from Exception to Throwable.  
New Fuel\Core\View catches the Error objects and shows expected backtrace.