### PR TITLE
Catching Throwable instead of Exception

### DIFF
--- a/classes/database/query.php
+++ b/classes/database/query.php
@@ -84,7 +84,7 @@ class Database_Query
 			// Return the SQL string
 			return $this->compile();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			return $e->getMessage();
 		}

--- a/classes/fieldset/field.php
+++ b/classes/fieldset/field.php
@@ -476,7 +476,7 @@ class Fieldset_Field
 		{
 			return $this->build();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			return $e->getMessage();
 		}

--- a/classes/presenter.php
+++ b/classes/presenter.php
@@ -351,7 +351,7 @@ abstract class Presenter
 		{
 			return $this->render();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			\Errorhandler::exception_handler($e);
 

--- a/classes/theme.php
+++ b/classes/theme.php
@@ -161,7 +161,7 @@ class Theme
 		{
 			return (string) $this->render();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			\Errorhandler::exception_handler($e);
 

--- a/classes/view.php
+++ b/classes/view.php
@@ -257,13 +257,10 @@ class View
 				// Load the view within the current scope
 				include $__file_name;
 			}
-			catch (\Throwable $e)
+			finally
 			{
 				// Delete the output buffer
 				ob_end_clean();
-
-				// Re-throw the exception
-				throw $e;
 			}
 
 			// Get the captured output and close the buffer

--- a/classes/view.php
+++ b/classes/view.php
@@ -226,7 +226,7 @@ class View
 		{
 			return $this->render();
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			\Errorhandler::exception_handler($e);
 
@@ -257,7 +257,7 @@ class View
 				// Load the view within the current scope
 				include $__file_name;
 			}
-			catch (\Exception $e)
+			catch (\Throwable $e)
 			{
 				// Delete the output buffer
 				ob_end_clean();


### PR DESCRIPTION
Some classes catch all exceptions to show error pages, but `Error` was miscatched on PHP 7.x because they catches only `Exception` class.  
This PR changes `catch (\Exception $e)` into `catch (\Throwable $e)` to prevent miscatching catchable fatal errors.

For example, the following view codes throw a `Call to a member function bar() on null` error, but it cannot be handled at `View::__toString()` on PHP 7.3 or earlier.  
Current codes will not catch this error, and `bootstrap.php`'s shutdown handler is called. At this time, no backtrace is shown on "Fatal Error" page, so it can be difficult to determine the error reasons.

```
<?php
$foo = null;
$foo->bar();
```

**This PR loses PHP 5.x compatibility** because `Throwable` is introduced on PHP 7.0.  
But, it is 2 years since PHP 5.x was no longer supported. Preventing debug difficulties on PHP 7.x or later may be more beneficial, I think....