### PR TITLE
Catch high load file caching errors

### DIFF
--- a/classes/cache/storage/file.php
+++ b/classes/cache/storage/file.php
@@ -330,22 +330,25 @@ class Cache_Storage_File extends \Cache_Storage_Driver
 		// make sure it exists
 		if (is_file($file))
 		{
-			$handle = fopen($file, 'r');
-			if ($handle)
-			{
-				// wait for a lock
-				while( ! flock($handle, LOCK_SH));
-
-				// read the cache data
-				$payload = file_get_contents($file);
-
-				//release the lock
-				flock($handle, LOCK_UN);
-
-				// close the file
-				fclose($handle);
-
+			$handle = @fopen($file, 'r');
+			if ( ! $handle) {
+				return false;
 			}
+			
+			// wait for a lock
+			while( ! flock($handle, LOCK_SH));
+
+			// read the cache data
+			$payload = @file_get_contents($file);
+			if ( ! $payload) {
+				return false;
+			}
+
+			//release the lock
+			flock($handle, LOCK_UN);
+
+			// close the file
+			fclose($handle);			
 		}
 
 		try


### PR DESCRIPTION
It seems to be a race condition that is occurring when multiple requests try to hit the expired cache at the same time!  Very difficult to reproduce in testing, these changes seemed to handle the issues in my production and I have not seen any more of these errors and the cache performance has not been impacted.  I was contemplating just wrapping the operation in a try/catch, but from what I have read these operations fopen and file_get_contents will not generate an exception.

Here are a few errors that pile up in the fuel logs during high load cache changing:
```
file_get_contents(/fuel/app/cache/db/6358477e0fb17783679ecb078ef6f053.cache): failed to open stream: No such file or directory in /fuel/core/classes/cache/storage/file.php on line 340
```

and this one as well:
```
fopen(/fuel/app/cache/db/74d391d280cc70ee51f8ecbe1cb59366.cache): failed to open stream: No such file or directory in /fuel/core/classes/cache/storage/file.php on line 333
```