### PR TITLE
php 8.1

### DIFF
--- a/classes/input.php
+++ b/classes/input.php
@@ -119,7 +119,7 @@ class Input
 			});
 
 			$ips = array_filter($ips, function($ip) use($exclude_reserved) {
-				return filter_var($ip, FILTER_VALIDATE_IP, $exclude_reserved ? FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE : null);
+				return filter_var($ip, FILTER_VALIDATE_IP, $exclude_reserved ? FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE : false);
 			});
 
 			if ($ips)


### PR DESCRIPTION
shutdown - filter_var(): Passing null to parameter #3 ($options) of type array|int is deprecated in /core/classes/input.php on 122
$options - cannot be null