### PR TITLE
php 8.1

### DIFF
--- a/classes/input/instance.php
+++ b/classes/input/instance.php
@@ -450,7 +450,7 @@ class Input_Instance
 		$method = strtolower($this->method());
 
 		// get the content type from the header, strip optional parameters
-		$content_header = \Input::headers('Content-Type');
+		$content_header = \Input::headers('Content-Type', false);
 		if (($content_type = strstr($content_header, ';', true)) === false)
 		{
 			$content_type = $content_header;


### PR DESCRIPTION
strstr(): Passing null to parameter #1 ($haystack) of type string is deprecated in /core/classes/input/instance.php on 454
strstr()  $haystack   cannot be  -  NULL