### PR TITLE
michelf/php-markdown updated recently for php 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
 		"phpseclib/phpseclib": "~2.0",
 		"paragonie/sodium_compat": "^1.6",
 		"monolog/monolog": "^1.18",
-		"michelf/php-markdown": "1.9.0"
+		"michelf/php-markdown": "~1.9.1"
 	}
 }


### PR DESCRIPTION
<=1.9.0 includes php 7.4 deprecation warnings