### PR TITLE
Supress deprecation warnings in PHP 8.1

### DIFF
--- a/classes/database/pdo/cached.php
+++ b/classes/database/pdo/cached.php
@@ -83,7 +83,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 * @return bool
 	 */
 	#[\ReturnTypeWillChange]
-	public function seek($offset)
+	public function seek(/*int */$offset)/*: void*/
 	{
 		if ( ! $this->offsetExists($offset))
 		{
@@ -92,7 +92,6 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 
 		$this->_current_row = $offset;
 
-		// since PHP 8.1: must return void
 		return true;
 	}
 
@@ -106,7 +105,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 * @return  mixed
 	 */
 	#[\ReturnTypeWillChange]
-	public function current()
+	public function current()/*: mixed*/
 	{
 		if ($this->valid())
 		{
@@ -130,7 +129,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 * @return  mixed
 	 */
 	#[\ReturnTypeWillChange]
-	public function next()
+	public function next()/*: void*/
 	{
 		parent::next();
 
@@ -141,7 +140,6 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 		// sanitize the data if needed
 		$this->_sanitizate();
 
-		// since PHP 8.1: must return void
 		return $this->_row;
 	}
 
@@ -161,7 +159,8 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @return boolean
 	 */
-	public function offsetExists($offset)
+	#[\ReturnTypeWillChange]
+	public function offsetExists(/*mixed */$offset)/*: bool*/
 	{
 		return isset($this->_results[$offset]);
 	}
@@ -175,7 +174,8 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @return  mixed
 	 */
-	public function offsetGet($offset)
+	#[\ReturnTypeWillChange]
+	public function offsetGet(/*mixed */$offset)/*: mixed*/
 	{
 		if ( ! $this->offsetExists($offset))
 		{
@@ -200,7 +200,8 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @throws  \FuelException
 	 */
-	final public function offsetSet($offset, $value)
+	#[\ReturnTypeWillChange]
+	final public function offsetSet(/*mixed */$offset, /*mixed */$value)/*: void*/
 	{
 		throw new \FuelException('Database results are read-only');
 	}
@@ -213,7 +214,8 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @throws  \FuelException
 	 */
-	final public function offsetUnset($offset)
+	#[\ReturnTypeWillChange]
+	final public function offsetUnset(/*mixed */$offset)/*: void*/
 	{
 		throw new \FuelException('Database results are read-only');
 	}

--- a/classes/database/pdo/cached.php
+++ b/classes/database/pdo/cached.php
@@ -82,6 +82,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function seek($offset)
 	{
 		if ( ! $this->offsetExists($offset))
@@ -91,6 +92,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 
 		$this->_current_row = $offset;
 
+		// since PHP 8.1: must return void
 		return true;
 	}
 
@@ -103,6 +105,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @return  mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		if ($this->valid())
@@ -126,6 +129,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 	 *
 	 * @return  mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		parent::next();
@@ -137,6 +141,7 @@ class Database_PDO_Cached extends \Database_Result implements \SeekableIterator,
 		// sanitize the data if needed
 		$this->_sanitizate();
 
+		// since PHP 8.1: must return void
 		return $this->_row;
 	}
 

--- a/classes/database/result.php
+++ b/classes/database/result.php
@@ -302,6 +302,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 *
 	 * @return  integer
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return $this->_total_rows;
@@ -316,6 +317,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 *
 	 * @return  mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return $this->_row;
@@ -326,6 +328,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 *
 	 * @return  integer
 	 */
+	#[\ReturnTypeWillChange]
 	public function key()
 	{
 		return $this->_current_row;
@@ -334,6 +337,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	/**
 	 * Implements [Iterator::next], moves to the next row.
 	 */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		++$this->_current_row;
@@ -342,6 +346,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	/**
 	 * Implements [Iterator::rewind], sets the current row to -1.
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 		// first row is zero, not one!
@@ -356,6 +361,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 *
 	 * @return  boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid()
 	{
 		return $this->_current_row >= 0 and $this->_current_row < $this->_total_rows;

--- a/classes/database/result.php
+++ b/classes/database/result.php
@@ -303,7 +303,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * @return  integer
 	 */
 	#[\ReturnTypeWillChange]
-	public function count()
+	public function count()/*: int*/
 	{
 		return $this->_total_rows;
 	}
@@ -318,7 +318,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * @return  mixed
 	 */
 	#[\ReturnTypeWillChange]
-	public function current()
+	public function current()/*: mixed*/
 	{
 		return $this->_row;
 	}
@@ -329,7 +329,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * @return  integer
 	 */
 	#[\ReturnTypeWillChange]
-	public function key()
+	public function key()/*: mixed*/
 	{
 		return $this->_current_row;
 	}
@@ -338,7 +338,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * Implements [Iterator::next], moves to the next row.
 	 */
 	#[\ReturnTypeWillChange]
-	public function next()
+	public function next()/*: void*/
 	{
 		++$this->_current_row;
 	}
@@ -347,7 +347,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * Implements [Iterator::rewind], sets the current row to -1.
 	 */
 	#[\ReturnTypeWillChange]
-	public function rewind()
+	public function rewind()/*: void*/
 	{
 		// first row is zero, not one!
 		$this->_current_row = -1;
@@ -362,7 +362,7 @@ abstract class Database_Result implements \Countable, \Iterator, \Sanitization
 	 * @return  boolean
 	 */
 	#[\ReturnTypeWillChange]
-	public function valid()
+	public function valid()/*: bool*/
 	{
 		return $this->_current_row >= 0 and $this->_current_row < $this->_total_rows;
 	}


### PR DESCRIPTION
Hey 👋 

PHP 8.1 gives some deprecations warnings for some interfaces where the return types will be changed.

In this PR I've added the `#[\ReturnTypeWillChange]` attribute to keep BC with PHP 7 and supress the warnings and I added the future type hints as comments.