### PR TITLE
fix php 8.1 error

### DIFF
--- a/classes/route.php
+++ b/classes/route.php
@@ -52,7 +52,7 @@ class Route
 	/**
 	 * @var  string  route module
 	 */
-	public $module = null;
+	public $module = '';
 
 	/**
 	 * @var  string  route directory


### PR DESCRIPTION
Fuel\Core\PhpErrorException [ Runtime Deprecated code usage ]:
ucfirst(): Passing null to parameter #1 ($string) of type string is deprecated
COREPATH/classes/presenter.php @ line 39