### PR TITLE
Fix redis infinite loop issue

### DIFF
--- a/classes/redis/db.php
+++ b/classes/redis/db.php
@@ -254,24 +254,19 @@ class Redis_Db
 
 	protected function readResponse()
 	{
-		$reply = fgets($this->connection, 512);
-
 		//  parse the response based on the reply identifier
-		if ($reply === false)
-		{
-			$reply = "";
-		}
+		$reply = trim(fgets($this->connection, 512));
 
-		switch (substr(trim($reply), 0, 1))
+		switch (substr($reply, 0, 1))
 		{
 			// error reply
 			case '-':
-				throw new \RedisException(trim(substr($reply, 1)));
+				throw new \RedisException(substr($reply, 1));
 				break;
 
 			// inline reply
 			case '+':
-				$response = substr(trim($reply), 1);
+				$response = substr($reply, 1);
 				if ($response === 'OK')
 				{
 					$response = true;
@@ -326,7 +321,7 @@ class Redis_Db
 
 			// integer reply
 			case ':':
-				$response = intval(substr(trim($reply), 1));
+				$response = intval(substr($reply, 1));
 				break;
 
 			default:

--- a/classes/session/driver.php
+++ b/classes/session/driver.php
@@ -755,6 +755,9 @@ abstract class Session_Driver
 	 */
 	protected function _unserialize($input)
 	{
+		// Prevent trigger php8' error with calling unserialize with null parameter 
+		$input === null and $input = '';
+
 		$data = @unserialize($input);
 
 		if (is_array($data))


### PR DESCRIPTION
This commit clean and fix Redis potential infinite loop by trimming value at the begining.

With previous code, the `$-1` case wasn't trimmed and would end with an infinite loop. Also, it's cleaner to trim it at the begining rather than in each case.

Also, fix `unserialize` issue in session driver class that would trigger a php 8.1 error if the input param is null.