### PR TITLE
Fix issue with package and module

### DIFF
--- a/classes/module.php
+++ b/classes/module.php
@@ -170,7 +170,7 @@ class Module
 			return static::$modules;
 		}
 
-		return array_key_exists($module, static::$modules);
+		return array_key_exists(ucfirst($module), static::$modules);
 	}
 
 	/**
@@ -181,7 +181,7 @@ class Module
 	 */
 	public static function exists($module)
 	{
-		if (array_key_exists($module, static::$modules))
+		if (array_key_exists(ucfirst($module), static::$modules))
 		{
 			return static::$modules[$module];
 		}

--- a/classes/package.php
+++ b/classes/package.php
@@ -127,7 +127,7 @@ class Package
 			return static::$packages;
 		}
 
-		return array_key_exists($package, static::$packages);
+		return array_key_exists(ucfirst($package), static::$packages);
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Package
 	 */
 	public static function exists($package)
 	{
-		if (array_key_exists($package, static::$packages))
+		if (array_key_exists(ucfirst($package), static::$packages))
 		{
 			return static::$packages[$package];
 		}


### PR DESCRIPTION
Fix bug induced by commit 2317bc2591f58bb9eec3849f72a1a6f6dd47ab7a from a couple of weeks in the `loaded` and `exists` methods of both classes `Package` and `Module`.

Since its capitalized on load, but the `array_key_exists` doesn't make sure it is.