### PR TITLE
Fix PHP 8 null parameter

### DIFF
--- a/classes/request/curl.php
+++ b/classes/request/curl.php
@@ -355,7 +355,7 @@ class Request_Curl extends \Request_Driver
 					else
 					{
 						//application/x-www-form-urlencoded
-						return http_build_query($input, null, '&');
+						return http_build_query($input, '', '&');
 					}
 				break;
 		}


### PR DESCRIPTION
Fix `http_build_query` is deprecated for php81