### PR TITLE
enable compression if needed

### DIFF
--- a/classes/database/pdo/connection.php
+++ b/classes/database/pdo/connection.php
@@ -46,6 +46,13 @@ class Database_PDO_Connection extends \Database_Connection
 			'cached'       => false,
 		), $this->_config);
 
+		// enable compression if needed
+		if ($this->_config['connection']['compress'])
+		{
+			// use client compression with mysql or mysqli (doesn't work with mysqlnd)
+			$this->_config['attrs'][\PDO::MYSQL_ATTR_COMPRESS] = true;
+		}
+		
 		// convert generic config values to specific attributes
 		if ( ! empty($this->_config['connection']['persistent']))
 		{


### PR DESCRIPTION
enable compression if needed. 

Note that the PDO driver isn't meant to be used directly, use platform specific drivers if available.