### PR TITLE
Fix to automatic conversion of false to array in prep_vars

### DIFF
--- a/classes/config/db.php
+++ b/classes/config/db.php
@@ -119,9 +119,9 @@ class Config_Db implements Config_Interface
 	 */
 	protected function prep_vars(&$array)
 	{
-		static $replacements = false;
+		static $replacements;
 
-		if ($replacements === false)
+		if (!isset($replacements))
 		{
 			foreach ($this->vars as $i => $v)
 			{

--- a/classes/config/file.php
+++ b/classes/config/file.php
@@ -96,9 +96,9 @@ abstract class Config_File implements Config_Interface
 	 */
 	protected function prep_vars(&$array)
 	{
-		static $replacements = false;
+		static $replacements;
 
-		if ($replacements === false)
+		if (!isset($replacements))
 		{
 			foreach ($this->vars as $i => $v)
 			{

--- a/classes/config/memcached.php
+++ b/classes/config/memcached.php
@@ -144,9 +144,9 @@ class Config_Memcached implements Config_Interface
 	 */
 	protected function prep_vars(&$array)
 	{
-		static $replacements = false;
+		static $replacements;
 
-		if ($replacements === false)
+		if (!isset($replacements))
 		{
 			foreach ($this->vars as $i => $v)
 			{

--- a/classes/lang/db.php
+++ b/classes/lang/db.php
@@ -132,9 +132,9 @@ class Lang_Db implements Lang_Interface
 	 */
 	protected function prep_vars(&$array)
 	{
-		static $replacements = false;
+		static $replacements;
 
-		if ($replacements === false)
+		if (!isset($replacements))
 		{
 			foreach ($this->vars as $i => $v)
 			{

--- a/classes/lang/file.php
+++ b/classes/lang/file.php
@@ -101,9 +101,9 @@ abstract class Lang_File implements Lang_Interface
 	 */
 	protected function prep_vars(&$array)
 	{
-		static $replacements = false;
+		static $replacements;
 
-		if ($replacements === false)
+		if (!isset($replacements))
 		{
 			foreach ($this->vars as $i => $v)
 			{


### PR DESCRIPTION
prep_vars is used in a number of classes to process path constants.

In php 8.1.x this automatic conversion of false to array is no longer supported.

The false to array conversion appears to be used here to run this processing once for the class and cache the results - using the boolean false value of the array to indicate that the vars hadn't been processed yet in these classes.

Fixes #2182