### PR TITLE
php 8.2 fix Deprecated code

### DIFF
--- a/classes/router.php
+++ b/classes/router.php
@@ -57,6 +57,10 @@ class Router
 			static::$routes[$path] = $options;
 			return;
 		}
+		elseif (is_null($path))
+		{
+			return;
+		}
 
 		$name = $path;
 		if (is_array($options) and array_key_exists('name', $options))


### PR DESCRIPTION
stripslashes(): Passing null to parameter #1 ($string) of type string is deprecated COREPATH/classes/route.php @ line 95
COREPATH/classes/router.php @ line 79