### PR TITLE
Fix PHP 7.4 deprecated code

### DIFF
--- a/classes/redis/db.php
+++ b/classes/redis/db.php
@@ -196,9 +196,10 @@ class Redis_Db
     {
         $args = array('PSUBSCRIBE', $pattern);
 
-        $command = sprintf('*%d%s%s%s', 2, CRLF, implode(array_map(function($arg) {
-            return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
-        }, $args), CRLF), CRLF);
+        $command = '*' . count($args) . CRLF;
+        foreach ($args as $arg) {
+            $command .= '$' . strlen($arg) . CRLF . $arg . CRLF;
+        }
 
         for ($written = 0; $written < strlen($command); $written += $fwrite)
         {

--- a/classes/redis/db.php
+++ b/classes/redis/db.php
@@ -196,10 +196,9 @@ class Redis_Db
     {
         $args = array('PSUBSCRIBE', $pattern);
 
-        $command = '*' . count($args) . CRLF;
-        foreach ($args as $arg) {
-            $command .= '$' . strlen($arg) . CRLF . $arg . CRLF;
-        }
+        $command = sprintf('*%d%s%s%s', 2, CRLF, implode(CRLF, array_map(function($arg) {
+		return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
+	}, $args)), CRLF);
 
         for ($written = 0; $written < strlen($command); $written += $fwrite)
         {


### PR DESCRIPTION
On implode function, passing a glue string after array is deprecated. I have changed it to the same piece of code that is in the __call method