### PR TITLE
[PHP 8.1.2, PHPUnit 10.2.5] Make phpunit executable

### DIFF
--- a/tests/agent.php
+++ b/tests/agent.php
@@ -23,7 +23,7 @@ class Test_Agent extends TestCase
 	/**
 	 * need to setup a fake browser environment
 	 */
-	protected function setUp()
+	protected function setUp(): void
 	{
 		// make sure we've got the Agent class in a known state
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-us,en;q=0.8,nl-be;q=0.5,nl;q=0.3';

--- a/tests/crypt.php
+++ b/tests/crypt.php
@@ -21,18 +21,18 @@ namespace Fuel\Core;
 class Test_Crypt extends TestCase
 {
 	private static $config_backup = array();
-	
+
 	private static $clear_text = "This is a string to encrypt";
 	private static $legacy_encrypted = "LO01JUJcY4z-BiQeWuOMxaEl9JYJjmLeoZCLgXqMVmtZSXpwN0NPSnJIblRmV0VvZHJKZjUycE5NNWRPOU5EdWlxTjR3MnJMMUtJx";
 
 	private static $cipherkey = "a8182a9b8f9231bd6eb092be0223f3b50e6bd26ee8d71d6ceccef8e9906cc59a";
 
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		// load and store the current crypt config
 		\Config::load('crypt', true);
 		static::$config_backup = \Config::get('crypt', array());
-		
+
 		// create a predictable one so we can test
 		\Config::set('crypt.legacy.crypto_key',  '9Kgt0c4LIb1g8GIhyAjnEnuU');
 		\Config::set('crypt.legacy.crypto_iv',   'PuMQGc0vA-ykX_QShEKRg3B4');
@@ -43,7 +43,7 @@ class Test_Crypt extends TestCase
 		\Crypt::_init();
 	}
 
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		\Config::set('crypt', static::$config_backup);
 		\Crypt::_init();

--- a/tests/date.php
+++ b/tests/date.php
@@ -20,7 +20,7 @@ namespace Fuel\Core;
  */
 class Test_Date extends TestCase
 {
-	protected function setUp()
+	protected function setUp(): void
 	{
 		// make sure the locale and language are is set correctly for the tests
 		setlocale(LC_ALL, 'en_US') === false and setlocale(LC_ALL, 'en_US.UTF8');

--- a/tests/debug.php
+++ b/tests/debug.php
@@ -20,14 +20,14 @@ namespace Fuel\Core;
  */
 class Test_Debug extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Remember old value, and set to browser mode.
         $this->old_is_cli = \Fuel::$is_cli;
         \Fuel::$is_cli = false;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original value
         \Fuel::$is_cli = $this->old_is_cli;

--- a/tests/fieldset.php
+++ b/tests/fieldset.php
@@ -20,7 +20,7 @@ namespace Fuel\Core;
  */
 class Test_Fieldset extends TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		// fake the uri for this request
 		isset($_SERVER['PATH_INFO']) and $this->pathinfo = $_SERVER['PATH_INFO'];
@@ -34,7 +34,7 @@ class Test_Fieldset extends TestCase
 		\Request::active($request);
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		// remove the fake uri
 		if (property_exists($this, 'pathinfo'))

--- a/tests/form.php
+++ b/tests/form.php
@@ -22,18 +22,18 @@ class Test_Form extends TestCase
 {
 	private static $config_security;
 
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		Config::load('security');
 		static::$config_security = Config::get('security');
 	}
 
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		Config::set('security', static::$config_security);
 	}
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		Config::load('form');
 		Config::set('form', array(
@@ -259,15 +259,15 @@ class Test_Form extends TestCase
 	{
 		$config = \Config::get('form.auto_id');
 		\Config::set('form.auto_id', true);
-		
+
 		$form = \Form::forge(__METHOD__);
-		
+
 		$label = 'label';
 		$id = 'id';
 		$output = $form->label($label, $id);
 		$expected = '<label for="form_id">label</label>';
 		$this->assertEquals($expected, $output);
-		
+
 		\Config::set('form.auto_id', $config);
 	}
 
@@ -280,15 +280,15 @@ class Test_Form extends TestCase
 	{
 		$config = \Config::get('form.auto_id');
 		\Config::set('form.auto_id', false);
-		
+
 		$form = \Form::forge(__METHOD__);
-		
+
 		$label = 'label';
 		$id = 'id';
 		$output = $form->label($label, $id);
 		$expected = '<label for="id">label</label>';
 		$this->assertEquals($expected, $output);
-		
+
 		\Config::set('form.auto_id', $config);
 	}
 
@@ -300,7 +300,7 @@ class Test_Form extends TestCase
 	public function test_open()
 	{
 		$form = \Form::forge(__METHOD__);
-		
+
 		$output = $form->open('uri/to/form');
 		$expected = '<form action="uri/to/form" accept-charset="utf-8" method="post">';
 		$this->assertEquals($expected, $output);
@@ -316,7 +316,7 @@ class Test_Form extends TestCase
 		\Config::set('security.csrf_auto_token', true);
 
 		$form = \Form::forge(__METHOD__);
-		
+
 		$output = $form->open('uri/to/form');
 		$expected = '<form action="uri/to/form" accept-charset="utf-8" method="post">'.PHP_EOL.'<input name="fuel_csrf_token" value="%s" type="hidden" id="form_fuel_csrf_token" />';
 		$this->assertStringMatchesFormat($expected, $output);

--- a/tests/format.php
+++ b/tests/format.php
@@ -20,7 +20,7 @@ namespace Fuel\Core;
  */
 class Test_Format extends TestCase
 {
-	protected function setUp()
+	protected function setUp(): void
 	{
 		Config::load('format', true);
 		Config::set('format', array(

--- a/tests/html.php
+++ b/tests/html.php
@@ -20,14 +20,14 @@ namespace Fuel\Core;
  */
 class Test_Html extends TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->old_url_suffix = Config::get('url_suffix');
 		$this->old_index_file = Config::get('index_file');
 		$this->old_base_url = Config::get('base_url');
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		Config::set('url_suffix', $this->old_url_suffix);
 		Config::set('index_file', $this->old_index_file);

--- a/tests/pagination.php
+++ b/tests/pagination.php
@@ -38,12 +38,12 @@ class Test_Pagination extends TestCase
 		$rp->setValue($this->request, $this->request);
 	}
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->old_base_url = Config::get('base_url');
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		// remove the fake uri
 		if (property_exists($this, 'pathinfo'))

--- a/tests/uri.php
+++ b/tests/uri.php
@@ -20,14 +20,14 @@ namespace Fuel\Core;
  */
 class Test_Uri extends TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->old_url_suffix = Config::get('url_suffix');
 		$this->old_index_file = Config::get('index_file');
 		$this->old_base_url = Config::get('base_url');
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		Config::set('url_suffix', $this->old_url_suffix);
 		Config::set('index_file', $this->old_index_file);

--- a/tests/view.php
+++ b/tests/view.php
@@ -45,6 +45,7 @@ class Arraylike implements \ArrayAccess, \IteratorAggregate
 		unset($this->items[$offset]);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->items);


### PR DESCRIPTION
I encountered an issue while running PHPUnit in PHP 8.1.2 and PHPUnit 10.2.5 environment.

The problem arises due to the following reasons:

* Incompatibility of return types in some methods.
* `Fuel\Core\Arraylike::getIterator()` doesn't conform to `IteratorAggregate::getIterator(): Traversable` compatibility or the use of `#[\ReturnTypeWillChange]` is missing.

Although the tests fail, this pull request enables the execution of PHPUnit.