### PR TITLE
[php81] fix explode string parameter

### DIFF
--- a/classes/crypt.php
+++ b/classes/crypt.php
@@ -541,7 +541,7 @@ class Crypt
 	protected function decode($value, $key = false, $keylength = false)
 	{
 		// legacy or sodium value?
-		$value = explode('S:', $value);
+		$value = explode('S:', (string) $value);
 		if ( ! isset($value[1]))
 		{
 			// decode using the legacy method


### PR DESCRIPTION
Fixed an explode parameter for PHP 8.1 deprecations.

PHP: Deprecated Features - Manual
https://www.php.net/manual/en/migration81.deprecated.php

> Passing null to non-nullable parameters of built-in functions

Similar commits:
- [php81] fix strstr string paramenter · fuel/core@2d6ea6b
- string for php 8.1 · fuel/core@3fe0ef8
