### PR TITLE
[php81] make MySQLi error reporting compatible with before PHP 8.1

### DIFF
--- a/classes/database/mysqli/connection.php
+++ b/classes/database/mysqli/connection.php
@@ -66,6 +66,9 @@ class Database_MySQLi_Connection extends \Database_Connection
 			),
 			'enable_cache'   => true,
 		), $this->_config);
+
+		// Make error reporting compatible with the behavior prior to PHP 8.1
+		mysqli_report(MYSQLI_REPORT_OFF);
 	}
 
 	public function connect()


### PR DESCRIPTION
Migrations and tests fail when using MySQLi connection in PHP 8.1 or later.

So I have changed the error reporting mode to be compatible with pre-PHP 8.0 behavior.

PHP: Backward Incompatible Changes - Manual
https://www.php.net/manual/en/migration81.incompatible.php

> The default error handling mode has been changed from "silent" to "exceptions" See the MySQLi reporting mode page for more details on what this entails, and how to explicitly set this attribute. To restore the previous behaviour use: mysqli_report(MYSQLI_REPORT_OFF);