### PR TITLE
feat: Allow monolog/monolog v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"composer/installers": "~1.0",
 		"phpseclib/phpseclib": "~3.0",
 		"paragonie/sodium_compat": "^1.6",
-		"monolog/monolog": "^1.18",
+		"monolog/monolog": "^1.18|^2|^3",
 		"michelf/php-markdown": "~1.9.1"
 	}
 }


### PR DESCRIPTION
monolog is used in many PHP libraries but monolog v1 is no longer supported in most ones; we can not install fuel/core along with the libraries. This pull request adds support for monolog 2.x and 3.x. I could not find any required changes to fuel/core itself so we can upgrade safely. Users can select their favourite monolog version to use: pin to 1.x or upgrade to 2.x or 3.x.