### PR TITLE
Adjust imagerotate function call for PHP 8.3 compatibility

### DIFF
--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -87,9 +87,12 @@ class Image_Gd extends \Image_Driver
 		$bgcolor = $this->config['bgcolor'] !== null ? $this->config['bgcolor'] : '#000';
 		$color = $this->create_color($this->image_data, $bgcolor, 100);
 
-		if (version_compare(phpversion(), '8.3', '>=')) {
+		if (version_compare(phpversion(), '8.3', '>='))
+		{
 			$this->image_data = imagerotate($this->image_data, $degrees, $color);
-		} else {
+		}
+		else
+		{
 			$this->image_data = imagerotate($this->image_data, $degrees, $color, false);
 		}
 	}

--- a/classes/image/gd.php
+++ b/classes/image/gd.php
@@ -86,7 +86,12 @@ class Image_Gd extends \Image_Driver
 		$degrees = 360 - $degrees;
 		$bgcolor = $this->config['bgcolor'] !== null ? $this->config['bgcolor'] : '#000';
 		$color = $this->create_color($this->image_data, $bgcolor, 100);
-		$this->image_data = imagerotate($this->image_data, $degrees, $color, false);
+
+		if (version_compare(phpversion(), '8.3', '>=')) {
+			$this->image_data = imagerotate($this->image_data, $degrees, $color);
+		} else {
+			$this->image_data = imagerotate($this->image_data, $degrees, $color, false);
+		}
 	}
 
 	protected function _watermark($filename, $position, $padding = array(5,5))


### PR DESCRIPTION
As of PHP 8.3, The unused ignore_transparent has been completely removed.

See the docs from [here](https://www.php.net/manual/en/function.imagerotate)