### PR TITLE
Fix fuel/core#2211: Security:strip_tags() breaks o with acute

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -191,7 +191,8 @@ class Security
 	{
 		if ( ! is_array($value))
 		{
-			$value = filter_var(strip_tags($value), FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+			$value = preg_replace('/\x00|<[^>]*>?/', '', strip_tags($value));
+			$value = str_replace(["'", '"'], ['&#39;', '&#34;'], $value);
 		}
 		else
 		{


### PR DESCRIPTION
See issue #2211 for wider discussion.
This fixes an issue in Security:strip_tags() that breaks o/O with acute accent.
Also makes this method more conformant with an old (pre-PHP8) code, ie. filter_var with FILTER_SANITIZE_STRING.

Fix is based on the code in the comment in https://www.php.net/manual/en/filter.filters.sanitize.php#129098 by "finkenb2 at msu dot edu".
