### PR TITLE
Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/classes/db.php
+++ b/classes/db.php
@@ -103,7 +103,7 @@ class DB
 	 * @param   array   columns to select
 	 * @return  Database_Query_Builder_Select
 	 */
-	public static function select_array($columns = null)
+	public static function select_array(?array $columns = null)
 	{
 		// columns must be a nullable array
 		if ( ! is_null($columns) and ! is_array($columns))

--- a/classes/input.php
+++ b/classes/input.php
@@ -37,7 +37,7 @@ class Input
 	 *
 	 * @return Input_Instance
 	 */
-	public static function forge($new = null, $input = null)
+	public static function forge(?Request $new = null, ?Input_Instance $input = null)
 	{
 		if ( ! is_null($new) and ! $new instanceOf Request)
 		{


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated