### PR TITLE
Fix: PHP 8.3 compatibility for IP validation in Validation class

### DIFF
--- a/classes/validation.php
+++ b/classes/validation.php
@@ -887,7 +887,7 @@ class Validation
 	 * @param   string  ipv4|ipv6
 	 * @return  bool
 	 */
-	public function _validation_valid_ip($val, $flag = null)
+	public function _validation_valid_ip($val, $flag = '')
 	{
 		switch (strtolower($flag))
 		{
@@ -896,6 +896,9 @@ class Validation
 				break;
 			case 'ipv6':
 				$flag = FILTER_FLAG_IPV6;
+				break;
+			default:
+				$flag = 0;
 				break;
 		}
 


### PR DESCRIPTION
- Updated `_validation_valid_ip` method to ensure compatibility with PHP 8.3.
- Changed default `$flag` parameter value to an empty string (`''`) to prevent errors.
- Added default case in `switch` to handle empty `$flag`, assigning `0` to ensure backward compatibility.
- Related documents:
    - https://www.php.net/manual/en/function.strtolower.php
    - https://www.php.net/manual/en/function.filter-var.php