### PR TITLE
Improve fallback logic for validation error messages

### DIFF
--- a/classes/validation/error.php
+++ b/classes/validation/error.php
@@ -83,10 +83,9 @@ class Validation_Error extends \Exception
 
 		if ($msg === false and ! ($msg = $this->field->get_error_message($this->rule)))
 		{
-			if (is_null($msg))
-			{
-				$msg = $this->field->fieldset()->validation()->get_message($this->rule);
-			}
+			
+			$msg = $this->field->fieldset()->validation()->get_message($this->rule);
+			
 			if ($msg === false)
 			{
 				$msg = \Lang::get('validation.'.$this->rule) ?: \Lang::get('validation.'.\Arr::get(explode(':', $this->rule), 0));

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -243,6 +243,7 @@ class Test_Arr extends TestCase
 	 */
 	public function test_get_throws_exception_when_array_is_not_an_array()
 	{
+		$this->expectException(\InvalidArgumentException::class);
 		$output = Arr::get('Jack', 'name', 'Unknown Name');
 	}
 

--- a/tests/arr.php
+++ b/tests/arr.php
@@ -568,6 +568,7 @@ class Test_Arr extends TestCase
 	 */
 	public function test_sort_of_non_array()
 	{
+		$this->expectException(\InvalidArgumentException::class);
 		$sorted = Arr::sort('not an array', 'foo.key');
 	}
 
@@ -714,6 +715,7 @@ class Test_Arr extends TestCase
 	 */
 	public function test_to_assoc_with_odd_number_of_elements()
 	{
+		$this->expectException(\BadMethodCallException::class);
 		$arr = array('foo', 'bar', 'baz');
 		Arr::to_assoc($arr);
 	}

--- a/tests/date.php
+++ b/tests/date.php
@@ -20,7 +20,7 @@ namespace Fuel\Core;
  */
 class Test_Date extends TestCase
 {
-	protected function setUp()
+	protected function setUp(): void
 	{
 		// make sure the locale and language are is set correctly for the tests
 		setlocale(LC_ALL, 'en_US') === false and setlocale(LC_ALL, 'en_US.UTF8');
@@ -64,6 +64,7 @@ class Test_Date extends TestCase
 	 */
 	public function test_days_in_month_13_exception()
 	{
+		$this->expectException(\UnexpectedValueException::class);
 		$output = Date::days_in_month(13);
 	}
 
@@ -236,6 +237,7 @@ class Test_Date extends TestCase
 	 */
 	public function test_range_to_array_invalid()
 	{
+		$this->expectException(\UnexpectedValueException::class);
 		$start = Date::create_from_string('2015-10-01', '%Y-%m-%d');
 		$end   = Date::create_from_string('2015-10-02', '%Y-%m-%d');
 		$range = Date::range_to_array($start, $end, "-2 days");

--- a/tests/num.php
+++ b/tests/num.php
@@ -41,6 +41,7 @@ class Test_Num extends TestCase
 	 */
 	public function test_bytes_exception()
 	{
+		$this->expectException(\Exception::class);
 		$output = Num::bytes('invalid');
 	}
 


### PR DESCRIPTION
Adds fallback to fieldset validation and language messages when field-level error is not set.

