### PR TITLE
Fix PHP 8.1+ deprecations: null passed to string functions

### DIFF
--- a/classes/controller/rest.php
+++ b/classes/controller/rest.php
@@ -437,9 +437,9 @@ abstract class Controller_Rest extends \Controller
 		// most other servers
 		elseif (\Input::server('HTTP_AUTHORIZATION'))
 		{
-			if (strpos(strtolower(\Input::server('HTTP_AUTHORIZATION')), 'basic') === 0)
+			if (strpos(strtolower((string) \Input::server('HTTP_AUTHORIZATION')), 'basic') === 0)
 			{
-				list($username, $password) = explode(':', base64_decode(substr(\Input::server('HTTP_AUTHORIZATION'), 6)));
+				list($username, $password) = explode(':', base64_decode(substr((string) \Input::server('HTTP_AUTHORIZATION'), 6)));
 			}
 		}
 

--- a/classes/format.php
+++ b/classes/format.php
@@ -404,7 +404,7 @@ class Format
 			static $escape_keys = array();
 			$recursive or $escape_keys = array('_xmlns' => 'xmlns');
 
-			if ( ! $recursive and strpos($string, 'xmlns') !== false and preg_match_all('/(\<.+?\>)/s', $string, $matches))
+			if ( ! $recursive and strpos((string) $string, 'xmlns') !== false and preg_match_all('/(\<.+?\>)/s', (string) $string, $matches))
 			{
 				foreach ($matches[1] as $tag)
 				{
@@ -568,7 +568,7 @@ class Format
 		$new_json = "";
 		$indent_level = 0;
 		$in_string = false;
-		$len = strlen($json);
+		$len = strlen((string) $json);
 
 		for ($c = 0; $c < $len; $c++)
 		{

--- a/classes/html.php
+++ b/classes/html.php
@@ -39,7 +39,7 @@ class Html
 	 */
 	public static function anchor($href, $text = null, $attr = array(), $secure = null)
 	{
-		if ( ! preg_match('#^(\w+://|javascript:|\#)# i', $href))
+		if ( ! preg_match('#^(\w+://|javascript:|\#)# i', (string) $href))
 		{
 			$urlparts = explode('?', $href, 2);
 			$href = \Uri::create($urlparts[0], array(), isset($urlparts[1]) ? $urlparts[1] : array(), $secure);
@@ -129,9 +129,9 @@ class Html
 	 */
 	public static function mail_to_safe($email, $text = null, $subject = null, $attr = array())
 	{
-		$text or $text = str_replace('@', '[at]', $email);
+		$text or $text = str_replace('@', '[at]', (string) $email);
 
-		$email = explode("@", $email);
+		$email = explode("@", (string) $email);
 
 		$subject and $subject = '?subject='.$subject;
 

--- a/classes/input.php
+++ b/classes/input.php
@@ -167,7 +167,7 @@ class Input
 	 */
 	public static function is_ajax()
 	{
-		return (static::server('HTTP_X_REQUESTED_WITH') !== null) and strtolower(static::server('HTTP_X_REQUESTED_WITH')) === 'xmlhttprequest';
+		return (static::server('HTTP_X_REQUESTED_WITH') !== null) and strtolower((string) static::server('HTTP_X_REQUESTED_WITH')) === 'xmlhttprequest';
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Input
 	 */
 	public static function server($index = null, $default = null)
 	{
-		return (func_num_args() === 0) ? $_SERVER : \Arr::get($_SERVER, strtoupper($index), $default);
+		return (func_num_args() === 0) ? $_SERVER : \Arr::get($_SERVER, strtoupper((string) $index), $default);
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Input
 			}
 		}
 
-		return empty($headers) ? $default : ((func_num_args() === 0) ? $headers : \Arr::get(array_change_key_case($headers), strtolower($index), $default));
+		return empty($headers) ? $default : ((func_num_args() === 0) ? $headers : \Arr::get(array_change_key_case($headers), strtolower((string) $index), $default));
 	}
 
 	/**

--- a/classes/request/driver.php
+++ b/classes/request/driver.php
@@ -138,7 +138,7 @@ abstract class Request_Driver
 	 */
 	public function set_method($method)
 	{
-		$this->method = strtoupper($method);
+		$this->method = strtoupper((string) $method);
 		return $this;
 	}
 
@@ -341,7 +341,7 @@ abstract class Request_Driver
 		}
 
 		// match on generic mime type
-		$mime = substr($mime, 0, strpos($mime, '/')).'/*';
+		$mime = substr((string) $mime, 0, strpos((string) $mime, '/')).'/*';
 		if (in_array($mime, $accept_mimes))
 		{
 			return true;

--- a/classes/security.php
+++ b/classes/security.php
@@ -56,7 +56,7 @@ class Security
 		if (\Config::get('security.csrf_autoload', false))
 		{
 			$check_token_methods = \Config::get('security.csrf_autoload_methods', array('post', 'put', 'delete'));
-			if (in_array(strtolower(\Input::method()), $check_token_methods) and ! static::check_token())
+			if (in_array(strtolower((string) \Input::method()), $check_token_methods) and ! static::check_token())
 			{
 				if (\Config::get('security.csrf_bad_request_on_fail', false))
 				{

--- a/classes/str.php
+++ b/classes/str.php
@@ -45,7 +45,7 @@ class Str
 			// Handle special characters.
 			preg_match_all('/&[a-z]+;/i', strip_tags($string), $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 			// fix preg_match_all broken multibyte support
-			if (MBSTRING and strlen($string !== mb_strlen($string)))
+			if (MBSTRING and strlen((string) $string) !== mb_strlen((string) $string))
 			{
 				$correction = 0;
 				foreach ($matches as $index => $match)
@@ -66,7 +66,7 @@ class Str
 			// Handle all the html tags.
 			preg_match_all('/<[^>]+>([^<]*)/', $string, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 			// fix preg_match_all broken multibyte support
-			if (MBSTRING and strlen($string !== mb_strlen($string)))
+			if (MBSTRING and strlen((string) $string) !== mb_strlen((string) $string))
 			{
 				$correction = 0;
 				foreach ($matches as $index => $match)
@@ -327,7 +327,7 @@ class Str
 	 */
 	public static function is_html($string)
 	{
-		return strlen(strip_tags($string)) < strlen($string);
+		return strlen(strip_tags((string) $string)) < strlen((string) $string);
 	}
 
 	// multibyte functions

--- a/classes/validation.php
+++ b/classes/validation.php
@@ -173,7 +173,7 @@ class Validation
 	{
 		$field = $this->add($name, $label);
 
-		is_array($rules) or $rules = explode('|', $rules);
+		is_array($rules) or $rules = explode('|', (string) $rules);
 
 		foreach ($rules as $rule)
 		{


### PR DESCRIPTION
## Summary

PHP 8.1 deprecated passing `null` to built-in string functions (`strlen()`, `strpos()`, `strtolower()`, `preg_match()`, `explode()`, etc.). These deprecations become `TypeError` in PHP 9.0.

This PR adds `(string)` casts where nullable values can reach string functions across 8 core files:

- **html.php** — `anchor()` and `mail_to_safe()` can receive null `$href`/`$email`
- **input.php** — `server()`, `headers()`, `is_ajax()` pass potentially null `$index` to `strtoupper()`/`strtolower()`
- **str.php** — **Fixes a logic bug** in `truncate()`: `strlen($string !== mb_strlen($string))` had wrong parentheses, passing a boolean to `strlen()` instead of comparing lengths. Also fixes `is_html()`
- **security.php** — `Input::method()` return cast in CSRF check
- **format.php** — `$string` and `$json` parameters in XML/JSON processing
- **validation.php** — `$rules` parameter in `add_field()`
- **controller/rest.php** — `HTTP_AUTHORIZATION` header value from `Input::server()`
- **request/driver.php** — `$method` and `$mime` parameters

## Bug fix in `Str::truncate()`

```php
// Before (broken — passes boolean to strlen):
if (MBSTRING and strlen($string !== mb_strlen($string)))

// After (correct — compares string lengths):
if (MBSTRING and strlen((string) $string) !== mb_strlen((string) $string))
```

This bug meant the multibyte offset correction in `truncate()` never executed.

## Test plan

- [x] Tested on PHP 8.4.8 with a production FuelPHP 1.9 application
- [x] All 8 files pass `php -l` syntax check
- [x] No deprecation warnings in runtime output
- [x] Backward compatible — `(string)` cast on a string is a no-op